### PR TITLE
feat: add mcp support to react runtime example

### DIFF
--- a/examples/react-runtime/config.terminal.toml
+++ b/examples/react-runtime/config.terminal.toml
@@ -32,6 +32,6 @@ max_turns = 5
 temperature = 0.5
 max_tokens = 500
 
-[plugin.mcp.mcp_sever.playwright]
+[plugin.mcp.mcp_server.playwright]
 command = "npx"
 args = ["@playwright/mcp@latest"]

--- a/examples/react-runtime/config.terminal.toml
+++ b/examples/react-runtime/config.terminal.toml
@@ -31,3 +31,7 @@ max_turns = 5
 [plugin.reactor.llm]
 temperature = 0.5
 max_tokens = 500
+
+[plugin.mcp.mcp_sever.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]

--- a/examples/react-runtime/pyproject.toml
+++ b/examples/react-runtime/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "ReAct loop iamai example."
 requires-python = ">=3.10"
 dependencies = [
+    "fastmcp>=3.4.2",
     "iamai",
     "iamai-example-utils",
 ]

--- a/examples/react-runtime/src/react_runtime/plugins/mcp.py
+++ b/examples/react-runtime/src/react_runtime/plugins/mcp.py
@@ -4,7 +4,7 @@ from fastmcp import Client
 
 
 class McpConfig(BaseModel):
-    mcp_sever:dict[str, dict[str, object]]
+    mcp_server:dict[str, dict[str, object]]
 
 class McpPlugin(Plugin):
     name = "mcp"
@@ -14,15 +14,15 @@ class McpPlugin(Plugin):
     async def startup(self) -> None:
         self.state.setdefault("client", {})
         self.state.setdefault("tools", {})
-        for sever_name, sever_cfg in self.config_obj.mcp_sever.items():  # ty:ignore[unresolved-attribute]
+        for server_name, server_cfg in self.config_obj.mcp_server.items():  # ty:ignore[unresolved-attribute]
             client = Client({
-                "mcpServers": {sever_name: sever_cfg}
+                "mcpServers": {server_name: server_cfg}
             })
             await client.__aenter__()
-            self.state["client"][sever_name] = client
+            self.state["client"][server_name] = client
             # 加载工具列表
             mcp_tools = await client.list_tools()
-            self.state["tools"][sever_name] = [
+            self.state["tools"][server_name] = [
                 (mt.name, mt.description) for mt in mcp_tools
             ]
 
@@ -31,8 +31,8 @@ class McpPlugin(Plugin):
             await client.__aexit__(None, None, None)
 
     async def call_tool(self, tool_name: str, tool_input: dict) -> str:
-        for sever_name, client in self.state["client"].items():
-            prefix = f"{sever_name}."
+        for server_name, client in self.state["client"].items():
+            prefix = f"{server_name}."
             if tool_name.startswith(prefix):
                 raw_name = tool_name[len(prefix):]
                 result = await client.call_tool(raw_name, tool_input)
@@ -41,9 +41,9 @@ class McpPlugin(Plugin):
 
     def describe_tools(self) -> str:
         lines = []
-        for sever_name, tools in self.state.get("tools", {}).items():
+        for server_name, tools in self.state.get("tools", {}).items():
             for name, desc in tools:
-                lines.append(f"{sever_name}.{name}: {desc}")
+                lines.append(f"{server_name}.{name}: {desc}")
         return "\n".join(lines) or "(no MCP tools)"
 
 

--- a/examples/react-runtime/src/react_runtime/plugins/mcp.py
+++ b/examples/react-runtime/src/react_runtime/plugins/mcp.py
@@ -1,0 +1,49 @@
+from iamai import Plugin
+from pydantic import BaseModel
+from fastmcp import Client
+
+
+class McpConfig(BaseModel):
+    mcp_sever:dict[str, dict[str, object]]
+
+class McpPlugin(Plugin):
+    name = "mcp"
+    description = "用于与MCP服务器进行通信和交互"
+    config_model = McpConfig
+
+    async def startup(self) -> None:
+        self.state.setdefault("client", {})
+        self.state.setdefault("tools", {})
+        for sever_name, sever_cfg in self.config_obj.mcp_sever.items():  # ty:ignore[unresolved-attribute]
+            client = Client({
+                "mcpServers": {sever_name: sever_cfg}
+            })
+            await client.__aenter__()
+            self.state["client"][sever_name] = client
+            # 加载工具列表
+            mcp_tools = await client.list_tools()
+            self.state["tools"][sever_name] = [
+                (mt.name, mt.description) for mt in mcp_tools
+            ]
+
+    async def shutdown(self) -> None:
+        for client in self.state.get("client", {}).values():
+            await client.__aexit__(None, None, None)
+
+    async def call_tool(self, tool_name: str, tool_input: dict) -> str:
+        for sever_name, client in self.state["client"].items():
+            prefix = f"{sever_name}."
+            if tool_name.startswith(prefix):
+                raw_name = tool_name[len(prefix):]
+                result = await client.call_tool(raw_name, tool_input)
+                return str(result)
+        raise ValueError(f"unknown MCP tool: {tool_name}")
+
+    def describe_tools(self) -> str:
+        lines = []
+        for sever_name, tools in self.state.get("tools", {}).items():
+            for name, desc in tools:
+                lines.append(f"{sever_name}.{name}: {desc}")
+        return "\n".join(lines) or "(no MCP tools)"
+
+

--- a/examples/react-runtime/src/react_runtime/plugins/reactor.py
+++ b/examples/react-runtime/src/react_runtime/plugins/reactor.py
@@ -35,6 +35,11 @@ class ReactorPlugin(Plugin):
             return
         tools = cast(ToolsPlugin, ctx.runtime.get_plugin("tools"))
         memory = ctx.runtime.get_plugin("memory")
+        mcp = ctx.runtime.get_plugin("mcp")
+        all_tools = (
+            f"{tools.describe_tools()}\n"
+            f"{mcp.describe_tools()}"  # ty:ignore[unresolved-attribute]
+        )
         settings = resolve_llm_settings(
             self.config_obj, default_temperature=0.5, default_max_tokens=500
         )
@@ -56,15 +61,16 @@ class ReactorPlugin(Plugin):
                         "role": "user",
                         "content": (
                             f"Question: {question}\n\n"
-                            f"Available tools:\n{tools.describe_tools()}\n\n"
+                            f"Available tools:\n{all_tools}\n\n"
                             f"Saved notes:\n{format_transcript(memory.state.get('notes', []), limit=8)}\n\n"
                             f"Trace so far:\n{format_transcript(trace_lines, limit=10)}"
                         ),
                     },
                 ],
