### PR TITLE
feat: define extension discovery contract

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@ Status values:
 | 1. FOSSA governance | `BLOCKED_EXTERNAL` | [PR #446](https://github.com/retrofor/iamai/pull/446); [baseline](docs/reference/fossa-governance-baseline.rst); [#436 update](https://github.com/retrofor/iamai/issues/436#issuecomment-4978607129) | Last verified 2026-07-15; no FOSSA CLI, token, or login; resume with project-admin login or API key |
 | 2. Low-risk dependencies | `DONE` | [#437](https://github.com/retrofor/iamai/pull/437), [#439](https://github.com/retrofor/iamai/pull/439), [#441](https://github.com/retrofor/iamai/pull/441), [#442](https://github.com/retrofor/iamai/pull/442), [#443](https://github.com/retrofor/iamai/pull/443); [final CI](https://github.com/retrofor/iamai/actions/runs/29404149717) | Completed 2026-07-15 at [`dev@47e4b8a`](https://github.com/retrofor/iamai/commit/47e4b8a7a671ce82826c6f4e1238ec255cff1506) |
 | 3. Gated dependencies | `DONE` | [#438](https://github.com/retrofor/iamai/pull/438), [release rehearsal](https://github.com/retrofor/iamai/actions/runs/29404691605), [#449](https://github.com/retrofor/iamai/pull/449), [#440](https://github.com/retrofor/iamai/pull/440), [final CI](https://github.com/retrofor/iamai/actions/runs/29407069117), [CodeQL](https://github.com/retrofor/iamai/actions/runs/29407068347) | Completed 2026-07-15 at [`dev@44a237a`](https://github.com/retrofor/iamai/commit/44a237a7c75fb0ca52ac87a0fed862b6186968ae) |
-| 4. Version 0.4 contract | `IN_PROGRESS` | [#435](https://github.com/retrofor/iamai/issues/435) | Started 2026-07-15; execute 0.4-A, then 0.4-B, then 0.4-C |
+| 4. Version 0.4 contract | `IN_PROGRESS` | [#435](https://github.com/retrofor/iamai/issues/435); [0.4-A PR #451](https://github.com/retrofor/iamai/pull/451) | 0.4-A implemented 2026-07-15; execute 0.4-B, then 0.4-C |
 | 5. Version 1.0 contract | `TODO` | [#434](https://github.com/retrofor/iamai/issues/434) | Start after workstream 4 |
 | 6. needs-info closure | `TODO` | Issues #294, #295, #297, #306 | Time-triggered exception: execute after 2026-07-29 23:59 UTC even if workstreams 4-5 remain active |
 
@@ -64,8 +64,8 @@ Tracking: [#436](https://github.com/retrofor/iamai/issues/436)
 
 Tracking: [#435](https://github.com/retrofor/iamai/issues/435)
 
-- [ ] 0.4-A: publish packaging/discovery metadata and deterministic error contracts.
-- [ ] 0.4-A: add installable reference adapter and plugin fixtures with isolated-install tests.
+- [x] 0.4-A: publish packaging/discovery metadata and deterministic error contracts.
+- [x] 0.4-A: add installable reference adapter and plugin fixtures with isolated-install tests.
 - [ ] 0.4-B: implement one root/runtime/adapter/plugin schema generator.
 - [ ] 0.4-B: add stable IDs, contract version, defaults, and secret annotations.
 - [ ] 0.4-B: prove CLI and management API schema equivalence.

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -36,7 +36,7 @@ Entry points
    name = "iamai-plugin-echo"
    version = "0.1.0"
    dependencies = [
-     "iamai>=0.1,<0.2",
+     "iamai>=0.3,<0.5",
    ]
 
    [project.entry-points."iamai.plugins"]
@@ -134,7 +134,8 @@ iamai 插件依赖
    auto_discover_plugins = true
 
 开启后，iamai 会加载环境中所有 ``iamai.plugins`` entry points。生产环境更建议显式列出插件；
-自动发现适合开发、示例项目和受控的私有运行环境。
+自动发现适合开发、示例项目和受控的私有运行环境。发现结果先按 entry point 名排序，
+再交给插件依赖排序器，因此相同安装环境会得到确定的加载结果。
 
 适配器包
 --------
@@ -147,7 +148,7 @@ iamai 插件依赖
    name = "iamai-adapter-acme"
    version = "0.1.0"
    dependencies = [
-     "iamai>=0.1,<0.2",
+     "iamai>=0.3,<0.5",
      "httpx>=0.27",
    ]
 
@@ -181,11 +182,37 @@ iamai 插件依赖
 命名约定
 --------
 
-- 插件包推荐命名 ``iamai-plugin-<name>``。
-- 适配器包推荐命名 ``iamai-adapter-<platform>``。
-- Entry point 名应和 ``Plugin.name`` 或 ``Adapter.name`` 保持一致。
+- 申请进入社区 registry 的插件包必须命名为 ``iamai-plugin-<name>``，适配器包必须命名为
+  ``iamai-adapter-<platform>``；私有 distribution 可以使用自己的命名规则。
+- Distribution 必须通过标准 ``Requires-Dist: iamai...`` 声明所支持的 iamai 版本范围；
+  安装器负责在运行前拒绝不兼容组合，运行时不维护第二套版本字段。
+- 插件和适配器必须分别发布到 ``iamai.plugins`` 和 ``iamai.adapters`` group。
+- Entry point 名必须和 ``Plugin.name`` 或 ``Adapter.name`` 保持一致。
 - 配置表应分别使用 ``[plugin.<name>]`` 和 ``[adapter.<name>]``。
 - 包依赖交给 Python packaging，运行时加载顺序交给 ``requires`` / ``load_after``。
+
+发现与错误契约
+--------------
+
+配置中的 ``plugins`` / ``adapters`` 是显式启用清单。启用
+``auto_discover_plugins`` / ``auto_discover_adapters`` 后，运行时才会把对应 group 中其余已安装的
+entry points 按名称排序并追加到清单。自动发现是 opt-in，不改变显式引用的顺序。
+
+``management``、``management_api``、``terminal``、``onebot11``、``telegram`` 和 ``webhook``
+是内置保留名。已安装 distribution 不得在对应 group 中发布这些名称。一个 group 内也不得由多个
+distribution 发布同名 entry point；运行时不会选择 last-wins 结果。
+
+已安装 entry point 的发现失败会抛出公开的 ``iamai.ExtensionDiscoveryError``。异常提供稳定字段
+``code``、``group``、``entry_point``、``distributions`` 和 ``reason``，其中 ``code`` 是以下之一：
+
+- ``duplicate_entry_point``：多个 distribution 发布同组同名入口。
+- ``reserved_entry_point``：入口名与内置别名冲突。
+- ``load_failed``：入口模块或属性无法加载。
+- ``invalid_object``：入口没有返回对应的 ``Plugin`` / ``Adapter`` 子类。
+- ``name_mismatch``：入口名和类的 ``name`` 不一致。
+
+错误字符串固定包含 code、group、entry point、排序后的 distribution 标识和原因，便于 CI 及运维系统
+稳定断言。显式加载只检查被请求的入口；自动发现按入口名排序后报告第一个错误。
 
 适配器兼容性规范草案
 --------------------

--- a/python/iamai/__init__.py
+++ b/python/iamai/__init__.py
@@ -54,7 +54,7 @@ from .rules import (
     when_any,
     word_in,
 )
-from .runtime import Runtime
+from .runtime import ExtensionDiscoveryError, Runtime
 from .session import SessionManager
 from .state import JsonStateStore, NullStateStore, SqliteStateStore, StateStore
 
@@ -80,6 +80,7 @@ __all__ = [
     "Context",
     "Depends",
     "Event",
+    "ExtensionDiscoveryError",
     "Message",
     "FieldCondition",
     "FieldOp",

--- a/python/iamai/runtime.py
+++ b/python/iamai/runtime.py
@@ -56,6 +56,46 @@ PLUGIN_ENTRY_POINT_GROUP = "iamai.plugins"
 ADAPTER_ENTRY_POINT_GROUP = "iamai.adapters"
 
 
+class ExtensionDiscoveryError(RuntimeError):
+    """Stable error raised when an installed extension cannot be discovered."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        group: str,
+        entry_point: str,
+        distributions: tuple[str, ...],
+        reason: str,
+    ) -> None:
+        self.code = code
+        self.group = group
+        self.entry_point = entry_point
+        self.distributions = tuple(sorted(distributions))
+        self.reason = reason
+        distribution = ",".join(self.distributions) or "unknown"
+        super().__init__(
+            "extension discovery failed: "
+            f"code={code}; group={group}; entry_point={entry_point}; "
+            f"distribution={distribution}; reason={reason}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _InstalledEntryPoint:
+    group: str
+    name: str
+    value: str
+    distribution: str
+    raw: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedExtensionRef:
+    ref: str
+    entry_point: _InstalledEntryPoint | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class PluginDescriptor:
     """Resolved plugin metadata used for ordering and runtime inspection."""
@@ -821,8 +861,15 @@ class Runtime:
         adapters: list[Adapter] = []
         adapter_map: dict[str, Adapter] = {}
         for ref in self._configured_adapter_refs():
-            adapter_ref = self._resolve_adapter_ref(str(ref))
-            adapter_cls = self._resolve_adapter_class(adapter_ref)
+            resolved = self._resolve_adapter_ref(str(ref))
+            if resolved.entry_point is None:
+                adapter_cls = self._resolve_adapter_class(resolved.ref)
+            else:
+                adapter_cls = self._load_installed_extension(
+                    resolved.entry_point,
+                    expected=Adapter,
+                    kind="Adapter",
+                )
             adapter = adapter_cls(self, self.get_adapter_config(adapter_cls.name))
             adapters.append(adapter)
             adapter_map[adapter.name] = adapter
@@ -1039,11 +1086,20 @@ class Runtime:
         is_builtin: bool,
     ) -> list[PluginDescriptor]:
         plugin_classes: list[type[Any]]
-        resolved_ref = self._resolve_plugin_ref(ref)
+        resolved = self._resolve_plugin_ref(ref)
+        resolved_ref = resolved.ref
+        if resolved.entry_point is not None:
+            plugin_classes = [
+                self._load_installed_extension(
+                    resolved.entry_point,
+                    expected=Plugin,
+                    kind="Plugin",
+                    reload_module=reload_modules,
+                )
+            ]
         # Check for a file path first: avoids splitting Windows drive letters (C:\...)
         # as if they were a "module:Class" separator.
-        path_candidate = self._resolve_path_candidate(resolved_ref)
-        if path_candidate is not None:
+        elif (path_candidate := self._resolve_path_candidate(resolved_ref)) is not None:
             module = self._load_module_from_path(path_candidate, reload_module=reload_modules)
             plugin_classes = self._plugin_classes_from_module(module)
         elif ":" in resolved_ref:
@@ -1081,33 +1137,147 @@ class Runtime:
             )
         return descriptors
 
-    def _resolve_plugin_ref(self, ref: str) -> str:
+    def _resolve_plugin_ref(self, ref: str) -> _ResolvedExtensionRef:
+        entry_point = self._select_entry_point(
+            self._plugin_entry_points_by_name(),
+            group=PLUGIN_ENTRY_POINT_GROUP,
+            name=ref,
+            reserved=BUILTIN_PLUGINS,
+        )
         if ref in BUILTIN_PLUGINS:
-            return BUILTIN_PLUGINS[ref]
-        entry_point = self._plugin_entry_points_by_name().get(ref)
+            return _ResolvedExtensionRef(BUILTIN_PLUGINS[ref])
         if entry_point is not None:
-            return str(entry_point.value)
-        return ref
+            return _ResolvedExtensionRef(entry_point.value, entry_point)
+        return _ResolvedExtensionRef(ref)
 
-    def _resolve_adapter_ref(self, ref: str) -> str:
+    def _resolve_adapter_ref(self, ref: str) -> _ResolvedExtensionRef:
+        entry_point = self._select_entry_point(
+            self._adapter_entry_points_by_name(),
+            group=ADAPTER_ENTRY_POINT_GROUP,
+            name=ref,
+            reserved=BUILTIN_ADAPTERS,
+        )
         if ref in BUILTIN_ADAPTERS:
-            return BUILTIN_ADAPTERS[ref]
-        entry_point = self._adapter_entry_points_by_name().get(ref)
+            return _ResolvedExtensionRef(BUILTIN_ADAPTERS[ref])
         if entry_point is not None:
-            return str(entry_point.value)
-        return ref
+            return _ResolvedExtensionRef(entry_point.value, entry_point)
+        return _ResolvedExtensionRef(ref)
 
     def _discover_plugin_entry_points(self) -> list[str]:
-        return sorted(self._plugin_entry_points_by_name())
+        return self._discover_entry_point_names(
+            self._plugin_entry_points_by_name(),
+            group=PLUGIN_ENTRY_POINT_GROUP,
+            reserved=BUILTIN_PLUGINS,
+        )
 
     def _discover_adapter_entry_points(self) -> list[str]:
-        return sorted(self._adapter_entry_points_by_name())
+        return self._discover_entry_point_names(
+            self._adapter_entry_points_by_name(),
+            group=ADAPTER_ENTRY_POINT_GROUP,
+            reserved=BUILTIN_ADAPTERS,
+        )
 
-    def _plugin_entry_points_by_name(self) -> dict[str, metadata.EntryPoint]:
+    def _plugin_entry_points_by_name(self) -> dict[str, tuple[_InstalledEntryPoint, ...]]:
         return _entry_points_by_name(PLUGIN_ENTRY_POINT_GROUP)
 
-    def _adapter_entry_points_by_name(self) -> dict[str, metadata.EntryPoint]:
+    def _adapter_entry_points_by_name(self) -> dict[str, tuple[_InstalledEntryPoint, ...]]:
         return _entry_points_by_name(ADAPTER_ENTRY_POINT_GROUP)
+
+    def _discover_entry_point_names(
+        self,
+        entry_points: dict[str, Any],
+        *,
+        group: str,
+        reserved: dict[str, str],
+    ) -> list[str]:
+        for name in sorted(entry_points):
+            self._select_entry_point(
+                entry_points,
+                group=group,
+                name=name,
+                reserved=reserved,
+            )
+        return sorted(entry_points)
+
+    def _select_entry_point(
+        self,
+        entry_points: dict[str, Any],
+        *,
+        group: str,
+        name: str,
+        reserved: dict[str, str],
+    ) -> _InstalledEntryPoint | None:
+        raw_candidates = entry_points.get(name)
+        if raw_candidates is None:
+            return None
+        candidates = _coerce_entry_point_candidates(raw_candidates, group=group, name=name)
+        distributions = tuple(candidate.distribution for candidate in candidates)
+        if name in reserved:
+            raise ExtensionDiscoveryError(
+                code="reserved_entry_point",
+                group=group,
+                entry_point=name,
+                distributions=distributions,
+                reason="entry point name is reserved by a built-in extension",
+            )
+        if len(candidates) != 1:
+            raise ExtensionDiscoveryError(
+                code="duplicate_entry_point",
+                group=group,
+                entry_point=name,
+                distributions=distributions,
+                reason="multiple installed distributions publish the same entry point",
+            )
+        return candidates[0]
+
+    def _load_installed_extension(
+        self,
+        entry_point: _InstalledEntryPoint,
+        *,
+        expected: type[Any],
+        kind: str,
+        reload_module: bool = False,
+    ) -> type[Any]:
+        try:
+            if reload_module:
+                module_name, attr_name = _entry_point_target(entry_point)
+                obj = self._load_module_attr(
+                    module_name,
+                    attr_name,
+                    reload_module=True,
+                )
+            elif callable(getattr(entry_point.raw, "load", None)):
+                obj = entry_point.raw.load()
+            else:
+                module_name, attr_name = _entry_point_target(entry_point)
+                obj = self._load_module_attr(module_name, attr_name, reload_module=False)
+        except Exception as exc:
+            raise ExtensionDiscoveryError(
+                code="load_failed",
+                group=entry_point.group,
+                entry_point=entry_point.name,
+                distributions=(entry_point.distribution,),
+                reason=f"entry point load raised {type(exc).__name__}: {exc}",
+            ) from exc
+        if not isinstance(obj, type) or not issubclass(obj, expected):
+            article = "an" if kind.startswith(("A", "E", "I", "O", "U")) else "a"
+            raise ExtensionDiscoveryError(
+                code="invalid_object",
+                group=entry_point.group,
+                entry_point=entry_point.name,
+                distributions=(entry_point.distribution,),
+                reason=f"loaded object is not {article} {kind} subclass",
+            )
+        extension_name = getattr(obj, "name", "") or obj.__name__.lower()
+        if extension_name != entry_point.name:
+            raise ExtensionDiscoveryError(
+                code="name_mismatch",
+                group=entry_point.group,
+                entry_point=entry_point.name,
+                distributions=(entry_point.distribution,),
+                reason=f"loaded {kind}.name is {extension_name!r}",
+            )
+        return obj
 
     def _assert_unique_plugin_names(self, descriptors: list[PluginDescriptor]) -> None:
         owners: dict[str, str] = {}
@@ -1189,7 +1359,10 @@ class Runtime:
 
     def _load_module_attr(self, module_name: str, attr_name: str, *, reload_module: bool) -> Any:
         module = self._load_import_module(module_name, reload_module=reload_module)
-        return getattr(module, attr_name)
+        obj: Any = module
+        for part in attr_name.split("."):
+            obj = getattr(obj, part)
+        return obj
 
     def _load_import_module(self, module_name: str, *, reload_module: bool) -> ModuleType:
         module = importlib.import_module(module_name)
@@ -1711,9 +1884,69 @@ def dump_config_schema(path: str | Path, plugin_name: str | None = None) -> dict
     }
 
 
-def _entry_points_by_name(group: str) -> dict[str, metadata.EntryPoint]:
+def _entry_points_by_name(group: str) -> dict[str, tuple[_InstalledEntryPoint, ...]]:
     selected = metadata.entry_points().select(group=group)
-    return {entry_point.name: entry_point for entry_point in selected}
+    grouped: dict[str, list[_InstalledEntryPoint]] = {}
+    for entry_point in selected:
+        installed = _coerce_installed_entry_point(entry_point, group=group)
+        grouped.setdefault(installed.name, []).append(installed)
+    return {
+        name: tuple(sorted(items, key=lambda item: (item.distribution, item.value)))
+        for name, items in sorted(grouped.items())
+    }
+
+
+def _coerce_entry_point_candidates(
+    raw: Any,
+    *,
+    group: str,
+    name: str,
+) -> tuple[_InstalledEntryPoint, ...]:
+    candidates = raw if isinstance(raw, (tuple, list)) else (raw,)
+    return tuple(
+        candidate
+        if isinstance(candidate, _InstalledEntryPoint)
+        else _coerce_installed_entry_point(candidate, group=group, name=name)
+        for candidate in candidates
+    )
+
+
+def _coerce_installed_entry_point(
+    entry_point: Any,
+    *,
+    group: str,
+    name: str | None = None,
+) -> _InstalledEntryPoint:
+    return _InstalledEntryPoint(
+        group=str(getattr(entry_point, "group", group)),
+        name=str(name or entry_point.name),
+        value=str(entry_point.value),
+        distribution=_entry_point_distribution(entry_point),
+        raw=entry_point,
+    )
+
+
+def _entry_point_distribution(entry_point: Any) -> str:
+    distribution = getattr(entry_point, "dist", None)
+    if distribution is None:
+        return "unknown"
+    distribution_name = distribution.metadata.get("Name") or getattr(
+        distribution, "name", "unknown"
+    )
+    version = getattr(distribution, "version", None)
+    return f"{distribution_name}=={version}" if version else str(distribution_name)
+
+
+def _entry_point_target(entry_point: _InstalledEntryPoint) -> tuple[str, str]:
+    module_name = getattr(entry_point.raw, "module", None)
+    attr_name = getattr(entry_point.raw, "attr", None)
+    if module_name and attr_name:
+        return str(module_name), str(attr_name)
+    target = entry_point.value.partition(" [")[0]
+    module_name, separator, attr_name = target.partition(":")
+    if not separator or not module_name or not attr_name:
+        raise ValueError(f"entry point value must be module:attribute, got {entry_point.value!r}")
+    return module_name, attr_name
 
 
 class _NullPlugin(Plugin):

--- a/tests/fixtures/extensions/incompatible_plugin/pyproject.toml
+++ b/tests/fixtures/extensions/incompatible_plugin/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "iamai-plugin-incompatible"
+version = "0.1.0"
+description = "Resolver rejection fixture for an unsupported iamai version."
+requires-python = ">=3.11"
+dependencies = [
+    "iamai>=99",
+]
+
+[project.entry-points."iamai.plugins"]
+incompatible_plugin = "iamai_incompatible_plugin:IncompatiblePlugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/iamai_incompatible_plugin"]

--- a/tests/fixtures/extensions/incompatible_plugin/src/iamai_incompatible_plugin/__init__.py
+++ b/tests/fixtures/extensions/incompatible_plugin/src/iamai_incompatible_plugin/__init__.py
@@ -1,0 +1,9 @@
+"""Deliberately incompatible installable plugin fixture."""
+
+from iamai import Plugin
+
+
+class IncompatiblePlugin(Plugin):
+    """Plugin whose distribution requires an unsupported iamai version."""
+
+    name = "incompatible_plugin"

--- a/tests/fixtures/extensions/reference_adapter/pyproject.toml
+++ b/tests/fixtures/extensions/reference_adapter/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "iamai-adapter-reference"
+version = "0.1.0"
+description = "Installable reference adapter used by the iamai test suite."
+requires-python = ">=3.11"
+dependencies = [
+    "iamai>=0.3,<0.5",
+]
+
+[project.entry-points."iamai.adapters"]
+reference_adapter = "iamai_reference_adapter:ReferenceAdapter"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/iamai_reference_adapter"]

--- a/tests/fixtures/extensions/reference_adapter/src/iamai_reference_adapter/__init__.py
+++ b/tests/fixtures/extensions/reference_adapter/src/iamai_reference_adapter/__init__.py
@@ -1,0 +1,23 @@
+"""Installable reference adapter fixture."""
+
+from typing import Any
+
+from iamai import Adapter, Event, Message
+
+
+class ReferenceAdapter(Adapter):
+    """Minimal adapter exported through the ``iamai.adapters`` entry-point group."""
+
+    name = "reference_adapter"
+
+    async def start(self) -> None:
+        return None
+
+    async def send_message(
+        self,
+        message: Message,
+        *,
+        event: Event | None = None,
+        target: Any | None = None,
+    ) -> Any:
+        return None

--- a/tests/fixtures/extensions/reference_plugin/pyproject.toml
+++ b/tests/fixtures/extensions/reference_plugin/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "iamai-plugin-reference"
+version = "0.1.0"
+description = "Installable reference plugin used by the iamai test suite."
+requires-python = ">=3.11"
+dependencies = [
+    "iamai>=0.3,<0.5",
+]
+
+[project.entry-points."iamai.plugins"]
+reference_plugin = "iamai_reference_plugin:ReferencePlugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/iamai_reference_plugin"]

--- a/tests/fixtures/extensions/reference_plugin/src/iamai_reference_plugin/__init__.py
+++ b/tests/fixtures/extensions/reference_plugin/src/iamai_reference_plugin/__init__.py
@@ -1,0 +1,10 @@
+"""Installable reference plugin fixture."""
+
+from iamai import Plugin
+
+
+class ReferencePlugin(Plugin):
+    """Minimal plugin exported through the ``iamai.plugins`` entry-point group."""
+
+    name = "reference_plugin"
+    description = "Installed reference plugin"

--- a/tests/test_installed_extensions.py
+++ b/tests/test_installed_extensions.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tomllib
+import zipfile
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "extensions"
+
+
+def _wheel_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "_", value)
+
+
+def _wheel_version(value: str) -> str:
+    return value.replace("-", "_")
+
+
+def _record_row(path: str, content: bytes) -> tuple[str, str, str]:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=")
+    return path, f"sha256={digest.decode('ascii')}", str(len(content))
+
+
+def _build_fixture_wheel(fixture_dir: Path, output_dir: Path) -> Path:
+    """Build a minimal pure-Python wheel without requiring another build backend in CI."""
+    pyproject = tomllib.loads((fixture_dir / "pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject["project"]
+    distribution = str(project["name"])
+    version = str(project["version"])
+    normalized_distribution = _wheel_name(distribution)
+    normalized_version = _wheel_version(version)
+    dist_info = f"{normalized_distribution}-{normalized_version}.dist-info"
+
+    files: dict[str, bytes] = {}
+    for source_path in sorted((fixture_dir / "src").rglob("*.py")):
+        archive_path = source_path.relative_to(fixture_dir / "src").as_posix()
+        files[archive_path] = source_path.read_bytes()
+
+    metadata_lines = [
+        "Metadata-Version: 2.3",
+        f"Name: {distribution}",
+        f"Version: {version}",
+        f"Summary: {project['description']}",
+        f"Requires-Python: {project['requires-python']}",
+    ]
+    metadata_lines.extend(f"Requires-Dist: {item}" for item in project.get("dependencies", []))
+    files[f"{dist_info}/METADATA"] = ("\n".join(metadata_lines) + "\n\n").encode()
+    files[f"{dist_info}/WHEEL"] = (
+        "Wheel-Version: 1.0\n"
+        "Generator: iamai-test-fixture\n"
+        "Root-Is-Purelib: true\n"
+        "Tag: py3-none-any\n"
+    ).encode()
+
+    entry_point_lines: list[str] = []
+    for group, entries in sorted(project.get("entry-points", {}).items()):
+        entry_point_lines.append(f"[{group}]")
+        entry_point_lines.extend(f"{name} = {value}" for name, value in sorted(entries.items()))
+        entry_point_lines.append("")
+    files[f"{dist_info}/entry_points.txt"] = "\n".join(entry_point_lines).encode()
+
+    record_path = f"{dist_info}/RECORD"
+    record_rows = [_record_row(path, content) for path, content in sorted(files.items())]
+    record_rows.append((record_path, "", ""))
+    record_buffer: list[str] = []
+    for row in record_rows:
+        writer_output = _csv_row(row)
+        record_buffer.append(writer_output)
+    files[record_path] = "".join(record_buffer).encode()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = output_dir / f"{normalized_distribution}-{normalized_version}-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as wheel:
+        for archive_path, content in sorted(files.items()):
+            wheel.writestr(archive_path, content)
+    return wheel_path
+
+
+def _csv_row(row: tuple[str, str, str]) -> str:
+    from io import StringIO
+
+    buffer = StringIO(newline="")
+    csv.writer(buffer, lineterminator="\n").writerow(row)
+    return buffer.getvalue()
+
+
+@pytest.fixture(scope="session")
+def extension_wheels(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    output_dir = tmp_path_factory.mktemp("extension-wheels")
+    return {
+        name: _build_fixture_wheel(FIXTURES_ROOT / name, output_dir)
+        for name in ("reference_plugin", "reference_adapter", "incompatible_plugin")
+    }
+
+
+def _uv_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.pop("VIRTUAL_ENV", None)
+    return environment
+
+
+def _run_uv(
+    tmp_path: Path,
+    *arguments: str,
+) -> subprocess.CompletedProcess[str]:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv is required to run installed-distribution contract tests")
+    return subprocess.run(
+        [uv, *arguments],
+        cwd=tmp_path,
+        env=_uv_environment(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_installed_entry_points_support_explicit_and_opt_in_auto_discovery(
+    tmp_path: Path,
+    extension_wheels: dict[str, Path],
+) -> None:
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        """
+import importlib
+import iamai
+import json
+import os
+from pathlib import Path
+import sys
+
+from iamai import Runtime
+
+
+def load(mode: str) -> dict[str, object]:
+    explicit = mode == "explicit"
+    config = {
+        "runtime": {
+            "adapters": ["reference_adapter"] if explicit else [],
+            "plugins": ["reference_plugin"] if explicit else [],
+            "builtin_plugins": False,
+            "auto_discover_plugins": not explicit,
+            "auto_discover_adapters": not explicit,
+        },
+        "adapter": {},
+        "plugin": {},
+        "state": {},
+        "__meta__": {"root_dir": str(Path.cwd())},
+    }
+    runtime = Runtime(config, base_path=Path.cwd())
+    runtime.load_plugins()
+    runtime.load_adapters()
+    plugin = runtime.plugins[0]
+    adapter = runtime.adapters[0]
+    plugin_module = importlib.import_module(plugin.__class__.__module__)
+    adapter_module = importlib.import_module(adapter.__class__.__module__)
+    return {
+        "mode": mode,
+        "plugins": [item.plugin_name for item in runtime.plugins],
+        "adapters": [item.name for item in runtime.adapters],
+        "plugin_module": str(Path(plugin_module.__file__).resolve()),
+        "adapter_module": str(Path(adapter_module.__file__).resolve()),
+    }
+
+
+assert "PYTHONPATH" not in os.environ
+print(
+    json.dumps(
+        {
+            "prefix": sys.prefix,
+            "site_packages": [
+                str(Path(item).resolve()) for item in sys.path if "site-packages" in Path(item).parts
+            ],
+            "iamai_module": str(Path(iamai.__file__).resolve()),
+            "runs": [load("explicit"), load("auto")],
+        }
+    )
+)
+""".lstrip(),
+        encoding="utf-8",
+    )
+    result = _run_uv(
+        tmp_path,
+        "run",
+        "--isolated",
+        "--no-editable",
+        "--no-default-groups",
+        "--frozen",
+        "--project",
+        str(PROJECT_ROOT),
+        "--with",
+        str(extension_wheels["reference_plugin"]),
+        "--with",
+        str(extension_wheels["reference_adapter"]),
+        "python",
+        str(probe),
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    site_packages = [Path(item) for item in payload["site_packages"]]
+    iamai_module = Path(payload["iamai_module"])
+    assert any(iamai_module.is_relative_to(path) for path in site_packages)
+    assert not iamai_module.is_relative_to(PROJECT_ROOT)
+    for run in payload["runs"]:
+        assert run["plugins"] == ["reference_plugin"]
+        assert run["adapters"] == ["reference_adapter"]
+        assert any(Path(run["plugin_module"]).is_relative_to(path) for path in site_packages)
+        assert any(Path(run["adapter_module"]).is_relative_to(path) for path in site_packages)
+        assert str(FIXTURES_ROOT) not in run["plugin_module"]
+        assert str(FIXTURES_ROOT) not in run["adapter_module"]
+
+
+def test_standard_resolver_rejects_incompatible_iamai_requirement(
+    tmp_path: Path,
+    extension_wheels: dict[str, Path],
+) -> None:
+    result = _run_uv(
+        tmp_path,
+        "run",
+        "--isolated",
+        "--no-editable",
+        "--no-default-groups",
+        "--frozen",
+        "--project",
+        str(PROJECT_ROOT),
+        "--with",
+        str(extension_wheels["incompatible_plugin"]),
+        "python",
+        "-c",
+        "raise SystemExit('resolver unexpectedly accepted incompatible extension')",
+    )
+
+    assert result.returncode != 0
+    assert "iamai-plugin-incompatible" in result.stderr
+    assert "iamai>=99" in result.stderr.replace(" ", "")

--- a/tests/test_installed_extensions.py
+++ b/tests/test_installed_extensions.py
@@ -15,6 +15,7 @@ import zipfile
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_SOURCE_ROOT = PROJECT_ROOT / "python"
 FIXTURES_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "extensions"
 
 
@@ -213,7 +214,7 @@ print(
     site_packages = [Path(item) for item in payload["site_packages"]]
     iamai_module = Path(payload["iamai_module"])
     assert any(iamai_module.is_relative_to(path) for path in site_packages)
-    assert not iamai_module.is_relative_to(PROJECT_ROOT)
+    assert not iamai_module.is_relative_to(PROJECT_SOURCE_ROOT)
     for run in payload["runs"]:
         assert run["plugins"] == ["reference_plugin"]
         assert run["adapters"] == ["reference_adapter"]

--- a/tests/test_package_discovery.py
+++ b/tests/test_package_discovery.py
@@ -1,12 +1,146 @@
 from __future__ import annotations
 
+import asyncio
+import importlib
 from pathlib import Path
 from textwrap import dedent
-from types import SimpleNamespace
 from typing import Any
 
+import iamai
 import pytest
-from iamai import Runtime
+from iamai import Adapter, Event, Message, Plugin, Runtime
+
+import iamai.runtime as runtime_module
+
+
+_UNSET = object()
+
+
+class _FakeEntryPoints(list["_FakeEntryPoint"]):
+    def select(self, **params: str) -> "_FakeEntryPoints":
+        return _FakeEntryPoints(
+            entry_point
+            for entry_point in self
+            if all(getattr(entry_point, key) == value for key, value in params.items())
+        )
+
+
+class _FakeEntryPoint:
+    def __init__(
+        self,
+        name: str,
+        value: str,
+        *,
+        group: str,
+        distribution: str,
+        version: str = "1.0.0",
+        loaded: object = _UNSET,
+        error: Exception | None = None,
+    ) -> None:
+        self.name = name
+        self.value = value
+        self.group = group
+        self.dist = type(
+            "FakeDistribution",
+            (),
+            {"metadata": {"Name": distribution}, "version": version},
+        )()
+        self._loaded = loaded
+        self._error = error
+
+    def load(self) -> object:
+        if self._error is not None:
+            raise self._error
+        if self._loaded is not _UNSET:
+            return self._loaded
+        module_name, attr_name = self.value.split(":", 1)
+        return getattr(importlib.import_module(module_name), attr_name)
+
+
+class _AlphaPlugin(Plugin):
+    name = "alpha"
+
+
+class _ZetaPlugin(Plugin):
+    name = "zeta"
+
+
+class _MismatchedPlugin(Plugin):
+    name = "actual_plugin"
+
+
+class _DuplicatePlugin(Plugin):
+    name = "duplicate"
+
+
+class _ReservedManagementPlugin(Plugin):
+    name = "management"
+
+
+class _AdapterFixture(Adapter):
+    async def start(self) -> None:
+        return None
+
+    async def send_message(
+        self,
+        message: Message,
+        *,
+        event: Event | None = None,
+        target: Any | None = None,
+    ) -> Any:
+        return None
+
+
+class _AlphaAdapter(_AdapterFixture):
+    name = "alpha_adapter"
+
+
+class _ZetaAdapter(_AdapterFixture):
+    name = "zeta_adapter"
+
+
+class _MismatchedAdapter(_AdapterFixture):
+    name = "actual_adapter"
+
+
+class _ReservedTerminalAdapter(_AdapterFixture):
+    name = "terminal"
+
+
+def _install_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+    *entry_points: _FakeEntryPoint,
+) -> None:
+    monkeypatch.setattr(
+        runtime_module.metadata,
+        "entry_points",
+        lambda: _FakeEntryPoints(entry_points),
+    )
+
+
+def _assert_discovery_error(
+    error: Exception,
+    *,
+    code: str,
+    group: str,
+    entry_point: str,
+    distributions: tuple[str, ...],
+    reason: str,
+) -> None:
+    error_type = getattr(iamai, "ExtensionDiscoveryError", None)
+    assert error_type is not None, "iamai.ExtensionDiscoveryError must be public"
+    assert isinstance(error, error_type)
+    expected_distributions = tuple(sorted(distributions))
+    assert error.code == code
+    assert error.group == group
+    assert error.entry_point == entry_point
+    assert error.distributions == expected_distributions
+    assert error.reason == reason
+    assert str(error) == (
+        f"extension discovery failed: code={code}; group={group}; "
+        f"entry_point={entry_point}; distribution={','.join(expected_distributions)}; "
+        f"reason={reason}"
+    )
 
 
 def _make_config(
@@ -54,13 +188,64 @@ def test_plugin_entry_point_name_can_be_loaded_explicitly(
     monkeypatch.setattr(
         runtime,
         "_plugin_entry_points_by_name",
-        lambda: {"packaged": SimpleNamespace(value="pkg:PackagedPlugin")},
+        lambda: {
+            "packaged": _FakeEntryPoint(
+                "packaged",
+                "pkg:PackagedPlugin",
+                group="iamai.plugins",
+                distribution="packaged-plugin",
+            )
+        },
     )
 
     runtime.load_plugins()
 
     assert runtime.plugins[0].plugin_name == "packaged"
     assert runtime.list_plugins()[0]["ref"] == "pkg:PackagedPlugin"
+
+
+def test_dotted_plugin_entry_point_survives_hot_reload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_dir = tmp_path / "nested_pkg"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text(
+        dedent("""
+            from iamai import Plugin
+
+
+            class Holder:
+                class NestedPlugin(Plugin):
+                    name = "nested"
+            """),
+        encoding="utf-8",
+    )
+    runtime = Runtime(_make_config(tmp_path, plugins=["nested"]), base_path=tmp_path)
+    runtime.config["runtime"]["python_paths"] = [str(tmp_path)]
+    runtime._apply_python_paths()
+    nested_module = importlib.import_module("nested_pkg")
+
+    monkeypatch.setattr(
+        runtime,
+        "_plugin_entry_points_by_name",
+        lambda: {
+            "nested": _FakeEntryPoint(
+                "nested",
+                "nested_pkg:Holder.NestedPlugin [feature]",
+                group="iamai.plugins",
+                distribution="nested-plugin",
+                loaded=nested_module.Holder.NestedPlugin,
+            )
+        },
+    )
+
+    runtime.load_plugins()
+    first_type = type(runtime.plugins[0])
+    asyncio.run(runtime.reload_plugins())
+
+    assert runtime.plugins[0].plugin_name == "nested"
+    assert type(runtime.plugins[0]) is not first_type
 
 
 def test_auto_discover_plugins_loads_entry_points_and_honors_dependencies(
@@ -93,8 +278,18 @@ def test_auto_discover_plugins_loads_entry_points_and_honors_dependencies(
         runtime,
         "_plugin_entry_points_by_name",
         lambda: {
-            "child": SimpleNamespace(value="plugins_pkg:ChildPlugin"),
-            "base": SimpleNamespace(value="plugins_pkg:BasePlugin"),
+            "child": _FakeEntryPoint(
+                "child",
+                "plugins_pkg:ChildPlugin",
+                group="iamai.plugins",
+                distribution="child-plugin",
+            ),
+            "base": _FakeEntryPoint(
+                "base",
+                "plugins_pkg:BasePlugin",
+                group="iamai.plugins",
+                distribution="base-plugin",
+            ),
         },
     )
 
@@ -140,7 +335,14 @@ def test_adapter_entry_point_name_can_be_loaded_explicitly(
     monkeypatch.setattr(
         runtime,
         "_adapter_entry_points_by_name",
-        lambda: {"packaged_adapter": SimpleNamespace(value="adapter_pkg:PackagedAdapter")},
+        lambda: {
+            "packaged_adapter": _FakeEntryPoint(
+                "packaged_adapter",
+                "adapter_pkg:PackagedAdapter",
+                group="iamai.adapters",
+                distribution="packaged-adapter",
+            )
+        },
     )
 
     runtime.load_adapters()
@@ -186,9 +388,312 @@ def test_auto_discover_adapters_loads_entry_points(
     monkeypatch.setattr(
         runtime,
         "_adapter_entry_points_by_name",
-        lambda: {"auto_adapter": SimpleNamespace(value="auto_adapter_pkg:AutoAdapter")},
+        lambda: {
+            "auto_adapter": _FakeEntryPoint(
+                "auto_adapter",
+                "auto_adapter_pkg:AutoAdapter",
+                group="iamai.adapters",
+                distribution="auto-adapter",
+            )
+        },
     )
 
     runtime.load_adapters()
 
     assert runtime.adapters[0].name == "auto_adapter"
+
+
+def test_duplicate_entry_points_report_every_distribution_in_sorted_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "duplicate",
+            f"{__name__}:_DuplicatePlugin",
+            group="iamai.plugins",
+            distribution="zeta-extension",
+            version="2.0.0",
+            loaded=_DuplicatePlugin,
+        ),
+        _FakeEntryPoint(
+            "duplicate",
+            f"{__name__}:_DuplicatePlugin",
+            group="iamai.plugins",
+            distribution="alpha-extension",
+            version="3.0.0",
+            loaded=_DuplicatePlugin,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path), base_path=tmp_path)
+    runtime.config["runtime"]["auto_discover_plugins"] = True
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_plugins()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="duplicate_entry_point",
+        group="iamai.plugins",
+        entry_point="duplicate",
+        distributions=("zeta-extension==2.0.0", "alpha-extension==3.0.0"),
+        reason="multiple installed distributions publish the same entry point",
+    )
+
+
+def test_plugin_entry_point_cannot_shadow_builtin_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "management",
+            f"{__name__}:_ReservedManagementPlugin",
+            group="iamai.plugins",
+            distribution="third-party-management",
+            loaded=_ReservedManagementPlugin,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path), base_path=tmp_path)
+    runtime.config["runtime"]["auto_discover_plugins"] = True
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_plugins()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="reserved_entry_point",
+        group="iamai.plugins",
+        entry_point="management",
+        distributions=("third-party-management==1.0.0",),
+        reason="entry point name is reserved by a built-in extension",
+    )
+
+
+def test_adapter_entry_point_cannot_shadow_builtin_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "terminal",
+            f"{__name__}:_ReservedTerminalAdapter",
+            group="iamai.adapters",
+            distribution="third-party-terminal",
+            loaded=_ReservedTerminalAdapter,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path), base_path=tmp_path)
+    runtime.config["runtime"]["auto_discover_adapters"] = True
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_adapters()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="reserved_entry_point",
+        group="iamai.adapters",
+        entry_point="terminal",
+        distributions=("third-party-terminal==1.0.0",),
+        reason="entry point name is reserved by a built-in extension",
+    )
+
+
+def test_plugin_entry_point_rejects_non_plugin_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "wrong_plugin",
+            "builtins:object",
+            group="iamai.plugins",
+            distribution="wrong-plugin",
+            loaded=object(),
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path, plugins=["wrong_plugin"]), base_path=tmp_path)
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_plugins()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="invalid_object",
+        group="iamai.plugins",
+        entry_point="wrong_plugin",
+        distributions=("wrong-plugin==1.0.0",),
+        reason="loaded object is not a Plugin subclass",
+    )
+
+
+def test_adapter_entry_point_rejects_non_adapter_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "wrong_adapter",
+            "builtins:object",
+            group="iamai.adapters",
+            distribution="wrong-adapter",
+            loaded=object(),
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path, adapters=["wrong_adapter"]), base_path=tmp_path)
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_adapters()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="invalid_object",
+        group="iamai.adapters",
+        entry_point="wrong_adapter",
+        distributions=("wrong-adapter==1.0.0",),
+        reason="loaded object is not an Adapter subclass",
+    )
+
+
+def test_plugin_entry_point_name_must_match_plugin_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "declared_plugin",
+            f"{__name__}:_MismatchedPlugin",
+            group="iamai.plugins",
+            distribution="mismatched-plugin",
+            loaded=_MismatchedPlugin,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path, plugins=["declared_plugin"]), base_path=tmp_path)
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_plugins()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="name_mismatch",
+        group="iamai.plugins",
+        entry_point="declared_plugin",
+        distributions=("mismatched-plugin==1.0.0",),
+        reason="loaded Plugin.name is 'actual_plugin'",
+    )
+
+
+def test_adapter_entry_point_name_must_match_adapter_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "declared_adapter",
+            f"{__name__}:_MismatchedAdapter",
+            group="iamai.adapters",
+            distribution="mismatched-adapter",
+            loaded=_MismatchedAdapter,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path, adapters=["declared_adapter"]), base_path=tmp_path)
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_adapters()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="name_mismatch",
+        group="iamai.adapters",
+        entry_point="declared_adapter",
+        distributions=("mismatched-adapter==1.0.0",),
+        reason="loaded Adapter.name is 'actual_adapter'",
+    )
+
+
+def test_entry_point_load_failure_preserves_original_cause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    load_error = ImportError("missing optional dependency")
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "broken",
+            "iamai.plugins.management:ManagementPlugin",
+            group="iamai.plugins",
+            distribution="broken-plugin",
+            loaded=_ReservedManagementPlugin,
+            error=load_error,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path, plugins=["broken"]), base_path=tmp_path)
+
+    with pytest.raises(Exception) as exc_info:
+        runtime.load_plugins()
+
+    _assert_discovery_error(
+        exc_info.value,
+        code="load_failed",
+        group="iamai.plugins",
+        entry_point="broken",
+        distributions=("broken-plugin==1.0.0",),
+        reason="entry point load raised ImportError: missing optional dependency",
+    )
+    assert exc_info.value.__cause__ is load_error
+
+
+def test_auto_discovery_order_is_deterministic_across_groups(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_entry_points(
+        monkeypatch,
+        _FakeEntryPoint(
+            "zeta_adapter",
+            f"{__name__}:_ZetaAdapter",
+            group="iamai.adapters",
+            distribution="zeta-adapter",
+            loaded=_ZetaAdapter,
+        ),
+        _FakeEntryPoint(
+            "zeta",
+            f"{__name__}:_ZetaPlugin",
+            group="iamai.plugins",
+            distribution="zeta-plugin",
+            loaded=_ZetaPlugin,
+        ),
+        _FakeEntryPoint(
+            "alpha_adapter",
+            f"{__name__}:_AlphaAdapter",
+            group="iamai.adapters",
+            distribution="alpha-adapter",
+            loaded=_AlphaAdapter,
+        ),
+        _FakeEntryPoint(
+            "alpha",
+            f"{__name__}:_AlphaPlugin",
+            group="iamai.plugins",
+            distribution="alpha-plugin",
+            loaded=_AlphaPlugin,
+        ),
+    )
+    runtime = Runtime(_make_config(tmp_path), base_path=tmp_path)
+    runtime.config["runtime"]["auto_discover_plugins"] = True
+    runtime.config["runtime"]["auto_discover_adapters"] = True
+
+    runtime.load_plugins()
+    runtime.load_adapters()
+
+    assert [plugin.plugin_name for plugin in runtime.plugins] == ["alpha", "zeta"]
+    assert [adapter.name for adapter in runtime.adapters] == [
+        "alpha_adapter",
+        "zeta_adapter",
+    ]


### PR DESCRIPTION
## Summary

- define deterministic installed entry-point discovery and public structured errors
- add installable reference plugin/adapter distributions and resolver-rejection fixture
- prove explicit and opt-in auto-discovery from isolated non-editable installs
- publish distribution naming, Requires-Dist, entry-point, and error contracts

Part of #435 (0.4-A).

## Verification

- `uv run pytest -q` (138 passed)
- `uv run ruff check .`
- `uv run python -m mypy`
- `cargo test --locked --no-default-features`
- `bash scripts/check_example_configs.sh`
- `uv run sphinx-build -W --keep-going -b html docs /tmp/iamai-docs-v04a-final`
- independent code review: APPROVE
- independent spec verification: CLEAR