### PR TITLE
Harden WebSocket middleware lifecycle with real loopback tests

### DIFF
--- a/python/iamai/adapters/middleware.py
+++ b/python/iamai/adapters/middleware.py
@@ -369,7 +369,14 @@ class JsonWebSocketClientMiddleware(AdapterMiddleware):
                 await self._unbind_connection()
             if self._closed.is_set():
                 return
-            await asyncio.sleep(self.reconnect_interval)
+            try:
+                await asyncio.wait_for(
+                    self._closed.wait(),
+                    timeout=max(self.reconnect_interval, 0.0),
+                )
+            except TimeoutError:
+                continue
+            return
 
     async def _consume_connection(self, websocket: Any, role: str = "universal") -> None:
         async for payload in websocket:
@@ -580,6 +587,9 @@ class JsonWebSocketServerMiddleware(JsonWebSocketClientMiddleware):
         current = self._current_ws_by_role(role)
         if current is not None:
             self.logger.warning("closing previous %s reverse ws %s connection", self.name, role)
+            if current is self._api_socket_for_calls():
+                self._connection_ready.clear()
+                await self._fail_pending(ConnectionError(f"{self.name} connection replaced"))
             try:
                 await current.close(code=1012, reason="replaced by new connection")
             except Exception:
@@ -616,6 +626,7 @@ class JsonWebSocketServerMiddleware(JsonWebSocketClientMiddleware):
     ) -> None:
         if websocket is None:
             websocket = self._current_ws_by_role(role)
+        was_api_socket = websocket is self._api_socket_for_calls()
         if self._event_websocket is websocket:
             self._event_websocket = None
         if self._api_websocket is websocket:
@@ -625,10 +636,13 @@ class JsonWebSocketServerMiddleware(JsonWebSocketClientMiddleware):
         self._websocket = self._api_websocket or self._event_websocket
         if self._api_socket_for_calls() is None:
             self._connection_ready.clear()
-        await self._fail_pending(ConnectionError(f"{self.name} connection closed"))
+        if was_api_socket:
+            await self._fail_pending(ConnectionError(f"{self.name} connection closed"))
 
     def _api_socket_for_calls(self) -> Any | None:
-        return self._api_websocket or self._websocket or self._event_websocket
+        if self.path_event == self.path_api:
+            return self._api_websocket or self._websocket
+        return self._api_websocket
 
     def _resolve_ws_role(self, path: str) -> str | None:
         if self.path_event == self.path_api and path == self.path_event:

--- a/python/iamai/adapters/middleware.py
+++ b/python/iamai/adapters/middleware.py
@@ -369,10 +369,14 @@ class JsonWebSocketClientMiddleware(AdapterMiddleware):
                 await self._unbind_connection()
             if self._closed.is_set():
                 return
+            reconnect_delay = max(self.reconnect_interval, 0.0)
+            if reconnect_delay == 0:
+                await asyncio.sleep(0)
+                continue
             try:
                 await asyncio.wait_for(
                     self._closed.wait(),
-                    timeout=max(self.reconnect_interval, 0.0),
+                    timeout=reconnect_delay,
                 )
             except TimeoutError:
                 continue

--- a/tests/test_adapter_middleware.py
+++ b/tests/test_adapter_middleware.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+import pytest
+import websockets
 
 from iamai import Event, Message, Runtime
 from iamai.adapters.middleware import (
     EventFieldMap,
+    InboundEnvelope,
     JsonHttpWebhookMiddleware,
     JsonWebSocketClientMiddleware,
+    JsonWebSocketServerMiddleware,
     OutboundAction,
 )
 from iamai.adapters.onebot11 import OneBot11Adapter
@@ -27,6 +33,16 @@ def _make_runtime(tmp_path: Path) -> Runtime:
         },
         base_path=tmp_path,
     )
+
+
+async def _wait_until(predicate: Callable[[], bool], *, timeout: float = 2.0) -> None:
+    async with asyncio.timeout(timeout):
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+
+def _server_port(server: Any) -> int:
+    return int(server.sockets[0].getsockname()[1])
 
 
 def test_event_field_map_builds_default_event_and_coerces_ids() -> None:
@@ -170,6 +186,32 @@ class MinimalWsAdapter(JsonWebSocketClientMiddleware):
         return OutboundAction(kind="message", action="send", params={"message": message.segments})
 
 
