### PR TITLE
feat: update skill chat runtime example

### DIFF
--- a/examples/skill-chat-runtime/README.md
+++ b/examples/skill-chat-runtime/README.md
@@ -1,274 +1,100 @@
 # skill-chat-runtime
 
-基于技能路由（skill routing）的最小聊天机器人示例，展示 iamai 框架的**消息路由、工具调用、执行追踪和技能学习**能力。
+A minimal skill-routing chatbot example for `iamai`.
 
-## 概述
+It demonstrates:
 
-通过 4 个插件实现一个带"学习能力"的聊天机器人——用户聊得越多，它越"懂"该怎么路由消息：
+- message routing
+- tool calls
+- trace recording
+- skill search and promotion
+- LLM fallback replies
 
-- 每条消息经过「路由」决定该用哪个工具处理
-- 执行过程记录为「追踪记录（trace）」
-- 成功的追踪记录自动提炼为「技能清单（skill manifest）」
-- 后续消息优先匹配历史技能，形成自我优化循环
+## Start
 
-**展示的 iamai 特性：**
-
-- `message_handler` 自由文本匹配（无需命令前缀）
-- `command` 命令系统
-- `plugin_dirs` 自动发现
-- 插件依赖与加载顺序（`requires`、`load_after`）
-- 多阶段 Middleware（`before`、`error`）
-- 跨插件协作（通过 `runtime.get_plugin()`）
-- `ToolRegistry` 工具注册与调用
-- Pydantic 配置模型
-
-## 快速开始
-
-```bash
-# Windows（在 iamai 根目录）
-.venv\Scripts\Activate.ps1
-cd examples\skill-chat-runtime
-python run.py
+```powershell
+cd D:\jiandian\iamai
+uv run --package skill-chat-runtime python -m iamai --config examples/skill-chat-runtime/config.terminal.toml
 ```
 
-```bash
-# Linux / macOS
-source .venv/bin/activate
-cd examples/skill-chat-runtime
-python run.py
+The terminal prompt is `skill> `.
+
+## How it works
+
+1. User input is routed to an existing skill first.
+2. If no skill matches, heuristic rules are checked.
+3. If nothing matches, the router calls `llm_reply`.
+4. `llm_reply` traces are automatically promoted after 3 consecutive successes.
+
+The example also keeps a persistent trace buffer, so you can inspect the last runs and manually promote them later.
+
+## Chatting
+
+You can type natural language directly:
+
+- `画图软件哪个最好`
+- `帮我推荐一个适合 UI 设计的工具`
+- `我想要一个更适合新手的绘图软件`
+
+The bot will:
+
+- try to reuse an existing skill
+- otherwise use the LLM fallback
+
+If you want to force the command form, use:
+
+- `/chat <message>`
+
+## Commands
+
+### Chat and routing
+
+- `/chat <message>` - route a message explicitly
+- `/route <message>` - show the route decision for a message
+
+### Skill management
+
+- `/skills` - list recent skills
+- `/skills <query>` - search skills
+- `/skill <skill_id>` - inspect a skill
+- `/skill <skill_id> replay` - replay the source trace
+- `/skill promote [title]` - promote the latest successful trace
+
+### Trace inspection
+
+- `/trace` - show the latest trace
+- `/traces` - show recent traces
+- `/successes` - show recent successful traces
+- `/failures` - show recent failed traces
+
+### Runtime management
+
+- `/plugins` - list loaded plugins
+- `/adapters` - list adapters
+- `/reload` - reload plugins
+
+## LLM config
+
+This example reads its own `.env` file at:
+
+- `examples/skill-chat-runtime/.env`
+
+Required variables:
+
+```env
+OPENAI_API_KEY=...
+OPENAI_BASE_URL=...
+OPENAI_MODEL=...
 ```
 
-启动后看到 `skill>` 提示符即可输入。
+For DeepSeek compatibility, the current local `.env` uses:
 
-## 核心概念
+- `OPENAI_BASE_URL=https://api.deepseek.com`
+- `OPENAI_MODEL=deepseek-v4-pro`
 
-### 一条消息的完整流程
+## Files
 