-                max_tokens=420,
+                max_tokens=1000,
             )
             data = payload if isinstance(payload, dict) else {}
+            print(data)
             thought = clip_text(str(data.get("thought", "")).strip() or f"turn {turn}", limit=120)
             final = str(data.get("final", "")).strip()
             if final:
@@ -76,20 +82,23 @@ class ReactorPlugin(Plugin):
             if not isinstance(action, dict):
                 raise ValueError("model returned an invalid action payload")
             tool_name = str(action.get("tool", "")).strip()
-            tool_input = str(action.get("input", "")).strip()
+            tool_input_raw = action.get("input", "")
             if not tool_name:
                 raise ValueError("model did not choose a tool or final answer")
-            observation = await tools.run_tool(tool_name, tool_input, ctx)
+            try:
+                observation = await tools.run_tool(tool_name, str(tool_input_raw).strip(), ctx)
+            except Exception:
+                observation = await mcp.call_tool(tool_name, tool_input_raw)  # ty:ignore[unresolved-attribute]
             trace.add(
                 "tool",
                 tool_name,
-                input=tool_input,
+                input=tool_input_raw,
                 output=observation,
                 turn=turn,
                 thought=thought,
             )
             trace_lines.append(
-                f"turn {turn}: thought={thought} action={tool_name}({clip_text(tool_input, limit=60)}) "
+                f"turn {turn}: thought={thought} action={tool_name}({clip_text(str(tool_input_raw).strip(), limit=60)}) "
                 f"observation={clip_text(observation, limit=140)}"
             )
         if not final_answer:

--- a/examples/react-runtime/src/react_runtime/plugins/reactor.py
+++ b/examples/react-runtime/src/react_runtime/plugins/reactor.py
@@ -70,7 +70,6 @@ class ReactorPlugin(Plugin):
                 max_tokens=1000,
             )
             data = payload if isinstance(payload, dict) else {}
-            print(data)
             thought = clip_text(str(data.get("thought", "")).strip() or f"turn {turn}", limit=120)
             final = str(data.get("final", "")).strip()
             if final:

--- a/python/iamai/agent.py
+++ b/python/iamai/agent.py
@@ -334,7 +334,7 @@ class LLMClient:
             temperature=temperature,
             max_tokens=max_tokens,
             trace=trace,
-            response_format={"type":"json_object"}
+            response_format={"type": "json_object"}
         )
         value = extract_json_value(text)
         if isinstance(value, (dict, list)):

--- a/python/iamai/agent.py
+++ b/python/iamai/agent.py
@@ -7,7 +7,7 @@ import os
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
-from typing import Any, cast
+from typing import Any, cast, Optional
 
 DEFAULT_LLM_MODEL = ""
 
