### PR TITLE
docs: make ledger verification evidence stable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -102,5 +102,5 @@ Deadline: 2026-07-29 23:59 UTC.
 ## Cross-cutting verification
 
 - [x] Recheck GitHub Dependabot alerts after dependency-graph recomputation: 0 open alerts on 2026-07-16; none dismissed manually.
-- [x] Verify the latest completed merge at `dev@a2aaa6d`: required checks and CodeQL green, branch protection intact, and working tree clean.
-- [ ] Repeat the protection, release-evidence, and clean-tree check after every future merge.
+- [x] Verify the latest implementation merge preceding this ledger at `dev@a2aaa6d`: required checks and CodeQL green, branch protection intact, and working tree clean.
+- [ ] Repeat the protection, release-evidence, and clean-tree check after every future implementation merge.


### PR DESCRIPTION
## Summary

- describe `a2aaa6d` as the latest implementation merge preceding the ledger
- scope the repeatable verification obligation to future implementation merges
- avoid making the ledger sentence stale as soon as its own documentation PR merges

## Validation

- `uv run pytest tests/test_docs_content.py tests/test_release_contract.py -q` (16 passed)
- `git diff --check`