-```
-用户输入: "帮我算一下 17 * 23 + 5"
-    │
-    ▼
-┌──────────┐
-│  router  │  _route() 路由决策
-│          │  ① 技能匹配：搜索 skill 库，找最佳匹配
-│          │  ② 启发式：匹配不到就按关键词规则
-│          │  ③ 兜底：都不行就走 echo
-└────┬─────┘
-     │ 决定: tool=math, skill=skill.math.quick
-     ▼
-┌──────────┐
-│  tools   │  run_tool("math", "17 * 23 + 5")
-│          │  → AST 解析 → 安全求值 → "396"
-└────┬─────┘
-     │
-     ▼
-┌──────────┐
-│  memory  │  append_trace(trace)
-│          │  记录完整追踪：输入、工具、结果、路由原因...
-└────┬─────┘
-     │
-     ▼
-┌──────────┐
-│  skills  │  ingest_trace(trace)  ← 自动提炼技能
-│          │  更新 skill.math.quick 的 success_count +1
-│          │  若 success_count >= 4 → 升级为 "promoted"
-└──────────┘
-```
-
-### 技能生命周期
-
-```
-draft ──(成功≥2次)──▶ verified ──(成功≥4次)──▶ promoted
-  │                                                │
-  └────────────────(失败≥3次 & 失败率≥60%)──────────▶ deprecated（不再参与匹配）
-```
-
-## 命令列表
-
-### 消息交互
-
-| 输入 | 说明 | 示例 |
-|------|------|------|
-| 自由文本 | 自动路由到合适的工具 | `hello`、`17*23+5`、`remember 我喜欢蓝色` |
-| `/chat` | 显式命令模式聊天 | `/chat what time is it` |
-| `/route` | 查看路由决策详情（调试用） | `/route 算一下 1+2` |
-
-### 技能管理
-
-| 命令 | 说明 | 示例 |
-|------|------|------|
-| `/skills` | 列出最近技能 | `/skills` |
-| `/skills <关键词>` | 搜索匹配的技能 | `/skills math` |
-| `/skill <id>` | 查看指定技能详情 | `/skill skill.math.quick` |
-| `/skill <id> replay` | 回放技能的源追踪记录 | `/skill skill.math.quick replay` |
-| `/skill promote [标题]` | 手动将最新追踪提升为技能 | `/skill promote quick math` |
-
-### 追踪诊断
-
-| 命令 | 说明 | 示例 |
-|------|------|------|
-| `/trace` | 查看最近一条追踪记录 | `/trace` |
-| `/traces` | 列出最近 6 条追踪 | `/traces` |
-| `/successes` | 列出最近成功追踪 | `/successes` |
-| `/failures` | 列出最近失败追踪 | `/failures` |
-
-### 内置管理（来自框架）
-
-| 命令 | 说明 |
-|------|------|
-| `/plugins` | 列出已加载插件 |
-| `/adapters` | 列出适配器 |
-| `/reload` | 热重载插件 |
-
-## 目录结构
-
-```
-examples/skill-chat-runtime/
-├── run.py                           # 入口脚本
-├── pyproject.toml                   # 项目配置
-├── config.terminal.toml             # 终端模式配置
-└── src/
-    └── skill_chat_runtime/
-        ├── __init__.py
-        ├── skilllib.py              # 共享数据模型与工具函数
-        └── plugins/
-            ├── __init__.py
-            ├── memory.py             # 追踪记录与笔记存储
-            ├── skills.py             # 技能清单管理与搜索
-            ├── tools.py              # 原子工具注册与调用
-            └── router.py             # 消息路由与调度
-```
-
-## 插件详解
-
-### 插件依赖关系
-
-```
-┌─────────┐
-│ memory  │ ◄── 存储追踪记录、笔记、错误信息
-└────┬────┘
-     │ requires
-┌────▼────┐
-│ skills  │ ◄── 管理技能清单，搜索与评分
-└────┬────┘
-     │ requires
-┌────▼────┐
-│ tools   │ ◄── 注册 5 个原子工具（echo/math/remember/recall/search_skill）
-└────┬────┘
-     │ requires + load_after
-┌────▼────┐
-│ router  │ ◄── 接收消息 → 路由决策 → 调用工具 → 记录追踪 → 提炼技能
-└─────────┘
-```
-
-加载顺序：`memory → skills → tools → router`
-
-### MemoryPlugin — 追踪与笔记
-
-**功能**：存储执行追踪记录（trace）和用户笔记（notes）。
-
-**Middleware**：
-
-| 阶段 | 方法 | 功能 |
-|------|------|------|
-| `before` | `ensure_buffers` | 确保 `notes`、`traces`、`last_error` 字段存在 |
-| `error` | `explain_agent_error` | 捕获异常，仅对 router 插件做友好提示 |
-
-**关键方法**：
-
-- `append_trace(trace)` — 存储追踪记录，超过 `trace_limit` 自动裁剪
-- `last_trace()` — 获取最近一条追踪记录
-
-### SkillsPlugin — 技能清单
-
-**功能**：管理技能清单的增删改查，提供搜索与评分。
-
-**技能状态流转**：`draft → verified → promoted`（升级）/ `deprecated`（降级）
-
-**关键方法**：
-
-- `search(query)` — 按词元重叠评分搜索技能
-- `best_match(query)` — 返回最佳匹配技能
-- `ingest_trace(trace)` — 从追踪记录更新或创建技能（自动提升）
-- `promote_latest_trace()` — 手动将最新追踪提升为技能
-
-### ToolsPlugin — 工具集
-
-**功能**：注册 5 个原子工具，通过 `ToolRegistry` 统一调用。
-
-| 工具名 | 功能 | 示例 |
-|--------|------|------|
-| `echo` | 回显输入文本 | `heard: hello` |
-| `math` | 安全求值算术表达式（AST 解析） | `17*23+5 → 396` |
-| `remember` | 存储笔记 | `stored note: 我喜欢蓝色` |
-| `recall` | 按关键词搜索笔记 | 返回匹配结果 |
-| `search_skill` | 搜索技能清单 | 返回匹配的技能列表 |
-
-### RouterPlugin — 路由调度
-
-**功能**：接收所有消息，决定用哪个工具处理，记录追踪，触发技能学习。
-
-**路由优先级**：
-1. **技能匹配** — 用 `skills.best_match()` 找最佳技能，分数 ≥ `skill_threshold` 则命中
-2. **启发式规则** — 按内置关键词规则匹配（纯数字表达式→math，含"remember"→remember...）
-3. **兜底** — 都不匹配就走 `echo`
-
-**消息入口**：
-- `free_chat`（`@message_handler`）处理不以 `/` 开头的自由文本
-- `/chat` 命令显式调用
-- `/route` 命令调试模式（跳过自动技能提炼）
-
-### skilllib.py — 共享数据模型
-
-| 类/函数 | 用途 |
-|---------|------|
-| `RouteDecision` | 路由决策结果（来源、工具名、技能ID、分数） |
-| `TraceRecord` | 单次执行追踪（输入、工具、结果、路径、状态） |
-| `SkillManifest` | 技能定义（触发器、示例、步骤、生命周期、评分） |
-| `score_skill(query, manifest)` | 基于词元重叠的加权评分算法 |
-| `build_skill_manifest(trace)` | 从追踪记录构建新技能 |
-| `tokenize(text)` | 分词并去除停用词 |
-| `default_seed_skills()` | 返回 5 个内置种子技能 |
-
-## 评分算法
-
-`score_skill()` 对查询词元和技能清单各字段进行加权匹配：
-
-| 匹配字段 | 权重 | 说明 |
-|----------|:----:|------|
-| `title` 命中 | ×3.0 | 标题匹配最重要 |
-| `triggers` 命中 | ×2.5 | 触发词匹配 |
-| `tags` 命中 | ×2.0 | 标签匹配 |
-| `summary` 命中 | ×1.5 | 摘要匹配 |
-| `examples` 命中 | ×1.0 | 示例匹配 |
-| `tool_name` 命中 | +2.0 | 工具名直接命中加分 |
-| `lifecycle=promoted` | +3.0 | 已推广技能加分 |
-| `lifecycle=verified` | +2.0 | 已验证技能加分 |
-| `lifecycle=deprecated` | ×0.3 | 已弃用技能大幅降权 |
-| 成功率 | ×4.0 | 成功率越高分越高 |
-| 复用次数 | ×0.25 | 重用越多分越高（上限10次） |
-
-## 配置说明
-
-关键配置项（完整配置见 `config.terminal.toml`）：
-
-```toml
-[runtime]
-command_prefixes = ["/"]
-adapters = ["terminal"]
-plugin_dirs = ["src/skill_chat_runtime/plugins"]   # 插件自动发现
-python_paths = ["src"]                              # 源码路径
-superusers = ["skill-user"]
-
-[plugin.memory]
-note_limit = 12           # 最多保留笔记数
-trace_limit = 8           # 最多保留追踪数
-
-[plugin.skills]
-skill_limit = 20          # 最多保留技能数
-auto_promote = true       # 是否自动提炼技能
-search_limit = 5          # 搜索返回结果数
-
-[plugin.router]
-skill_threshold = 0.45    # 技能匹配最低分数阈值
-```
+- `src/skill_chat_runtime/plugins/router.py` - routing and fallback
+- `src/skill_chat_runtime/plugins/tools.py` - tool registry and `llm_reply`
+- `src/skill_chat_runtime/plugins/skills.py` - skill storage and promotion
+- `src/skill_chat_runtime/plugins/memory.py` - notes and trace buffers

