### PR TITLE
docs: define post-v0.3 execution spec

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,103 @@
+# Post-v0.3 execution TODO
+
+This ledger tracks the ordered work defined in
+[`docs/reference/post-v0.3-execution-spec.rst`](docs/reference/post-v0.3-execution-spec.rst).
+Evidence must be a commit, PR, CI run, test output, issue comment, or an explicit external blocker.
+
+Status values:
+
+- `TODO`: not started.
+- `IN_PROGRESS`: the current sequential workstream.
+- `BLOCKED_EXTERNAL`: requires credentials, an external owner, or a future deadline; the checkbox stays open.
+- `DONE`: every acceptance criterion is satisfied and linked.
+
+## Execution status
+
+| Workstream | Status | Evidence | Blocker / last verified / resume condition |
+| --- | --- | --- | --- |
+| 0. Specification baseline | `IN_PROGRESS` | [PR #445](https://github.com/retrofor/iamai/pull/445); local docs tests and Sphinx `-W` pass | Last verified 2026-07-15; resume after PR CI and merge |
+| 1. FOSSA governance | `TODO` | [#436](https://github.com/retrofor/iamai/issues/436) | Start after workstream 0 |
+| 2. Low-risk dependencies | `TODO` | PRs #437, #439, #441, #442, #443 | Start after workstream 1 is `DONE` or `BLOCKED_EXTERNAL` |
+| 3. Gated dependencies | `TODO` | PRs #438 and #440 | Start after workstream 2 |
+| 4. Version 0.4 contract | `TODO` | [#435](https://github.com/retrofor/iamai/issues/435) | Start after workstream 3 |
+| 5. Version 1.0 contract | `TODO` | [#434](https://github.com/retrofor/iamai/issues/434) | Start after workstream 4 |
+| 6. needs-info closure | `TODO` | Issues #294, #295, #297, #306 | Time-triggered exception: execute after 2026-07-29 23:59 UTC even if workstreams 4-5 remain active |
+
+## 0. Specification baseline
+
+- [ ] Publish the execution spec and this ledger through a reviewed PR with green CI.
+
+## 1. FOSSA and release governance
+
+Tracking: [#436](https://github.com/retrofor/iamai/issues/436)
+
+- [ ] Confirm whether a FOSSA project-admin login or API token is available.
+- [ ] Repoint the FOSSA project and revision analysis from `master` to `dev`.
+- [ ] Confirm the project license is SPDX `MIT` and remove the phantom AGPL conclusion.
+- [ ] Change the project policy from `Single-Binary Distribution` to `Standard Bundle`.
+- [ ] Export the current issue inventory with dependency, version, license, policy, locator, and disposition.
+- [ ] Resolve, allow, or time-bound waive every current finding.
+- [ ] Verify one `dev` revision and one PR revision; attach evidence to #436.
+- [ ] Remove or replace the v0.3.0 waiver before 2026-08-15.
+- [ ] Close #436 only after the spec completion definition is met.
+
+## 2. Low-risk dependency PRs
+
+- [ ] Update, verify, and merge [#437](https://github.com/retrofor/iamai/pull/437) (`serde_json`).
+- [ ] Update, verify, and merge [#439](https://github.com/retrofor/iamai/pull/439) (Ruff/FastMCP).
+- [ ] Update, verify, and merge [#441](https://github.com/retrofor/iamai/pull/441) (Mypy 2).
+- [ ] Update, verify, and merge [#442](https://github.com/retrofor/iamai/pull/442) (Pytest 9).
+- [ ] Update, verify, and merge [#443](https://github.com/retrofor/iamai/pull/443) (Sphinx 9).
+- [ ] Verify final `dev` lockfiles and post-merge CI.
+
+## 3. Dependency PRs with special gates
+
+- [ ] Update [#438](https://github.com/retrofor/iamai/pull/438) to the latest `dev`.
+- [ ] Run a non-tag release rehearsal for #438 and verify every build and attestation job.
+- [ ] Merge #438 and verify post-merge `dev` CI.
+- [ ] Add real WebSocket loopback regression tests for #440.
+- [ ] Run the loopback tests on Python 3.11 and 3.13.
+- [ ] Update, verify, and merge [#440](https://github.com/retrofor/iamai/pull/440).
+- [ ] Verify post-merge `dev` CI.
+
+## 4. Version 0.4 extension contract
+
+Tracking: [#435](https://github.com/retrofor/iamai/issues/435)
+
+- [ ] 0.4-A: publish packaging/discovery metadata and deterministic error contracts.
+- [ ] 0.4-A: add installable reference adapter and plugin fixtures with isolated-install tests.
+- [ ] 0.4-B: implement one root/runtime/adapter/plugin schema generator.
+- [ ] 0.4-B: add stable IDs, contract version, defaults, and secret annotations.
+- [ ] 0.4-B: prove CLI and management API schema equivalence.
+- [ ] 0.4-C: publish adapter and plugin conformance helpers.
+- [ ] 0.4-C: run the helpers against both reference distributions in isolated environments.
+- [ ] Document ecosystem admission evidence and close #435.
+
+## 5. Version 1.0 public API contract
+
+Tracking: [#434](https://github.com/retrofor/iamai/issues/434)
+
+- [ ] Publish the versioned Event/Message serialization contract.
+- [ ] Add valid/invalid golden round-trip tests.
+- [ ] Publish and test Runtime/Adapter/Plugin lifecycle ordering and failure semantics.
+- [ ] Define and test Context event scope, reply routing, dependency injection, and invalidation semantics.
+- [ ] Expose a schema/contract version and test supported evolution rules.
+- [ ] Publish the normative conformance matrix.
+- [ ] Publish the deprecation policy and minimum support window.
+- [ ] Publish the final 0.x to 1.0 migration guide.
+- [ ] Validate the complete contract against a 1.0 RC and close #434.
+
+## 6. needs-info issue closure
+
+Deadline: 2026-07-29 23:59 UTC.
+
+- [ ] Recheck [#294](https://github.com/retrofor/iamai/issues/294), [#295](https://github.com/retrofor/iamai/issues/295), and [#297](https://github.com/retrofor/iamai/issues/297) after the deadline.
+- [ ] Close them if unanswered, or replace them with one owned, testable i18n issue.
+- [ ] Recheck [#306](https://github.com/retrofor/iamai/issues/306) after the deadline.
+- [ ] Close or migrate #306 unless it proves a core runtime scheduling contract.
+- [ ] Confirm no unowned wishlist remains on the core roadmap.
+
+## Cross-cutting verification
+
+- [ ] Recheck GitHub Dependabot alerts after dependency-graph recomputation; do not dismiss fixed alerts manually.
+- [ ] Keep `dev` protection, release evidence, and the working tree clean after every merge.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -30,6 +30,7 @@
    cli
    configuration
    extensions
+   post-v0.3-execution-spec
    docs-i18n-versions
    rules
    webhook-signatures

--- a/docs/reference/post-v0.3-execution-spec.rst
+++ b/docs/reference/post-v0.3-execution-spec.rst
@@ -1,0 +1,223 @@
+v0.3 之后的执行规范
+=====================
+
+状态
+----
+
+本规范定义 ``v0.3.0`` 发布后的六个连续执行工作流，编号为 1 到 6。仓库根目录
+``TODO.md`` 另外使用工作流 0 记录本规范和台账自身的发布门；工作流 0 不属于这六个产品工作流。
+GitHub issue、pull request、CI run 和外部合规系统保存完成证据。
+
+规范中的“必须”是验收要求，“建议”是默认工程选择。除非工作流被标记为
+``BLOCKED_EXTERNAL``，后一个工作流只能在前一个工作流满足完成定义后开始。工作流 6 是唯一例外：
+它由 2026-07-29 截止时间触发，必须按期执行，不能等待 0.4 或 1.0 工作结束。
+``BLOCKED_EXTERNAL`` 必须同时记录阻塞方、所需权限或事件、最后验证时间和恢复条件，
+不能用来代替可以在仓库内完成的工作。
+
+共同质量门
+----------
+
+每个代码变更必须满足：
+
+* 基于最新 ``dev`` 创建独立分支和 pull request。
+* 先运行与改动直接相关的测试，再运行 Ruff、Mypy、Pytest、Rust tests、配置验证和
+  Sphinx ``-W`` 中适用的完整门禁。
+* 所有受保护检查使用变更后的最新提交重新运行，不接受旧提交上的绿灯。
+* pull request 的可执行 review thread 全部解决；合并后再次确认 ``dev`` CI。
+* 不通过移动已发布 tag、改写公共历史或人工删除安全告警来制造完成状态。
+
+工作流 1：FOSSA 与发布治理
+---------------------------
+
+目标
+~~~~
+
+让 FOSSA 分析真实默认分支 ``dev``、读取项目 MIT 许可证，并产生可以逐项审计的
+当前 revision 结果。跟踪项为 `GitHub issue #436 <https://github.com/retrofor/iamai/issues/436>`_。
+
+必须完成
+~~~~~~~~
+
+* FOSSA 项目 source revision 从旧 ``master`` 改为 ``dev``。
+* 项目许可证识别为 SPDX ``MIT``，不再出现无法由当前 manifest、lockfile 或源码解释的
+  phantom AGPL 结论。
+* 项目策略从旧 ``Single-Binary Distribution`` 调整为适合本项目发布形态的 ``Standard Bundle``。
+* 导出当前 revision 的全部 issue 清单，至少包含 dependency、version、license、policy、
+  locator 和处置结论。
+* 对真实问题执行升级、移除、策略允许或具名书面豁免；任何豁免必须有范围和失效日期。
+* 在一个 ``dev`` revision 和一个 pull request revision 上取得可复现结果。
+* 在结果稳定前，``License Compliance`` 不得加入 ``dev`` 的 required checks。
+
+完成定义
+~~~~~~~~
+
+FOSSA revision、清单和 GitHub status URL 均指向 ``dev``；所有 findings 已清零或逐项处置；
+证据链接写入 `#436 <https://github.com/retrofor/iamai/issues/436>`_，现有 ``v0.3.0`` 豁免在
+2026-08-15 前关闭或被新的具名决策替代。
+
+外部阻塞
+~~~~~~~~
+
+修改 FOSSA 项目和读取 issue 明细需要项目管理员登录或 API token。没有这些权限时，执行者必须
+记录公开可验证的 project/status 信息、凭据探测结果和恢复条件，然后将本工作流标记为
+``BLOCKED_EXTERNAL``，不能猜测 11 条 issue 的内容。
+
+工作流 2：低风险依赖升级
+-------------------------
+
+目标
+~~~~
+
+逐个处理已通过针对性门禁的 Dependabot pull request：``#437``、``#439``、``#441``、
+``#442`` 和 ``#443``。
+
+执行规则
+~~~~~~~~
+
+* 每个分支必须先更新到最新 ``dev``，再取得 fresh green。
+* ``#437`` 只改变 Cargo lock 中的 serde_json patch，可独立处理。
+* ``#439``、``#441``、``#442``、``#443`` 共享 ``uv.lock``，必须一次只更新和合并一个；
+  下一项必须在前一项进入 ``dev`` 后重新 rebase。
+* Mypy、Pytest 和 Sphinx 的 major 更新只针对当前具体 PR 放行，不建立未来 major 自动合并策略。
+* FOSSA 的旧 ``master`` 状态不作为依赖兼容性证据；真实 required checks、CodeQL 和
+  pre-commit 才是 GitHub 合并门。
+
+完成定义
+~~~~~~~~
+
+五个 pull request 均已合并或被一个有等价版本和更完整验证的新 PR 取代；最终 ``dev`` lockfile
+一致，完整 CI 通过，未留下并行旧 lock 分支造成的冲突。
+
+工作流 3：带专项门禁的依赖升级
+-------------------------------
+
+GitHub Actions major 更新
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``#438`` 必须在精确最新 head 上触发一次非 tag ``workflow_dispatch`` release rehearsal。
+该 run 不得发布 PyPI 或 GitHub Release，但必须完成 validate、sdist、所有 Linux、musllinux、
+Windows、macOS wheels、artifact download 和 provenance attestation。只有 rehearsal 全绿且普通
+PR CI fresh green 后才能合并。
+
+WebSocket runtime major 更新
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``#440`` 改变生产依赖，必须先增加真实 loopback tests，而不是只依赖 fake transport。测试至少覆盖：
+
+* client connect 和鉴权 header；
+* server handler 的 path/role 解析；
+* JSON 双向 send/echo；
+* 正常 close；
+* 断线后的 reconnect 或明确终止语义；
+* Python 3.11 和 3.13。
+
+完成定义
+~~~~~~~~
+
+``#438`` 的 rehearsal 证据和 ``#440`` 的 loopback tests 链接到对应 PR；两个 PR 在最新 ``dev``
+上取得 fresh green 并按顺序合并，合并后 ``dev`` CI 通过。
+
+工作流 4：0.4 扩展契约
+----------------------
+
+目标
+~~~~
+
+完成 `GitHub issue #435 <https://github.com/retrofor/iamai/issues/435>`_，让第三方 adapter 和
+plugin 可以被独立打包、发现、配置和验证。
+
+0.4-A：打包与发现
+~~~~~~~~~~~~~~~~~~
+
+* 发布 distribution 命名、``iamai`` 兼容范围 metadata 和 entry-point group 规范。
+* 提供一个可安装 reference adapter fixture 和一个 reference plugin fixture。
+* 在隔离安装环境验证显式加载与 opt-in auto-discovery，不使用仓库本地 import path。
+* 对重复 entry-point 名、entry-point 与 ``Plugin.name`` / ``Adapter.name`` 不一致以及错误对象类型
+  给出稳定、可断言的 runtime 错误。
+* 兼容范围使用标准 ``Requires-Dist`` 声明，不发明第二套 runtime version metadata；隔离安装测试必须
+  证明 package resolver 会拒绝与当前 ``iamai`` 版本不兼容的扩展。
+* discovery 顺序必须确定，失败信息必须包含 group、entry-point、distribution 和原因。
+
+0.4-B：统一 Schema 导出
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* 单一生成器导出 root/runtime、adapter 和 plugin 配置 JSON Schema。
+* payload 必须包含稳定 ``$id``、contract version、默认值；secret 字段在对应 property schema 上使用
+  JSON Schema ``writeOnly: true``，且不得导出 secret 的运行时值。
+* CLI ``config-schema`` 和 management API ``/schema`` 对同一扩展集合输出语义等价 payload。
+* 输出顺序稳定，并有 golden/equivalence tests。
+
+0.4-C：公开 conformance kit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* adapter helper 覆盖配置、inbound normalize、outbound encode/API、启动、取消、失败清理和错误语义。
+* plugin helper 覆盖 metadata、配置、依赖、handler 注册、权限、生命周期和清理。
+* reference adapter/plugin 在独立安装环境运行公开 helper。
+* ecosystem admission 文档列出 metadata、安全声明、兼容范围和 conformance 证据。
+
+完成定义
+~~~~~~~~
+
+`#435 <https://github.com/retrofor/iamai/issues/435>`_ 的全部 acceptance criteria 有自动测试或
+明确的人工证据；三个切片各自以小型 PR 合并，
+公开文档和第三方可导入的测试 helper 与实现同步。
+
+工作流 5：1.0 公共 API 契约
+---------------------------
+
+目标
+~~~~
+
+完成 `GitHub issue #434 <https://github.com/retrofor/iamai/issues/434>`_，在 1.0 RC 前发布可测试的
+兼容性规范。该工作流依赖工作流 4 完成。
+
+必须完成
+~~~~~~~~
+
+* 定义 ``Event`` 和 ``Message`` 的版本化序列化形式、必需/可选字段、未知字段和 round-trip 规则。
+* 定义 ``Runtime``、``Adapter`` 和 ``Plugin`` 的启动、正常关闭、取消、失败清理、reload 和
+  handler admission 顺序。
+* 单独定义 ``Context`` 的事件作用域、回复路由、依赖注入和失效语义；``Context`` 不拥有 runtime
+  lifecycle。
+* 公开 schema/contract version，并用兼容性测试证明已支持的演进规则。
+* 建立规范条款到自动测试或人工检查的一一对应 conformance matrix。
+* 定义 public symbol、配置 key、entry point 和序列化字段的弃用警告机制、最短支持窗口和删除规则。
+* 发布最后一个 ``0.x`` 到 ``1.0`` 的迁移指南，列出所有有意 breaking changes。
+
+完成定义
+~~~~~~~~
+
+版本化规范、golden tests、生命周期 contract tests、conformance matrix、弃用政策和迁移指南全部进入
+``dev``，并在 1.0 RC 构建上通过。
+
+工作流 6：needs-info issue 收敛
+--------------------------------
+
+目标
+~~~~
+
+在 2026-07-29 截止日后收敛 ``#294``、``#295``、``#297`` 和 ``#306``，避免没有维护者和真实
+使用场景的请求长期占用路线图。
+
+处理规则
+~~~~~~~~
+
+* 截止日前保留 issue，并只接受能说明当前行为、期望行为、使用场景、归属仓库和验收示例的回复。
+* ``#294``、``#295``、``#297`` 若证明是同一 i18n 缺口，合并成一个新的、可执行的 issue；若只是
+  文档本地化而当前版本已支持，则关闭并链接现有文档。
+* ``#306`` 默认迁移到独立 scheduler plugin、service integration 或对应外部包；只有能证明是多个
+  扩展共同需要的通用 scheduling contract 时才保留在核心仓库，不把 scheduler 错归类为传输 adapter。
+* 2026-07-29 23:59 UTC 后仍无有效回复的 issue 关闭，并引用原 clarification 请求。
+
+完成定义
+~~~~~~~~
+
+四个 issue 均被关闭、迁移，或被有 owner、范围、验收标准和里程碑的新 issue 取代；核心路线图不保留
+无归属的 wishlist。
+
+跨工作流安全告警基线
+--------------------
+
+Dependabot API 的告警状态可能晚于 lockfile 和 dependency graph。执行者必须等待默认分支扫描完成，
+再用 manifest/lockfile 和 GitHub dependency graph 复核。只有误报、撤回 advisory 或不准确规则才可
+人工 dismiss；已通过升级或移除解决的告警应由 GitHub 自动关闭。


### PR DESCRIPTION
## Summary

- define the six ordered post-v0.3 workstreams and their acceptance criteria
- add a repository-backed TODO ledger with status, evidence, blockers, and resume conditions
- document the time-triggered exception for needs-info issue closure

## Validation

- `uv run pytest -q tests/test_docs_content.py tests/test_docs_extensions.py`
- `uv run sphinx-build -W --keep-going -b html docs /tmp/iamai-spec-docs`
- independent review: APPROVE

Tracks #434, #435, and #436.