+class MinimalReverseWsAdapter(JsonWebSocketServerMiddleware):
+    name = "minimal_reverse_ws"
+    field_map = EventFieldMap(message="message")
+
+    def __init__(self, runtime: Runtime, config: dict[str, Any] | None = None) -> None:
+        super().__init__(runtime, config)
+        self.envelopes: list[InboundEnvelope] = []
+
+    def normalize_payload(
+        self,
+        payload: Any,
+        envelope: InboundEnvelope,
+    ) -> Event | list[Event] | None:
+        self.envelopes.append(envelope)
+        return super().normalize_payload(payload, envelope)
+
+    def encode_message(
+        self,
+        message: Message,
+        *,
+        event: Event | None = None,
+        target: Any | None = None,
+    ) -> OutboundAction:
+        return OutboundAction(kind="message", action="send", params={"message": message.segments})
+
+
 def test_json_websocket_client_middleware_matches_pending_echo(tmp_path: Path) -> None:
     async def scenario() -> Any:
         adapter = MinimalWsAdapter(_make_runtime(tmp_path), {"api_timeout": 1})
@@ -206,6 +248,281 @@ def test_json_websocket_client_middleware_emits_inbound_json(tmp_path: Path) -> 
 
     assert emitted[0].text == "hello"
     assert emitted[0].user_id == "alice"