--- a/examples/skill-chat-runtime/config.terminal.toml
+++ b/examples/skill-chat-runtime/config.terminal.toml
@@ -28,10 +28,8 @@ trace_limit = 8
 [plugin.skills]
 skill_limit = 20
 auto_promote = true
+llm_promote_threshold = 3
 search_limit = 5
-
-[plugin.tools]
-math_limit = 1
 
 [plugin.router]
 skill_threshold = 0.45

--- a/examples/skill-chat-runtime/pyproject.toml
+++ b/examples/skill-chat-runtime/pyproject.toml
@@ -5,7 +5,9 @@ description = "Minimal chatbot example with traces, skill manifests, and skill r
 requires-python = ">=3.10"
 dependencies = [
     "iamai",
+    "iamai-example-utils",
 ]
 
 [tool.uv.sources]
 iamai = { workspace = true }
+iamai-example-utils = { workspace = true }

--- a/examples/skill-chat-runtime/src/skill_chat_runtime/data/seed_skills.json
+++ b/examples/skill-chat-runtime/src/skill_chat_runtime/data/seed_skills.json
@@ -1,16 +1,16 @@
 [
   {
-    "id": "skill.echo.basic",
+    "id": "skill.llm_reply.basic",
     "title": "Basic chat reply",
-    "summary": "Use echo to answer short greetings and simple conversational prompts.",
+    "summary": "Use llm_reply to answer short greetings and simple conversational prompts.",
     "goal": "Handle casual conversation and short greetings.",
-    "tool_name": "echo",
+    "tool_name": "llm_reply",
     "triggers": ["hello", "hi", "greeting", "chat"],
     "examples": ["hello", "hi there"],
-    "steps": ["echo the user text back in a compact form"],
+    "steps": ["use the fallback LLM to answer compactly"],
     "tags": ["seed", "chat"],
     "status": "seed",
-    "lifecycle": "promoted",
+    "lifecycle": "draft",
     "score": 1.0
   },
   {

--- a/examples/skill-chat-runtime/src/skill_chat_runtime/plugins/router.py
+++ b/examples/skill-chat-runtime/src/skill_chat_runtime/plugins/router.py
@@ -75,8 +75,8 @@ class RouterPlugin(Plugin):
                     score=0.5,
                 )
         return RouteDecision(
-            source="heuristic",
-            tool_name="echo",
+            source="llm",
+            tool_name="llm_reply",
             tool_input=clean,
             reason="fallback reply",
             score=0.1,
@@ -119,7 +119,10 @@ class RouterPlugin(Plugin):
             trace.status = "success"
             trace.reply_text = reply
             memory.append_trace(trace)
-            if origin != "inspect" and bool(skills.config.get("auto_promote", True)):
+            if (
+                origin != "inspect"
+                and bool(skills.config.get("auto_promote", True))
+            ):
                 generated = skills.ingest_trace(trace)
                 if generated is not None:
                     logger.info(

--- a/examples/skill-chat-runtime/src/skill_chat_runtime/plugins/skills.py
+++ b/examples/skill-chat-runtime/src/skill_chat_runtime/plugins/skills.py
@@ -24,6 +24,7 @@ class SkillsConfig(BaseModel):
 
     skill_limit: int = 20
     auto_promote: bool = True
+    llm_promote_threshold: int = 3
     search_limit: int = 5
     verified_success_threshold: int = 2
     promoted_success_threshold: int = 4
@@ -47,7 +48,33 @@ class SkillsPlugin(Plugin):
         if not skills:
             skills = default_seed_skills()
             self._store_skills(skills)
+        else:
+            self._backfill_llm_skill_trace(skills)
         return skills
+
+    def _backfill_llm_skill_trace(self, skills: list[SkillManifest]) -> None:
+        """Fill missing llm_reply trace references from recent memory when available."""
+        memory = self.runtime.get_plugin("memory")
+        trace = next(
+            (
+                item
+                for item in reversed(memory.state.get("traces", []))
+                if item.get("status") == "success"
+                and item.get("tool_name") == "llm_reply"
+                and item.get("mode") != "inspect"
+            ),
+            None,
+        )
+        if trace is None:
+            return
+        changed = False
+        for skill in skills:
+            if skill.tool_name == "llm_reply" and not skill.source_trace_id:
+                skill.source_trace_id = str(trace.get("trace_id", ""))
+                if skill.source_trace_id:
+                    changed = True
+        if changed:
+            self._store_skills(skills)
 
     def _store_skills(self, skills: list[SkillManifest]) -> None:
         """Persist skills to plugin state, trimming to the configured limit."""
@@ -61,6 +88,7 @@ class SkillsPlugin(Plugin):
         failure_rate = (skill.failure_count / total) if total else 0.0
         verified_threshold = int(self.config.get("verified_success_threshold", 2))
         promoted_threshold = int(self.config.get("promoted_success_threshold", 4))
+        llm_promote_threshold = int(self.config.get("llm_promote_threshold", promoted_threshold))
         deprecated_threshold = int(self.config.get("deprecated_failure_threshold", 3))
         deprecated_ratio = float(self.config.get("deprecated_failure_ratio", 0.6))
 
@@ -71,7 +99,16 @@ class SkillsPlugin(Plugin):
                 skill.deprecated_at = skill.updated_at
             return skill
 
-        if skill.success_count >= promoted_threshold:
+        success_gate = (
+            skill.consecutive_success_count
+            if skill.tool_name == "llm_reply"
+            else skill.success_count
+        )
+        gate_threshold = (
+            llm_promote_threshold if skill.tool_name == "llm_reply" else promoted_threshold
+        )
+
+        if success_gate >= gate_threshold:
             skill.lifecycle = "promoted"
             skill.status = "promoted"
             if not skill.promoted_at:
@@ -95,8 +132,10 @@ class SkillsPlugin(Plugin):
         skill.last_outcome = outcome
         if outcome == "success":
             skill.success_count += 1
+            skill.consecutive_success_count += 1
         else:
             skill.failure_count += 1
+            skill.consecutive_success_count = 0
         total = skill.success_count + skill.failure_count
         if total > 0:
             skill.score = round(
@@ -106,6 +145,10 @@ class SkillsPlugin(Plugin):
 
     def _find_skill_index(self, skills: list[SkillManifest], trace: TraceRecord) -> int | None:
         """Find the index of a skill matching the given trace (by ID or signature)."""
+        if trace.tool_name == "llm_reply":
+            for index, skill in enumerate(skills):
+                if skill.tool_name == "llm_reply":
+                    return index
         if trace.skill_id:
             for index, skill in enumerate(skills):
                 if skill.id == trace.skill_id:
@@ -159,6 +202,7 @@ class SkillsPlugin(Plugin):
             manifest = build_skill_manifest(trace, title=title)
             manifest.reuse_count = 1
             manifest.success_count = 1
+            manifest.consecutive_success_count = 1
             manifest.last_used_at = trace.timestamp
             manifest.last_outcome = "success"
             manifest.updated_at = trace.timestamp
@@ -171,6 +215,8 @@ class SkillsPlugin(Plugin):
 
         skill = skills[index]
         self._touch_skill(skill, outcome="success", timestamp=trace.timestamp)
+        if not skill.source_trace_id:
+            skill.source_trace_id = trace.trace_id
         skill.last_used_at = trace.timestamp
         skill.updated_at = trace.timestamp
         if trace.input_text and trace.input_text not in skill.examples:
@@ -192,10 +238,17 @@ class SkillsPlugin(Plugin):
     def promote_latest_trace(self, *, title: str | None = None) -> SkillManifest | None:
         """Promote the latest successful trace into a skill manifest."""
         memory = self.runtime.get_plugin("memory")
-        trace = memory.last_trace()
+        trace = next(
+            (
+                item
+                for item in reversed(memory.state.get("traces", []))
+                if item.get("status") == "success" and item.get("mode") != "inspect"
+            ),
+            None,
+        )
         if trace is None:
             return None
-        return self.ingest_trace(trace, title=title)
+        return self.ingest_trace(TraceRecord.model_validate(trace), title=title)
 
     def format_search(self, query: str, *, limit: int | None = None) -> str:
         """Format skill search results as a human-readable string."""
@@ -279,8 +332,8 @@ class SkillsPlugin(Plugin):
                         f"- path: {' -> '.join(trace.path) if trace.path else trace.tool_name}",
                         f"- reply: {trace.reply_text or '-'}",
                         f"- error: {trace.error or '-'}",
-                    ]
-                )
+                ]
+            )
             await ctx.reply("\n".join(lines))
             return
         await ctx.reply(json.dumps(target.model_dump(mode="python"), indent=2, ensure_ascii=False))