@@ -268,7 +268,7 @@ class LLMClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
         trace: AgentTrace | None = None,
-        response_format: dict[str, str] | None = None
+        response_format: Optional[dict[str,str]] = None
     ) -> str:
         """Call the configured chat model and return stripped text."""
         if os.getenv("iamai_LLM_MOCK"):

--- a/python/iamai/agent.py
+++ b/python/iamai/agent.py
@@ -268,6 +268,7 @@ class LLMClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
         trace: AgentTrace | None = None,
+        response_format:dict[str, str] | None = None
     ) -> str:
         """Call the configured chat model and return stripped text."""
         if os.getenv("iamai_LLM_MOCK"):
@@ -294,6 +295,7 @@ class LLMClient:
                 messages=cast(Any, messages),
                 temperature=(self.config.temperature if temperature is None else temperature),
                 max_tokens=self.config.max_tokens if max_tokens is None else max_tokens,
+                response_format=response_format
             )
         except Exception as exc:
             raise AgentError(f"chat completion failed: {exc}") from exc
@@ -326,11 +328,13 @@ class LLMClient:
                     "role": "system",
                     "content": "Return valid JSON only. Do not wrap it in markdown fences.",
                 },
+                
                 *messages,
             ],
             temperature=temperature,
             max_tokens=max_tokens,
             trace=trace,
+            response_format={"type":"json_object"}
         )
         value = extract_json_value(text)
         if isinstance(value, (dict, list)):

--- a/python/iamai/agent.py
+++ b/python/iamai/agent.py
@@ -268,7 +268,7 @@ class LLMClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
         trace: AgentTrace | None = None,
-        response_format:dict[str, str] | None = None
+        response_format: dict[str, str] | None = None
     ) -> str:
         """Call the configured chat model and return stripped text."""
         if os.getenv("iamai_LLM_MOCK"):

--- a/python/iamai/agent.py
+++ b/python/iamai/agent.py
@@ -268,7 +268,7 @@ class LLMClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
         trace: AgentTrace | None = None,
-        response_format: Optional[dict[str,str]] = None
+        response_format: Optional[dict[str,str]] = {"type": "text"}
     ) -> str:
         """Call the configured chat model and return stripped text."""
         if os.getenv("iamai_LLM_MOCK"):

--- a/python/iamai/context.py
+++ b/python/iamai/context.py
@@ -14,11 +14,11 @@ from .message import Message
 class Context:
     """Runtime context passed to handlers and middleware."""
 
-    runtime: "Runtime"
-    adapter: "Adapter"
-    plugin: "Plugin"
+    runtime: "Runtime"  # 同chore1
+    adapter: "Adapter"  # 同chore1
+    plugin: "Plugin"    # 同chore1
     event: Event
-    handler: "BoundHandler"
+    handler: "BoundHandler" # 同chore1
     matches: dict[str, Any] = field(default_factory=dict)
 
     @property

--- a/python/iamai/context.py
+++ b/python/iamai/context.py
@@ -14,11 +14,11 @@ from .message import Message
 class Context:
     """Runtime context passed to handlers and middleware."""
 
-    runtime: "Runtime"  # 同chore1
-    adapter: "Adapter"  # 同chore1
-    plugin: "Plugin"    # 同chore1
+    runtime: "Runtime"
+    adapter: "Adapter"
+    plugin: "Plugin"
     event: Event
-    handler: "BoundHandler" # 同chore1
+    handler: "BoundHandler"
     matches: dict[str, Any] = field(default_factory=dict)
 
     @property

--- a/python/iamai/plugin.py
+++ b/python/iamai/plugin.py
@@ -37,7 +37,7 @@ class HandlerSpec:
 class BoundHandler:
     """A handler callback bound to a concrete plugin instance."""
 
-    plugin: "Plugin"
+    plugin: "Plugin"    # chore1：第三行有“from __future__ import annotations”，还需要前向引用吗？
     spec: HandlerSpec
     callback: Callable[["Context"], Awaitable[Any] | Any]
 

--- a/python/iamai/plugin.py
+++ b/python/iamai/plugin.py
@@ -37,7 +37,7 @@ class HandlerSpec:
 class BoundHandler:
     """A handler callback bound to a concrete plugin instance."""
 
-    plugin: "Plugin"    # chore1：第三行有“from __future__ import annotations”，还需要前向引用吗？
+    plugin: Plugin
     spec: HandlerSpec
     callback: Callable[["Context"], Awaitable[Any] | Any]
 


### PR DESCRIPTION
1. add fastmcp dependency to pyproject.toml
2. add mcp plugin config and implementation
3. update reactor plugin to use mcp tools
4. add response_format support to LLM client
5. fix type annotation comments in plugin and context files