+
+
+def test_json_websocket_client_loopback_auth_echo_and_clean_close(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        emitted: list[Event] = []
+        authorization_headers: list[str | None] = []
+        blocked_request_received = asyncio.Event()
+
+        async def dispatch(event: Event, adapter: Any) -> None:
+            emitted.append(event)
+
+        async def handler(websocket: Any) -> None:
+            authorization_headers.append(websocket.request.headers.get("Authorization"))
+            await websocket.send('{"message":"from-loopback","user_id":"server"}')
+            request = json.loads(await websocket.recv())
+            await websocket.send(
+                json.dumps({"status": "ok", "echo": request["echo"], "data": request["params"]})
+            )
+            await websocket.recv()
+            blocked_request_received.set()
+            await websocket.wait_closed()
+
+        server = await websockets.serve(handler, "127.0.0.1", 0)
+        runtime = _make_runtime(tmp_path)
+        runtime.dispatch = dispatch  # type: ignore[method-assign]
+        adapter = MinimalWsAdapter(
+            runtime,
+            {
+                "url": f"ws://127.0.0.1:{_server_port(server)}/events",
+                "access_token": "loopback-secret",
+                "api_timeout": 1,
+                "reconnect_interval": 0.01,
+            },
+        )
+        adapter_task = asyncio.create_task(adapter.start())
+        try:
+            await _wait_until(adapter._connection_ready.is_set)
+            response = await adapter.call_api("ping", value=1)
+            await _wait_until(lambda: len(emitted) == 1)
+
+            assert authorization_headers == ["Bearer loopback-secret"]
+            assert emitted[0].text == "from-loopback"
+            assert response["data"] == {"value": 1}
+
+            pending = asyncio.create_task(adapter.call_api("never-replies"))
+            await asyncio.wait_for(blocked_request_received.wait(), timeout=1)
+            await adapter.close()
+            with pytest.raises(RuntimeError, match="adapter closed"):
+                await pending
+            assert adapter._pending == {}
+            assert adapter._websocket is None
+            assert not adapter._connection_ready.is_set()
+            await asyncio.wait_for(adapter_task, timeout=1)
+        finally:
+            await adapter.close()
+            if not adapter_task.done():
+                adapter_task.cancel()
+                await asyncio.gather(adapter_task, return_exceptions=True)
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
+
+
+def test_json_websocket_server_loopback_routes_event_and_api_roles(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        emitted: list[Event] = []
+
+        async def dispatch(event: Event, adapter: Any) -> None:
+            emitted.append(event)
+
+        runtime = _make_runtime(tmp_path)
+        runtime.dispatch = dispatch  # type: ignore[method-assign]
+        adapter = MinimalReverseWsAdapter(
+            runtime,
+            {
+                "host": "127.0.0.1",
+                "port": 0,
+                "path_event": "/events",
+                "path_api": "/api",
+                "access_token": "reverse-secret",
+                "api_timeout": 1,
+            },
+        )
+        adapter_task = asyncio.create_task(adapter.start())
+        try:
+            await _wait_until(lambda: adapter._ws_server is not None)
+            port = _server_port(adapter._ws_server)
+            headers = {"Authorization": "Bearer reverse-secret"}
+            async with websockets.connect(
+                f"ws://127.0.0.1:{port}/events", additional_headers=headers
+            ) as event_websocket:
+                await _wait_until(lambda: adapter._event_websocket is not None)
+                assert adapter._api_websocket is None
+                assert not adapter._connection_ready.is_set()
+
+                async with websockets.connect(
+                    f"ws://127.0.0.1:{port}/api", additional_headers=headers
+                ) as api_websocket:
+                    await _wait_until(lambda: adapter._api_websocket is not None)
+                    await _wait_until(
+                        lambda: (
+                            adapter._event_websocket is not None
+                            and adapter._api_websocket is not None
+                        )
+                    )
+                    assert adapter._event_websocket is not adapter._api_websocket
+
+                    await event_websocket.send('{"message":"reverse-event","user_id":"client"}')
+                    await _wait_until(lambda: len(emitted) == 1)
+
+                    call = asyncio.create_task(adapter.call_api("get-status", detail=True))
+                    request = json.loads(await asyncio.wait_for(api_websocket.recv(), timeout=1))
+                    await event_websocket.close()
+                    await _wait_until(lambda: adapter._event_websocket is None)
+                    assert adapter._connection_ready.is_set()
+                    await api_websocket.send(
+                        json.dumps({"status": "ok", "echo": request["echo"], "role": "api"})
+                    )
+                    response = await call
+
+                    assert emitted[0].text == "reverse-event"
+                    assert adapter.envelopes[0].transport == "ws-server"
+                    assert adapter.envelopes[0].connection_role == "event"
+                    assert request["action"] == "get-status"
+                    assert request["params"] == {"detail": True}
+                    assert response["role"] == "api"
+                    assert adapter._pending == {}
+        finally:
+            await adapter.close()
+            await asyncio.wait_for(adapter_task, timeout=1)
+            assert adapter._pending == {}
+
+    asyncio.run(scenario())
+
+
+def test_json_websocket_server_loopback_rejects_bad_path_and_token(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        adapter = MinimalReverseWsAdapter(
+            _make_runtime(tmp_path),
+            {
+                "host": "127.0.0.1",
+                "port": 0,
+                "path_event": "/events",
+                "path_api": "/api",
+                "access_token": "reverse-secret",
+            },
+        )
+        adapter_task = asyncio.create_task(adapter.start())
+        try:
+            await _wait_until(lambda: adapter._ws_server is not None)
+            port = _server_port(adapter._ws_server)
+            valid_headers = {"Authorization": "Bearer reverse-secret"}
+            invalid_headers = {"Authorization": "Bearer wrong-secret"}
+
+            async with websockets.connect(
+                f"ws://127.0.0.1:{port}/wrong", additional_headers=valid_headers
+            ) as wrong_path:
+                await wrong_path.wait_closed()
+                assert wrong_path.close_code == 4404
+
+            async with websockets.connect(
+                f"ws://127.0.0.1:{port}/events", additional_headers=invalid_headers
+            ) as wrong_token:
+                await wrong_token.wait_closed()
+                assert wrong_token.close_code == 4401
+            assert adapter._event_websocket is None
+            assert adapter._api_websocket is None
+            assert adapter._websocket is None
+            assert not adapter._connection_ready.is_set()
+            assert adapter._pending == {}
+        finally:
+            await adapter.close()
+            await asyncio.wait_for(adapter_task, timeout=1)
+
+    asyncio.run(scenario())
+
+
+def test_json_websocket_server_replaces_api_socket_and_fails_old_pending(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        adapter = MinimalReverseWsAdapter(
+            _make_runtime(tmp_path),
+            {
+                "host": "127.0.0.1",
+                "port": 0,
+                "path_event": "/events",
+                "path_api": "/api",
+                "api_timeout": 1,
+            },
+        )
+        adapter_task = asyncio.create_task(adapter.start())
+        try:
+            await _wait_until(lambda: adapter._ws_server is not None)
+            port = _server_port(adapter._ws_server)
+            async with websockets.connect(f"ws://127.0.0.1:{port}/api") as first_api:
+                await _wait_until(adapter._connection_ready.is_set)
+                old_call = asyncio.create_task(adapter.call_api("old-connection"))
+                await asyncio.wait_for(first_api.recv(), timeout=1)
+
+                async with websockets.connect(f"ws://127.0.0.1:{port}/api") as second_api:
+                    with pytest.raises(ConnectionError, match="connection replaced"):
+                        await asyncio.wait_for(old_call, timeout=0.5)
+                    assert adapter._pending == {}
+                    await _wait_until(adapter._connection_ready.is_set)
+
+                    new_call = asyncio.create_task(adapter.call_api("new-connection"))
+                    request = json.loads(await asyncio.wait_for(second_api.recv(), timeout=1))
+                    await second_api.send(
+                        json.dumps({"status": "ok", "echo": request["echo"], "generation": 2})
+                    )
+                    response = await new_call
+
+                    assert response["generation"] == 2
+                    assert adapter._pending == {}
+        finally:
+            await adapter.close()
+            await asyncio.wait_for(adapter_task, timeout=1)
+
+    asyncio.run(scenario())
+
+
+def test_json_websocket_client_reconnects_and_close_interrupts_backoff(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        connection_count = 0
+        close_second_connection = asyncio.Event()
+
+        async def handler(websocket: Any) -> None:
+            nonlocal connection_count
+            connection_count += 1
+            if connection_count == 1:
+                await websocket.close(code=1012, reason="restart")
+                return
+            request = json.loads(await websocket.recv())
+            await websocket.send(
+                json.dumps({"status": "ok", "echo": request["echo"], "attempt": connection_count})
+            )
+            await close_second_connection.wait()
+            await websocket.close(code=1012, reason="restart")
+
+        server = await websockets.serve(handler, "127.0.0.1", 0)
+        adapter = MinimalWsAdapter(
+            _make_runtime(tmp_path),
+            {
+                "url": f"ws://127.0.0.1:{_server_port(server)}/events",
+                "api_timeout": 1,
+                "reconnect_interval": 0.01,
+            },
+        )
+        adapter_task = asyncio.create_task(adapter.start())
+        try:
+            await _wait_until(lambda: connection_count == 2 and adapter._connection_ready.is_set())
+            response = await adapter.call_api("second-attempt")
+            assert response["attempt"] == 2
+            assert adapter._pending == {}
+
+            adapter.reconnect_interval = 5
+            close_second_connection.set()
+            await _wait_until(lambda: not adapter._connection_ready.is_set())
+            await asyncio.sleep(0.02)
+            await adapter.close()
+            await asyncio.wait_for(adapter_task, timeout=0.25)
+            assert connection_count == 2
+            assert adapter._pending == {}
+            assert adapter._websocket is None
+        finally:
+            await adapter.close()
+            if not adapter_task.done():
+                adapter_task.cancel()
+                await asyncio.gather(adapter_task, return_exceptions=True)
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
 
 
 def test_onebot11_send_message_keeps_group_and_private_params(tmp_path: Path) -> None:

--- a/tests/test_adapter_middleware.py
+++ b/tests/test_adapter_middleware.py
@@ -495,7 +495,7 @@ def test_json_websocket_client_reconnects_and_close_interrupts_backoff(tmp_path:
             {
                 "url": f"ws://127.0.0.1:{_server_port(server)}/events",
                 "api_timeout": 1,
-                "reconnect_interval": 0.01,
+                "reconnect_interval": 0,
             },
         )
         adapter_task = asyncio.create_task(adapter.start())


### PR DESCRIPTION
## Summary

- add real localhost WebSocket coverage for client auth, echo correlation, reverse event/API roles, rejection codes, reconnects, clean close, and API socket replacement
- keep split reverse-WebSocket event connections from becoming API-ready or failing API pending work when they disconnect
- make reconnect backoff interruptible and fail requests bound to an API socket before replacing it

## Validation

- WebSockets 15.0.1: `126 passed`
- WebSockets 16.1 isolated environment: `126 passed`
- middleware suite on both versions: `13 passed`
- `uv run ruff check .`
- `uv run python -m mypy`
- `cargo test --no-default-features`
- `bash scripts/check_example_configs.sh`
- `uv run sphinx-build -W --keep-going -b html docs docs/_build/html`

This is the regression-test prerequisite for gated dependency PR #440.