--- a/examples/skill-chat-runtime/src/skill_chat_runtime/plugins/tools.py
+++ b/examples/skill-chat-runtime/src/skill_chat_runtime/plugins/tools.py
@@ -4,14 +4,19 @@ import ast
 import logging
 import operator
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from iamai import Context, Plugin, ToolRegistry
-from pydantic import BaseModel
+from iamai.config import load_env_file
+from iamai_example_utils import LLMSettings, chat_text, format_transcript, resolve_llm_settings
+from pydantic import BaseModel, Field
 
 from skill_chat_runtime.skilllib import summarize
 
 logger = logging.getLogger(__name__)
+
+load_env_file(Path(__file__).resolve().parents[3] / ".env", override=True)
 
 _BINARY_OPS: dict[type[ast.operator], Callable[[Any, Any], Any]] = {
     ast.Add: operator.add,
@@ -33,6 +38,7 @@ class ToolsConfig(BaseModel):
     """Configuration for the tools plugin."""
 
     math_limit: float | None = None
+    llm: LLMSettings = Field(default_factory=LLMSettings)
 
 
 class ToolsPlugin(Plugin):
@@ -48,11 +54,11 @@ class ToolsPlugin(Plugin):
         """Create and populate the tool registry, then persist it in state."""
         registry = ToolRegistry()
         for name, description, callback, needs_ctx in (
-            ("echo", "echo a compact response", self._echo, False),
             ("math", "evaluate an arithmetic expression", self._math, False),
             ("remember", "store a short note or preference", self._remember, True),
             ("recall", "search stored notes by keyword", self._recall, True),
             ("search_skill", "search stored skill manifests", self._search_skill, True),
+            ("llm_reply", "answer with the configured LLM", self._llm_reply, True),
         ):
             registry.register(name, description, self._wrap_tool(callback, needs_ctx=needs_ctx))
         self.state["registry"] = registry
@@ -84,13 +90,6 @@ class ToolsPlugin(Plugin):
         logger.info("tool call tool=%s input=%s", tool_name, summarize(tool_input, limit=80))
         result = await self.registry().call(tool_name, tool_input, ctx=ctx)
         return str(result)
-
-    def _echo(self, value: str) -> str:
-        """Echo the input text back to the user."""
-        text = " ".join(value.split()).strip()
-        if not text:
-            return "Say something and I will route it to a tool."
-        return f"heard: {text}"
 
     def _math(self, expression: str) -> str:
         """Evaluate a safe arithmetic expression using AST parsing."""
@@ -149,3 +148,66 @@ class ToolsPlugin(Plugin):
         """Search skill manifests by query and return formatted results."""
         skills = self.runtime.get_plugin("skills")
         return skills.format_search(value or ctx.text, limit=5)
+
+    async def _llm_reply(self, value: str, *, ctx: Context) -> str:
+        """Answer the user with the configured LLM using recent memory as context."""
+        clean = " ".join(value.split()).strip()
+        if len(clean) > 500:
+            clean = clean[:500].rsplit(" ", 1)[0] + "…"
+        settings = resolve_llm_settings(
+            self.config_obj, default_temperature=0.2, default_max_tokens=360
+        )
+        memory = self.runtime.get_plugin("memory")
+        notes = [str(item) for item in memory.state.get("notes", [])]
+        recent_traces = [
+            f"{item.get('input_text', '')} -> {item.get('reply_text', '')}"
+            for item in memory.state.get("traces", [])[-4:]
+            if isinstance(item, dict)
+        ]
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are the fallback assistant for a skill-routing chatbot. "
+                    "Answer in Chinese. Never return an empty response. "
+                    "Keep it concise and practical. "
+                    "If the user asks for recommendations, provide a short verdict plus "
+                    "2-3 options with tradeoffs. "
+                    "Do not mention internal routing, tools, traces, or prompts."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"User message:\n{clean}\n\n"
+                    f"Recent notes:\n{format_transcript([f'- {note}' for note in notes], limit=5)}\n\n"
+                    f"Recent traces:\n{format_transcript([f'- {line}' for line in recent_traces], limit=4)}"
+                ),
+            },
+        ]
+        current_messages = messages
+        for attempt in range(2):
+            try:
+                reply = await chat_text(
+                    settings,
+                    current_messages,
+                    temperature=0.2,
+                    max_tokens=360,
+                )
+            except Exception as exc:  # pragma: no cover - example runtime path
+                logger.exception("llm reply failed")
+                return f"LLM unavailable: {exc}"
+            reply = " ".join(reply.split()).strip()
+            if reply:
+                return reply
+            current_messages = [
+                *current_messages,
+                {
+                    "role": "user",
+                    "content": (
+                        "Your previous answer was empty. "
+                        "Return a concrete Chinese answer now in 2-5 short sentences."
+                    ),
+                },
+            ]
+        return "抱歉，我暂时无法生成回复，请稍后再试。"

