### PR TITLE
docs: refine FOSSA governance contract

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ Status values:
 | Workstream | Status | Evidence | Blocker / last verified / resume condition |
 | --- | --- | --- | --- |
 | 0. Specification baseline | `DONE` | [PR #445](https://github.com/retrofor/iamai/pull/445); [post-merge CI](https://github.com/retrofor/iamai/actions/runs/29400584855); [CodeQL](https://github.com/retrofor/iamai/actions/runs/29400584086) | Completed 2026-07-15 |
-| 1. FOSSA governance | `BLOCKED_EXTERNAL` | [PR #446](https://github.com/retrofor/iamai/pull/446); [baseline](docs/reference/fossa-governance-baseline.rst); [#436 recheck](https://github.com/retrofor/iamai/issues/436#issuecomment-4989820286) | Last verified 2026-07-16; FOSSA still targets `master` and the environment has no CLI, token, or login; resume with project-admin login or API key |
+| 1. FOSSA governance | `BLOCKED_EXTERNAL` | [PR #446](https://github.com/retrofor/iamai/pull/446); [baseline](docs/reference/fossa-governance-baseline.rst); [#436 permission/API recheck](https://github.com/retrofor/iamai/issues/436#issuecomment-4990648437) | Last verified 2026-07-16; FOSSA still targets `master`; resume with a Full credential or UI session granting project View/Edit and `SetPolicy` |
 | 2. Low-risk dependencies | `DONE` | [#437](https://github.com/retrofor/iamai/pull/437), [#439](https://github.com/retrofor/iamai/pull/439), [#441](https://github.com/retrofor/iamai/pull/441), [#442](https://github.com/retrofor/iamai/pull/442), [#443](https://github.com/retrofor/iamai/pull/443); [final CI](https://github.com/retrofor/iamai/actions/runs/29404149717) | Completed 2026-07-15 at [`dev@47e4b8a`](https://github.com/retrofor/iamai/commit/47e4b8a7a671ce82826c6f4e1238ec255cff1506) |
 | 3. Gated dependencies | `DONE` | [#438](https://github.com/retrofor/iamai/pull/438), [release rehearsal](https://github.com/retrofor/iamai/actions/runs/29404691605), [#449](https://github.com/retrofor/iamai/pull/449), [#440](https://github.com/retrofor/iamai/pull/440), [final CI](https://github.com/retrofor/iamai/actions/runs/29407069117), [CodeQL](https://github.com/retrofor/iamai/actions/runs/29407068347) | Completed 2026-07-15 at [`dev@44a237a`](https://github.com/retrofor/iamai/commit/44a237a7c75fb0ca52ac87a0fed862b6186968ae) |
 | 4. Version 0.4 contract | `DONE` | [#435](https://github.com/retrofor/iamai/issues/435); [0.4-A PR #451](https://github.com/retrofor/iamai/pull/451); [0.4-B PR #453](https://github.com/retrofor/iamai/pull/453); [0.4-C PR #454](https://github.com/retrofor/iamai/pull/454); [metadata follow-up PR #460](https://github.com/retrofor/iamai/pull/460); [post-merge CI](https://github.com/retrofor/iamai/actions/runs/29485373909); [CodeQL](https://github.com/retrofor/iamai/actions/runs/29485371056) | Completed 2026-07-16 at [`dev@a2aaa6d`](https://github.com/retrofor/iamai/commit/a2aaa6d2e25744e7a172d221ae177a8b190597f6) after resolving the actionable #454 review thread |
@@ -31,11 +31,12 @@ Status values:
 
 Tracking: [#436](https://github.com/retrofor/iamai/issues/436)
 
-- [x] Confirm whether a FOSSA project-admin login or API token is available: none is present in the current environment.
+- [x] Confirm whether a usable FOSSA Full credential or UI session is available: none is present in the current environment.
 - [ ] Repoint the FOSSA project and revision analysis from `master` to `dev`.
-- [ ] Confirm the project license is SPDX `MIT` and remove the phantom AGPL conclusion.
-- [ ] Change the project policy from `Single-Binary Distribution` to `Standard Bundle`.
-- [ ] Export the current issue inventory with dependency, version, license, policy, locator, and disposition.
+- [ ] Confirm the exact `dev` revision detects first-party SPDX `MIT` and has no unexplained AGPL matches.
+- [ ] Change the project policy from `Single-Binary Distribution` to `Standard Bundle Distribution`.
+- [ ] Export active and ignored issue inventories with dependency, version, license, policy, locator, status,
+  waiver/ignore reason, and disposition.
 - [ ] Resolve, allow, or time-bound waive every current finding.
 - [ ] Verify one `dev` revision and one PR revision; attach evidence to #436.
 - [ ] Remove or replace the v0.3.0 waiver before 2026-08-15.

--- a/docs/reference/fossa-governance-baseline.rst
+++ b/docs/reference/fossa-governance-baseline.rst
@@ -4,7 +4,7 @@ FOSSA 治理基线
 状态
 ----
 
-``BLOCKED_EXTERNAL``，最后验证时间为 2026-07-15。跟踪项为
+``BLOCKED_EXTERNAL``，最后验证时间为 2026-07-16。跟踪项为
 `GitHub issue #436 <https://github.com/retrofor/iamai/issues/436>`_。
 
 本页记录 FOSSA 变更前的可公开复现证据和凭据边界。它不是合规通过结论，也不枚举认证后才能读取的
@@ -13,45 +13,83 @@ issue 明细。
 公开 FOSSA 快照
 ---------------
 
-安全查询入口为：
+公开 project API 入口为：
 
 .. code-block:: text
 
-   https://app.fossa.com/api/projects/git%2Bgithub.com%2Fretrofor%2Fiamai?ref_type=branch
+   https://app.fossa.com/api/projects/git%2Bgithub.com%2Fretrofor%2Fiamai?ref=dev&ref_type=branch
 
-完整 project JSON 含有不应进入 issue、CI 日志或文档的 ``updateHook.secret_key``。只能保存明确白名单
-投影，不得复制原始响应。
+完整 project JSON 含有不应进入 issue、CI 日志或文档的 ``updateHook.secret_key``。不得直接输出或先保存
+原始响应；查询时必须在管道中直接构造白名单投影，例如：
 
-2026-07-15 的白名单快照：
+.. code-block:: bash
+
+   curl -fsSL 'https://app.fossa.com/api/projects/git%2Bgithub.com%2Fretrofor%2Fiamai?ref=dev&ref_type=branch' \
+       | jq '{locator, public, default_branch, tracking_branches,
+              policy: {id: .policyId, title: .policy.title, type: .policy.type},
+              last_analyzed_revision,
+              head: {locator: .head.locator, updatedAt: .head.updatedAt,
+                     integration_hook_status: .head.integration_hook_status,
+                     dependency_count: .head.dependency_count,
+                     license_count: .head.license_count,
+                     todo_count: .head.todo_count,
+                     unresolved_issue_count: .head.unresolved_issue_count},
+              dev_reference: ([.references[]
+                | select(.name == "dev")
+                | {name, type, revision_id}][0])}'
+
+2026-07-16 的白名单快照：
 
 * locator：``git+github.com/retrofor/iamai``；project 为 public。
 * default branch：``master``；tracking branches 包含 ``master``，不包含 ``dev``。
 * policy：``Single-Binary Distribution``，policy id ``98653``，type ``LICENSING``。
-* last analyzed revision：``a59126dec42ebeb6dd55df9fd7382284fb4a7af0``，时间为
-  2026-05-06 06:16:47 UTC。
-* 旧 head 显示 119 dependencies、54 licenses、9 todos、24 unresolved licensing issues。
-* ``dev`` reference 仍停在 ``935c8afe347bc1af7a8db10525a444cf183ec0de``；当前 GitHub ``dev``
-  已前进到 ``23b7cb90ba3481c2f98b1df538240f1a227f9a8f``。
+* last analyzed project revision 仍是
+  ``a59126dec42ebeb6dd55df9fd7382284fb4a7af0``，创建时间为 2026-05-06 06:16:49 UTC。
+* 旧 ``master`` head 显示 119 dependencies、54 licenses、9 todos；公开摘要在 2026-07-16
+  重新计算后显示 0 unresolved licensing issues，但它仍是旧 revision，不能证明当前 ``dev`` 合规。
+  该旧 revision 的 source-license matches 仍包含 ``AGPL-3.0-or-later``（``docs/source/credits.md``）
+  和 ``AGPL-3.0-only``（``Cargo.toml``、``DECLARED_LICENSE``、``COPYING``）；应分析当前 ``dev``
+  并核对新匹配路径，不能改写历史 revision 来制造通过状态。
+* ``dev`` reference 已前进到 ``1e34500e8357e36477536f5c76f5d9548aaae0d7``，但该 revision 的
+  ``integration_hook_status`` 为 ``NONE``，依赖、许可证和 issue 计数均为空。当前 GitHub ``dev`` 为
+  ``d2e5216b8c611c7f7e53e0027865919bd790f33f``，对应公开 revision API 返回 404。
 * licensing issue scanning 和 status check 均启用；GitHub update hook active，last error 为 null。
 
-旧 pull request status 曾显示 11 issues，但当前公开旧 head 显示 24 个 unresolved licensing issues。
-未认证前不能假定两个数字代表同一 revision 或同一组 finding。
+最新可复现的 pull request revision ``71eb09e4f9b753caf1651429b2f58723cbcf13f6`` 已完成分析，
+公开 revision 摘要显示 113 dependencies、37 licenses、8 todos、0 unresolved issues，并识别出
+first-party ``MIT``。它的 GitHub ``License Compliance`` status 成功，但 target URL 仍错误地位于
+``refs/branch/master/71eb09e...``；合并后的 ``dev`` SHA 没有 FOSSA status。
+
+状态结果也会随 revision 改变：``1c49ebd`` 的 GitHub status 报告 3 issues，后续 ``c2321ac`` 和
+``71eb09e`` 报告全部通过。未认证的 revision 摘要不能替代完整 finding 清单，也不能解释旧 status
+中的 dependency、version、license、policy、locator 和 disposition。
 
 认证边界
 --------
 
 当前终端没有 ``fossa`` CLI，``FOSSA_API_KEY``、``FOSSA_API_TOKEN``、``FOSSA_TOKEN`` 均未设置，
-常见用户配置目录中也没有 FOSSA 凭据。issues API 返回 HTTP 302 到登录页，当前 revision 页面显示
+常见用户配置目录中也没有 FOSSA 凭据。公开 project、revision、dependencies 和 licenses API 可读；
+issue、issue export 和 policy rule API 返回 HTTP 302 到登录页，revision 页面显示
 ``window.logged_in = false``。
+
+FOSSA 官方权限模型将所需能力拆分如下：
+
+* 导出完整 finding 清单需要 Full credential 或 UI session 以及项目 View 权限；
+* 修改 default/tracked branch 需要项目 Edit 权限；
+* 应用 licensing policy 还需要 ``SetPolicy``；
+* 纠正跨项目 dependency license metadata 需要 organization Admin 或 Editor。
+
+因此 project-admin 不是唯一可行角色，但 Push-Only token 不足以读取或管理这些数据。GitHub App、
+``.fossa.yml`` 和带 Push-Only token 的 GitHub Actions 也不会向执行者授予上述 FOSSA 权限。
 
 因此下列操作不能在当前凭据边界内完成：
 
 * 导出包含 issue id、dependency、version、license、policy、locator 和状态的完整 finding 清单；
 * 备份或修改 FOSSA project settings 和 policy；
 * 把 default/tracked branch 改为 ``dev``；
-* 把 source license 确认为 MIT 并把 policy 改为 ``Standard Bundle``；
+* 把 policy 改为 ``Standard Bundle Distribution``；
 * 对精确 ``dev`` SHA 发起新分析，处理或逐项豁免 findings；
-* 让精确 SHA 的 ``License Compliance`` status 成功。
+* 证明精确 ``dev`` revision 的 first-party license 为 MIT 且没有未处置的 AGPL 匹配。
 
 仓库与 GitHub 基线
 ------------------
@@ -74,15 +112,40 @@ MIT，``Cargo.toml`` 也声明 MIT。发布输入的基线 digest 为：
    uv.lock     b31f2c8cb9702ab7452c1e377ce6638ebfe36e8a99ae676b9d020f11ec79acb1
    Cargo.lock  ea8cda5d4e4aa258b2716241315948a093615faa569c27a34326159a6f951860
 
+官方权限与 API 参考
+-------------------
+
+权限和恢复步骤以 FOSSA 官方文档为准：
+
+* `API tokens <https://docs.fossa.com/docs/organization-management/api-tokens>`_；
+* `roles and permissions <https://docs.fossa.com/docs/organization-management/role-based-access-control>`_；
+* `project settings <https://docs.fossa.com/docs/project-setup/project-settings>`_；
+* `Update Project API <https://docs.fossa.com/docs/api/reference/projects/updateProject>`_；
+* `Project Issue JSON Export API
+  <https://docs.fossa.com/docs/api/reference/projects/getProjectJSONExportIssues>`_；
+* `FOSSA configuration file <https://docs.fossa.com/docs/cli/references/files/fossa-yml>`_；
+* `GitHub App <https://docs.fossa.com/docs/integrations/github-app>`_ 和
+  `GitHub Actions <https://docs.fossa.com/docs/integrations/github-actions>`_；
+* `license corrections <https://docs.fossa.com/docs/licenses/license-corrections>`_ 和
+  `license disputes <https://docs.fossa.com/docs/licenses/license-disputes>`_。
+
 恢复步骤
 --------
 
-1. 取得最小权限的 FOSSA project administrator 登录或 API key；不得把 token 写入 issue 或日志。
-2. 在变更前导出 project settings、旧 policy 和完整 issues 清单。
-3. 把 default/tracked branch 改为 ``dev``，source license 改为 MIT，policy 改为
-   ``Standard Bundle``；此时不改 GitHub branch protection。
+1. 取得带最小充分权限的 FOSSA Full credential 或 UI session：issue export 需要 View，branch 设置需要
+   Edit，policy 应用需要 ``SetPolicy``；不得把 token 写入 issue 或日志。
+2. 在变更前导出 project settings、旧 policy，并对精确 revision 分别使用 ``status=active`` 和
+   ``status=ignored`` 导出 issues；也可用 ``/api/v2/issues`` 做等价的完整分页导出。清单必须保留 issue
+   状态、policy rule、豁免或忽略理由，不能只保存默认的 active 结果。
+3. 把 default/tracked branch 改为 ``dev``，policy 改为 ``Standard Bundle Distribution``；此时不改
+   GitHub branch protection。FOSSA 没有可直接设置的 project source-license 字段。
 4. 对执行时最新 ``dev`` SHA 和一个基于该 SHA 的 pull request revision 分别发起分析，核对 BOM 与
-   ``uv.lock``、``Cargo.lock`` 和发布 artifacts。
+   ``uv.lock``、``Cargo.lock`` 和发布 artifacts，并确认 first-party license 结果包含 MIT、不包含
+   无法解释的 AGPL。只有证明匹配路径不属于发布物或 first-party source，并记录 owner、理由且保留
+   过滤前后的 match inventory 时，才能使用 scan path filter。FOSSA dependency correction/conclusion 不能
+   充当 project source-license 设置。Dependency license correction 必须限定在 FOSSA 支持的对应 scope，
+   记录审计证据，并取得所需的 organization Admin 或 Editor 权限；license dispute 按项目 issue 的访问
+   权限提交，并同样保留证据和审计记录，不能把 correction 的组织级权限要求套用到 dispute。
 5. 修复真实 finding；无法立即修复的项目必须逐项记录 owner、理由、批准日和到期日。
 6. 同时验证两个 revision 的 FOSSA 页面/API 与 GitHub commit status，再把 revision、policy 或 waiver
    决策、package license metadata 证据链接到 #436 和 release checklist。
@@ -93,7 +156,8 @@ MIT，``Cargo.toml`` 也声明 MIT。发布输入的基线 digest 为：
 --------
 
 FOSSA 的 default/tracked branch 和 last analyzed revision 必须指向同一个已记录的 ``dev`` SHA；policy 为
-``Standard Bundle``，source license 为 MIT，没有 phantom AGPL；完整 issue inventory 可追溯到该 SHA 和
-lockfile digest；未解决项为零或都有具名、限时豁免；一个 ``dev`` revision 和一个 pull request revision
+``Standard Bundle Distribution``，该 revision 的 first-party license 为 MIT，没有未处置的 AGPL 匹配；
+完整 issue inventory 可追溯到该 SHA 和 lockfile digest；未解决项为零或都有具名、限时豁免；
+一个 ``dev`` revision 和一个 pull request revision
 的 ``License Compliance`` status 都成功；#436 与 release checklist 含 revision、policy/waiver 和 package
 license metadata 证据；现有 ``v0.3.0`` waiver 已关闭或被新的具名决策替代。

--- a/docs/reference/post-v0.3-execution-spec.rst
+++ b/docs/reference/post-v0.3-execution-spec.rst
@@ -32,35 +32,44 @@ GitHub issue、pull request、CI run 和外部合规系统保存完成证据。
 目标
 ~~~~
 
-让 FOSSA 分析真实默认分支 ``dev``、读取项目 MIT 许可证，并产生可以逐项审计的
-当前 revision 结果。跟踪项为 `GitHub issue #436 <https://github.com/retrofor/iamai/issues/436>`_。
+让 FOSSA 分析真实默认分支 ``dev``、确认该精确 revision 的 first-party license 扫描结果为 MIT，
+并产生可以逐项审计的当前 revision 结果。跟踪项为
+`GitHub issue #436 <https://github.com/retrofor/iamai/issues/436>`_。
 
 必须完成
 ~~~~~~~~
 
 * FOSSA 项目 source revision 从旧 ``master`` 改为 ``dev``。
-* 项目许可证识别为 SPDX ``MIT``，不再出现无法由当前 manifest、lockfile 或源码解释的
-  phantom AGPL 结论。
-* 项目策略从旧 ``Single-Binary Distribution`` 调整为适合本项目发布形态的 ``Standard Bundle``。
-* 导出当前 revision 的全部 issue 清单，至少包含 dependency、version、license、policy、
-  locator 和处置结论。
+* 精确 ``dev`` revision 的 first-party license 结果包含 SPDX ``MIT``，不再出现无法由当前
+  manifest、lockfile、匹配路径或源码解释的 phantom AGPL 结论。FOSSA project settings 没有可直接
+  设置的 source-license 字段，不能用设置一个标签代替 revision 证据。
+* 项目策略从旧 ``Single-Binary Distribution`` 调整为适合本项目发布形态的
+  ``Standard Bundle Distribution``。
+* 分别导出当前 revision 的 active 和 ignored issue 清单，至少包含 dependency、version、license、
+  policy、locator、状态、忽略或豁免理由和处置结论。
 * 对真实问题执行升级、移除、策略允许或具名书面豁免；任何豁免必须有范围和失效日期。
+  只有证明路径不属于发布物或 first-party source，并保留过滤前后 match inventory 时，才可使用 scan
+  path filter。Dependency correction/conclusion 不能代替 project source-license 证据。
 * 在一个 ``dev`` revision 和一个 pull request revision 上取得可复现结果。
 * 在结果稳定前，``License Compliance`` 不得加入 ``dev`` 的 required checks。
 
 完成定义
 ~~~~~~~~
 
-FOSSA revision、清单和 GitHub status URL 均指向 ``dev``；所有 findings 已清零或逐项处置；
+FOSSA revision、清单和 GitHub status URL 均指向 ``dev``；当前 revision 的 first-party license
+结果为 MIT 且没有未处置的 AGPL 匹配；所有 findings 已清零或逐项处置；
 证据链接写入 `#436 <https://github.com/retrofor/iamai/issues/436>`_，现有 ``v0.3.0`` 豁免在
 2026-08-15 前关闭或被新的具名决策替代。
 
 外部阻塞
 ~~~~~~~~
 
-修改 FOSSA 项目和读取 issue 明细需要项目管理员登录或 API token。没有这些权限时，执行者必须
-记录公开可验证的 project/status 信息、凭据探测结果和恢复条件，然后将本工作流标记为
-``BLOCKED_EXTERNAL``，不能猜测 11 条 issue 的内容。
+读取完整 issue 明细需要带项目 View 权限的 FOSSA Full credential 或 UI session；修改 default/tracked
+branch 需要项目 Edit 权限；应用目标 policy 还需要 ``SetPolicy``。这些权限不一定要求 organization
+admin；跨项目 dependency license correction 可能需要 organization Admin 或 Editor。Push-Only token、
+GitHub App 和仓库内配置不能替代。没有这些权限时，执行者必须记录公开
+可验证的 project/revision/status 信息、凭据探测结果和恢复条件，然后将本工作流标记为
+``BLOCKED_EXTERNAL``，不能根据摘要计数猜测 finding 内容或处置状态。
 
 工作流 2：低风险依赖升级
 -------------------------

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -39,6 +39,26 @@ def test_extensions_reference_contains_public_extension_specs() -> None:
     assert "``Requires-Dist``" in content
 
 
+def test_fossa_governance_docs_preserve_permission_and_evidence_boundaries() -> None:
+    baseline = _read("docs/reference/fossa-governance-baseline.rst")
+    execution_spec = _read("docs/reference/post-v0.3-execution-spec.rst")
+    todo = _read("TODO.md")
+
+    assert "不得直接输出或先保存" in baseline
+    assert "| jq '{locator, public, default_branch, tracking_branches," in baseline
+    assert "``status=active``" in baseline
+    assert "``status=ignored``" in baseline
+    assert "过滤前后的 match inventory" in baseline
+    assert "不能把 correction 的组织级权限要求套用到 dispute" in baseline
+    assert "项目 View 权限" in execution_spec
+    assert "项目 Edit 权限" in execution_spec
+    assert "``SetPolicy``" in execution_spec
+    assert "Push-Only token" in execution_spec
+    assert "``Standard Bundle Distribution``" in execution_spec
+    assert "source-license 字段" in execution_spec
+    assert "active and ignored issue inventories" in todo
+
+
 def test_serialization_reference_contains_v1_contract_rules() -> None:
     content = _read("docs/reference/serialization-contract.rst")
 


### PR DESCRIPTION
## Summary

- replace the over-broad project-admin blocker with the exact FOSSA View, Edit, and SetPolicy permission boundaries
- use the official Standard Bundle Distribution policy name and define source-license acceptance against an exact analyzed revision
- refresh the public FOSSA snapshot, preserve secret-safe whitelist querying, and require active plus ignored issue exports
- constrain scan-path filters, dependency corrections, and license disputes to auditable supported scopes
- add a documentation contract test for these governance invariants

## Evidence

- public project still defaults to and tracks master
- current dev is not analyzed; the latest successful PR status still links under refs/branch/master
- complete issue exports and policy rules still require an authenticated FOSSA session
- recheck recorded in #436: https://github.com/retrofor/iamai/issues/436#issuecomment-4990648437

## Validation

- 341 pytest tests passed
- Ruff passed
- Mypy passed for 95 source files
- 6 Rust tests passed
- all example configs passed
- Sphinx build passed with -W --keep-going
- git diff --check passed
- independent FOSSA API/RBAC review: APPROVE

Refs #436