### PR TITLE
fix: set repository context for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, windows, macos, sdist]
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       # Use to sign the release artifacts
       id-token: write


### PR DESCRIPTION
## Summary
- set `GH_REPO` in the tag-only GitHub Release step
- allow `gh release view/create/upload` to resolve the repository without a checkout

## Root cause
The v0.3.0 tag workflow built, attested, and published all artifacts to PyPI, then failed while creating the GitHub Release with `fatal: not a git repository`. The release job intentionally does not check out source, so `gh` needs an explicit repository context.

## Recovery
The v0.3.0 GitHub Release was created manually from the exact 16 attested workflow artifacts. This PR prevents the same failure on future tags.

## Validation
- `release.yml` parses successfully
- `GH_REPO=retrofor/iamai gh release view v0.3.0` succeeds from `/tmp`, outside any Git repository
- full CI runs on this PR