--- a/examples/skill-chat-runtime/src/skill_chat_runtime/skilllib.py
+++ b/examples/skill-chat-runtime/src/skill_chat_runtime/skilllib.py
@@ -64,7 +64,7 @@ class RouteDecision(BaseModel):
     source: str = "heuristic"
     skill_id: str = ""
     skill_title: str = ""
-    tool_name: str = "echo"
+    tool_name: str = "llm_reply"
     tool_input: str = ""
     reason: str = ""
     score: float = 0.0
@@ -79,7 +79,7 @@ class TraceRecord(BaseModel):
     reply_text: str = ""
     status: str = "success"
     mode: str = "chat"
-    tool_name: str = "echo"
+    tool_name: str = "llm_reply"
     tool_input: str = ""
     route_reason: str = ""
     skill_id: str = ""
@@ -112,6 +112,7 @@ class SkillManifest(BaseModel):
     reuse_count: int = 0
     success_count: int = 0
     failure_count: int = 0
+    consecutive_success_count: int = 0
     last_used_at: str = ""
     last_outcome: str = ""
     promoted_at: str = ""


### PR DESCRIPTION
## Summary

- Update the `skill-chat-runtime` example under `examples/skill-chat-runtime`
- Improve skill routing, tool handling, and LLM fallback behavior
- Update runtime configuration and README documentation

## Changes

- Refined router, skills, and tools plugins
- Updated seed skill definitions
- Adjusted example configuration and package metadata
- Updated README to describe the current runtime behavior