### PR TITLE
feat(harness): add controlled experiment runtime

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        iamai keeps the core focused on a safe, testable runtime. Platform integrations and model-specific capabilities normally belong in external packages.
+        iamai keeps the stable messaging core focused and testable. General-agent research changes belong in the provisional harness; platform integrations and model-specific capabilities normally belong in external packages.
 
   - type: textarea
     id: problem
@@ -23,6 +23,7 @@ body:
       label: Proposed ownership boundary
       options:
         - Core runtime or public API
+        - Provisional research harness
         - Official adapter or plugin
         - External ecosystem package
         - Documentation or example

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,26 @@ _Avoid_: Tool call, command, response
 The committed outcome of applying an Action to an Environment, including the next Observation and termination state.
 _Avoid_: Callback result, event
 
+**Tool Specification**:
+A frozen, versioned declaration for one asynchronous Tool, including its supported input schema, permission label, runtime capability claims, approval requirement, and token or cost reservation. Its metadata enables validation and audit; it does not isolate the implementation.
+_Avoid_: Runtime ToolRegistry entry, sandbox policy
+
+**Tool Call**:
+One non-final Action presented to a Controlled Tool Environment as an invocation attempt. It may be rejected before matching a Tool Specification; its Harness-visible outcome does not prove that an external effect occurred exactly once.
+_Avoid_: Plugin command, final answer
+
+**Execution Policy**:
+A versioned, static, default-deny declaration over Tool names, permission labels, and declared runtime capabilities. It is not the stable Runtime Permission, dynamic authorization, or containment.
+_Avoid_: Permission, sandbox, policy engine
+
+**Approval**:
+An Approver decision hash-bound to one Tool invocation through a fresh request nonce, Trial Action, Tool Specification, arguments, Execution Policy, Execution Budget, and reservation. It is not blanket permission or proof of safety.
+_Avoid_: Permission grant, safety check
+
+**Execution Budget**:
+Run-scoped Tool-attempt and reservation ceilings plus a per-call cooperative timeout shared by approval and Tool execution. It is not a Trial-wide deadline, an independently verified bill, or external-effect rollback.
+_Avoid_: Trial budget, billing guarantee
+
 **Trajectory**:
 The append-only, causally ordered evidence of a Trial. It records decision-relevant inputs and committed outcomes so the Trial can be audited and replayed without claiming access to hidden reasoning.
 _Avoid_: Trace, transcript, log

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,81 @@
+# iamai General-Agent Harness
+
+iamai is evolving toward a harness for auditable, replayable experiments on increasingly general agents. The harness keeps task execution, environment interaction, evidence, and evaluation independent from any one model, platform, or agent pattern.
+
+## Language
+
+**AGI North Star**:
+The research direction of building agents that transfer across explicit Task and Environment distributions, operate reliably over longer horizons, learn from evidence, and remain controllable. It is not a shipped capability, release claim, or single benchmark threshold.
+_Avoid_: AGI feature, AGI score
+
+**Runtime**:
+The stable messaging lifecycle host that loads Adapters and Plugins and dispatches Events. It is not the Harness or a Trial executor.
+_Avoid_: Harness, Agent runtime
+
+**Event**:
+The stable normalized messaging envelope dispatched by the Runtime. It is not an Observation or a Trajectory record.
+_Avoid_: Observation, Transition
+
+**SessionManager**:
+The stable messaging waiter and backlog coordinator. It is not an Experiment store, Trial, or Trajectory store.
+_Avoid_: Trial session, episode store
+
+**Harness**:
+The headless execution system that runs and records Experiments and Trials. It is independent from the stable messaging Runtime, which may host a messaging Environment.
+_Avoid_: Agent runtime, bot framework
+
+**Experiment**:
+A versioned comparison plan and its collected results over one or more Trials. Its task distribution, seeds, budgets, Agent versions, Environment versions, Evaluations, baselines, and caller-declared provenance are explicit.
+_Avoid_: Benchmark run, test batch
+
+**Trial**:
+One bounded attempt by an Agent to complete a Task in an Environment under a fixed seed, budget, and configuration.
+_Avoid_: Run, episode, session
+
+**Task**:
+The goal and initial data presented to a Trial. Evaluation criteria are declared by the selected Evaluator.
+_Avoid_: Prompt, request
+
+**Agent**:
+The decision-maker in a Trial. An Agent consumes Observations and proposes Actions; it may use a model, rules, search, memory, or human input internally.
+_Avoid_: LLM, bot, plugin
+
+**Environment**:
+The authoritative world a Trial interacts with. It produces Observations and commits the consequences of Actions.
+_Avoid_: Tool registry, adapter, runtime
+
+**Observation**:
+Information exposed by an Environment for an Agent's next decision. It may be partial, noisy, delayed, or adversarial.
+_Avoid_: Message, event, tool result
+
+**Action**:
+An Agent's proposed interaction with an Environment or its final answer for the Task.
+_Avoid_: Tool call, command, response
+
+**Transition**:
+The committed outcome of applying an Action to an Environment, including the next Observation and termination state.
+_Avoid_: Callback result, event
+
+**Trajectory**:
+The append-only, causally ordered evidence of a Trial. It records decision-relevant inputs and committed outcomes so the Trial can be audited and replayed without claiming access to hidden reasoning.
+_Avoid_: Trace, transcript, log
+
+**Trajectory Store**:
+Append-only persistence for versioned Experiment plans, Trial start markers, and immutable terminal Trajectories. It validates provenance and Replay before projecting results; it is not the messaging StateStore or SessionManager.
+_Avoid_: StateStore, SessionManager, log database
+
+**Evaluation**:
+A versioned judgment derived from a committed Trajectory under the selected Evaluator's declared criteria.
+_Avoid_: Reward, assertion, score only
+
+**Replay**:
+Reconstruction of Trial projections and Evaluation from an existing Trajectory without repeating Agent decisions or external effects.
+_Avoid_: Re-execution, retry
+
+**Re-execution**:
+A fresh Trial using the same declared specification. It produces the same result only when every participating component and dependency is deterministic.
+_Avoid_: Replay
+
+**Policy Checkpoint**:
+An immutable version of the Agent behavior selected for an Experiment, including the model, prompts, memory policy, and action policy that affect decisions.
+_Avoid_: Latest model, mutable agent state

--- a/README.md
+++ b/README.md
@@ -56,6 +56,33 @@ behavior that changes; Rust accelerates selected message and normalization paths
 > **Stable contract:** `v1.0.0` is the current 1.x compatibility line. Third-party extensions
 > should declare `iamai>=1,<2` and run the public conformance helpers before release.
 
+## General-agent research harness
+
+iamai is evolving beyond its stable messaging Runtime toward recorded, replayable experiments on
+increasingly general agents. The provisional `iamai.harness` namespace now provides the first
+headless, model-independent slice:
+
+```text
+Task → Agent → Environment → Trajectory → Evaluation
+```
+
+It runs bounded Trials, records immutable causal Trajectories, attributes failure and cancellation,
+and can replay results without repeating Agent decisions or Environment effects. The included
+`ScriptedAgent`, `LookupEnvironment`, and `ExactEvaluator` are deterministic baselines; they do not
+require a chat platform or an LLM.
+
+Versioned `Experiment` plans can group explicit baseline and candidate variants. A
+`JsonlTrajectoryStore` persists the plan, caller-declared provenance, Trial start markers, and full
+terminal Trajectories as integrity-checked JSONL, then resumes already committed Trials without
+repeating their effects. A start-only interrupted Trial is never re-executed automatically; other
+never-started Trials in the same plan may continue and the result remains explicitly incomplete.
+
+This namespace is deliberately not re-exported from top-level `iamai` and is not part of the stable
+1.x messaging contract yet. AGI is the research north star, not a shipped capability: progress must
+name the task/environment distribution, seeds, budgets, component versions, and baseline. See the
+[research harness guide](https://github.com/retrofor/iamai/blob/dev/docs/guides/research-harness.rst)
+and [roadmap](https://github.com/retrofor/iamai/blob/dev/docs/guides/roadmap.rst).
+
 ## Run a real message through it
 
 Install the stable runtime in your own project:
@@ -184,6 +211,7 @@ ambiguously, and exposes reusable adapter/plugin conformance helpers for package
 | Inspect public Python classes and functions | [API reference source](https://github.com/retrofor/iamai/tree/dev/docs/api) |
 | Publish or discover an extension | [Community store](https://github.com/retrofor/iamai/blob/dev/docs/community/store.rst) |
 | Compare iamai with platform and agent frameworks | [Ecosystem comparison](https://github.com/retrofor/iamai/blob/dev/docs/guides/ecosystem-comparison.rst) |
+| Run a recorded, replayable headless agent Trial | [Research harness guide](https://github.com/retrofor/iamai/blob/dev/docs/guides/research-harness.rst) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ iamai puts a small, explicit runtime between those two worlds:
 | **Platform edge** | Adapters normalize Terminal, OneBot, Telegram, and Webhook traffic into `Event` and `Message` objects. |
 | **Application code** | Plugins use `Context`, commands, rules, permissions, dependency injection, middleware, state, and sessions. |
 | **Runtime lifecycle** | Discovery, startup, shutdown, reload, rollback, configuration, and observability have documented behavior. |
-| **Agent execution** | Optional model calls, tools, approvals, traces, and guardrails sit behind the same permission and audit boundaries. |
+| **Agent execution** | Optional model calls, Tool metadata, approval hooks, traces, and example guardrails remain explicit and auditable. |
 
 iamai is a runtime, not an all-in-one bot dashboard. It does not require an LLM, hide the
 network boundary, or force application code into a platform-specific SDK. Python owns the
@@ -76,6 +76,18 @@ Versioned `Experiment` plans can group explicit baseline and candidate variants.
 terminal Trajectories as integrity-checked JSONL, then resumes already committed Trials without
 repeating their effects. A start-only interrupted Trial is never re-executed automatically; other
 never-started Trials in the same plan may continue and the result remains explicitly incomplete.
+
+For declared asynchronous Tools, `ControlledToolEnvironment` adds strict `ToolSpec` input
+validation, a static default-deny `ExecutionPolicy`, approvals bound to one exact request, and
+run-scoped reservation ledgers for Tool calls, tokens, and integer cost microunits. Each handled
+non-final Action records a `tool.call.outcome`; final Actions still terminate through the
+Environment without becoming Tool calls.
+
+These controls apply only to declared Harness Tool calls.
+They are not an OS, process, or network sandbox, a proof of safety, or an exactly-once guarantee.
+`tool_timeout_seconds` is a cooperative
+per-call timeout shared by approval and Tool execution, while `ToolResult` usage remains a trusted
+report from the Tool adapter rather than an independently verified provider bill.
 
 This namespace is deliberately not re-exported from top-level `iamai` and is not part of the stable
 1.x messaging contract yet. AGI is the research north star, not a shipped capability: progress must

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,7 +46,7 @@ iamai 在平台与业务之间放置一个小而明确的运行时：
 | **平台边缘** | Adapter 把 Terminal、OneBot、Telegram 和 Webhook 流量归一化为 `Event` 与 `Message`。 |
 | **业务代码** | Plugin 只使用 `Context`、命令、规则、权限、依赖注入、中间件、状态和会话。 |
 | **运行时生命周期** | 扩展发现、启动、关闭、重载、回滚、配置与可观测性都有明确合同。 |
-| **Agent 执行** | 可选的模型调用、工具、审批、trace 和 guardrail 复用同一套权限与审计边界。 |
+| **Agent 执行** | 可选的模型调用、Tool 声明、审批 hook、trace 和示例 guardrail 保持显式、可审计。 |
 
 iamai 是运行时，不是大而全的机器人控制台。它不强制使用 LLM，不隐藏网络边界，也不要求
 业务代码绑定某个平台 SDK。经常变化的行为留在 Python；选定的消息与归一化路径由 Rust 加速。
@@ -71,6 +71,15 @@ Environment 副作用的情况下 Replay。内置的 `ScriptedAgent`、`LookupEn
 把 plan、调用方声明的 provenance、Trial start marker 和完整终态 Trajectory 保存为带完整性校验的
 JSONL，并在恢复时跳过已经提交的 Trial，不重复其副作用。只有 start marker 的 interrupted Trial
 不会被自动重跑；同一 plan 中其它从未开始的 Trial 仍可继续，返回结果会明确保持 incomplete。
+
+对于声明后的异步 Tool，`ControlledToolEnvironment` 提供严格的 `ToolSpec` 输入校验、静态
+default-deny `ExecutionPolicy`、绑定单次精确请求的审批，以及按 run 计算的 Tool 调用、token 和
+整数费用微单位 reservation ledger。每个被处理的非 final Action 都会记录 `tool.call.outcome`；
+final Action 仍通过 Environment 终止，不会变成 Tool 调用。
+
+这些控制只适用于声明后的 Harness Tool 调用，不提供 OS、进程或网络沙箱，不证明调用安全，也不保证
+外部副作用 exactly-once。`tool_timeout_seconds` 是由审批和 Tool 执行共享的单次协作式 timeout；
+`ToolResult` usage 仍是 Tool adapter 提供的可信报告，不是独立核验过的 provider 账单。
 
 该 namespace 尚未从顶层 `iamai` 重新导出，也尚未进入稳定的 1.x 消息合同。AGI 是研究方向，
 不是已交付能力；任何进展结论都必须明确 Task/Environment 分布、seed、预算、组件版本和基线。

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,6 +54,29 @@ iamai 是运行时，不是大而全的机器人控制台。它不强制使用 L
 > **稳定合同：** `v1.0.0` 是当前 1.x 兼容线。第三方扩展应声明 `iamai>=1,<2`，并在发布前
 > 运行公开 conformance helpers。
 
+## 通用 Agent 研究 Harness
+
+iamai 正在稳定消息 Runtime 之外，建立面向更通用 Agent 的可记录、可回放实验执行面。provisional 的
+`iamai.harness` 已提供第一条与模型无关、无需消息平台的 headless 垂直切片：
+
+```text
+Task → Agent → Environment → Trajectory → Evaluation
+```
+
+它运行有界 Trial，记录不可变因果 Trajectory，归因失败与取消，并能在不重复 Agent 决策或
+Environment 副作用的情况下 Replay。内置的 `ScriptedAgent`、`LookupEnvironment` 与
+`ExactEvaluator` 是确定性基线，不要求聊天平台或 LLM。
+
+版本化 `Experiment` plan 可以组织显式 baseline 与 candidate variant。`JsonlTrajectoryStore`
+把 plan、调用方声明的 provenance、Trial start marker 和完整终态 Trajectory 保存为带完整性校验的
+JSONL，并在恢复时跳过已经提交的 Trial，不重复其副作用。只有 start marker 的 interrupted Trial
+不会被自动重跑；同一 plan 中其它从未开始的 Trial 仍可继续，返回结果会明确保持 incomplete。
+
+该 namespace 尚未从顶层 `iamai` 重新导出，也尚未进入稳定的 1.x 消息合同。AGI 是研究方向，
+不是已交付能力；任何进展结论都必须明确 Task/Environment 分布、seed、预算、组件版本和基线。
+详见[研究 Harness 指南](https://github.com/retrofor/iamai/blob/dev/docs/guides/research-harness.rst)与
+[路线图](https://github.com/retrofor/iamai/blob/dev/docs/guides/roadmap.rst)。
+
 ## 跑通一条真实消息链路
 
 在自己的项目中安装稳定版：
@@ -179,6 +202,7 @@ conformance helpers。
 | 查看公开 Python 类与函数 | [API 参考源码](https://github.com/retrofor/iamai/tree/dev/docs/api) |
 | 发布或发现扩展 | [社区商店](https://github.com/retrofor/iamai/blob/dev/docs/community/store.rst) |
 | 对比 iamai 与平台型、Agent 型框架 | [生态对比](https://github.com/retrofor/iamai/blob/dev/docs/guides/ecosystem-comparison.rst) |
+| 运行可记录、可回放的 headless Agent Trial | [研究 Harness 指南](https://github.com/retrofor/iamai/blob/dev/docs/guides/research-harness.rst) |
 
 ## 开发
 

--- a/docs/adr/0001-general-agent-research-harness.md
+++ b/docs/adr/0001-general-agent-research-harness.md
@@ -1,0 +1,7 @@
+---
+status: accepted
+---
+
+# Make the general-agent research harness the product north star
+
+iamai 1.0 is a stable messaging Runtime, while its model and tool helpers are provisional. We will add a headless, record-first `iamai.harness` whose core flow is `Task → Agent → Environment → Trajectory → Evaluation`; its execution model does not construct or use Runtime, Adapter, Plugin, Event, SessionManager, or any LLM provider, and the stable 1.x types retain their existing meanings and integrate only through a later messaging bridge. AGI is the research north star, not a release claim: every claim about progress or generality must identify the Task and Environment distribution, seeds, budgets, Agent and Evaluator versions, and baseline.

--- a/docs/adr/0002-controlled-tool-environment.md
+++ b/docs/adr/0002-controlled-tool-environment.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+---
+
+# Control declared Tool calls inside an Environment
+
+Controlled Tool execution belongs to a provisional Harness Environment. `ControlledToolEnvironment` treats each non-final `Action` as one Tool attempt, while a final `Action` terminates the Environment without becoming a Tool call. It does not reuse the stable messaging Runtime's `ToolRegistry` or `Permission` meanings.
+
+Each Tool combines a callable implementation with a frozen, versioned `ToolSpec`. Before invoking the callable, the Environment checks the supported schema subset without coercion, applies a static default-deny `ExecutionPolicy`, verifies declared token and integer cost reservations against a run-scoped `ExecutionBudget`, and obtains an exact-request `ApprovalDecision` when required. A fresh per-invocation request nonce prevents a cached decision from authorizing a later otherwise-identical call. One `ControlledToolEnvironment` instance belongs to one Trial. A handled non-final Action records one `tool.call.outcome` before its non-terminating `Transition`; cancellation records a cancelled outcome before the Trial cancellation records.
+
+The declaration, Policy, Budget, and Approver identity and configuration are covered by the Environment configuration hash. Implementations are not fingerprinted automatically, so callers must maintain honest Tool and Approver versions. `ToolResult` usage is trusted adapter evidence rather than an independently verified provider bill.
+
+These controls do not provide OS, process, filesystem, network, credential, or Python capability isolation. The per-call timeout is cooperative, is shared by approval and Tool execution, and cannot revoke an external effect that already occurred. A Trajectory outcome is audit evidence, not a proof of safety, rollback, or external exactly-once execution.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -15,7 +15,11 @@ Provisional research Harness
 ----------------------------
 
 ``iamai.harness`` 是独立的 provisional interface，不从顶层 ``iamai`` 重新导出，也不属于稳定的
-``1.x`` 消息合同。它当前提供 headless Trial、Replay、版本化 Experiment 和 JSONL Trajectory Store。
+``1.x`` 消息合同。它当前提供 headless Trial、Replay、版本化 Experiment、JSONL Trajectory Store，
+以及受控 Tool interface：``ToolSpec``、``Tool``、``ToolResult``、``ExecutionPolicy``、
+``ExecutionBudget``、``ApprovalRequest``、``ApprovalDecision``、``Approver``、``ToolCallStatus`` 和
+``ControlledToolEnvironment``。Harness ``ExecutionPolicy`` 不复用稳定消息 Runtime 的
+``Permission`` 或 ``ToolRegistry``，``ControlledToolEnvironment`` 也不是隔离沙箱。
 
 .. automodule:: iamai.harness
    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,3 +10,15 @@ API 参考
    :imported-members:
    :undoc-members:
    :show-inheritance:
+
+Provisional research Harness
+----------------------------
+
+``iamai.harness`` 是独立的 provisional interface，不从顶层 ``iamai`` 重新导出，也不属于稳定的
+``1.x`` 消息合同。它当前提供 headless Trial、Replay、版本化 Experiment 和 JSONL Trajectory Store。
+
+.. automodule:: iamai.harness
+   :members:
+   :imported-members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -3,6 +3,15 @@
 
 这一页先解释 iamai 的词汇。理解这些概念后，再读教程和 API 会更顺。
 
+两套执行面
+----------
+
+``1.x`` 的 ``Runtime``、``Event`` 与 ``SessionManager`` 属于稳定消息执行面。provisional 的
+``iamai.harness`` 使用 Task、Agent、Environment、Trajectory 与 Evaluation 运行 headless Trial，
+并由 Experiment 与 Trajectory Store 保存可比较的计划和证据。两套词汇不会互相改名：Event 不是
+Observation，消息 StateStore 不是 Trajectory Store，SessionManager 也不是 Trial store。研究执行面见
+:doc:`guides/research-harness`。
+
 Runtime
 ---
 

--- a/docs/guides/agent-runtime.rst
+++ b/docs/guides/agent-runtime.rst
@@ -1,9 +1,10 @@
-Agent Runtime
-=============
+Agent Runtime helpers（1.0）
+==============================
 
-iamai 内置的 agent runtime 是一组轻量工具，不是完整 agent 平台。它主要服务 examples 中的
-ReAct、Planner/Executor、Supervisor 等模式，让示例能共享模型配置、工具注册、trace 和简单
-guardrail。
+这一页描述 ``1.0`` 消息示例使用的 provisional 模型与工具 helpers，不是完整 Agent 平台，
+也不是新的 ``iamai.harness``。它们主要服务 examples 中的 ReAct、Planner/Executor、Supervisor
+等模式，让 Plugin 共享模型配置、工具注册、trace 和简单 guardrail。需要运行、记录和比较 headless
+Trial 时，请改读 :doc:`research-harness`。
 
 核心对象
 --------
@@ -56,6 +57,7 @@ guardrail。
 设计边界
 --------
 
+- ``Runtime`` 始终指稳定的消息生命周期 host；不要用它指代 Harness 或 Trial executor。
 - 把业务逻辑放回插件，把 agent runtime 当作能力模块。
 - 工具保持窄权限、显式输入和可枚举描述。
 - 保留 trace，不要让模型调用成为纯黑盒。

--- a/docs/guides/ecosystem-comparison.rst
+++ b/docs/guides/ecosystem-comparison.rst
@@ -224,20 +224,27 @@ iamai 当前不需要追求“大而全平台”。下一步优先补齐最能�
 差异化定位
 ----------
 
-iamai 应该定位为：
+``iamai 1.0`` 的已发布定位是：
 
-   一个安全、可测试、可嵌入的 Python + Rust runtime/agent runtime。它不替用户隐藏工程边界，而是把协议、
-   插件、规则、状态、权限、审计和 Agent 工具调用的边界做清楚。
+   一个安全、可测试、可嵌入的 Python + Rust 消息 Runtime。它不替用户隐藏工程边界，而是把协议、
+   插件、规则、状态、权限与审计边界做清楚。
+
+post-1.0 的架构方向是 :doc:`research-harness`：在不重定义稳定消息类型的前提下，建立 headless、
+record-first 的通用 Agent 研究 Harness。消息 Runtime 以后可以通过桥接成为一种 Environment，
+但 Harness 执行模型本身不构造或使用 Adapter、Plugin、Event、SessionManager 或某个 LLM provider。
 
 这和几个方向不同：
 
 - 不是 NoneBot 的生态替代品，而是更强调配置、观测和 Rust 数据核心的小型工程 runtime。
 - 不是 Koishi/AstrBot/LangBot 那样的全功能平台，而是可以被平台、服务和私有系统嵌入的库。
-- 不是 OpenClaw/Hermes 那样“先 agent 后 runtime”的自主 agent，而是先保证消息入口、权限和审计可靠，再逐步接入
-  agent workflow。
+- 不是 OpenClaw/Hermes 那样面向单个自主 Agent 产品的封装；Harness 优先保证 Task、Environment、
+  Trajectory、Evaluation、预算和基线被显式记录、可审计、可回放、可比较。只有组件与外部依赖都
+  确定且版本一致时，同一规范的 Re-execution 才应产生相同结果。
 
 短期结论
 --------
 
-iamai 的路线应该是：安全、可测试、可嵌入的 Python + Rust runtime/agent runtime。核心保持小而稳定；
-协议边界、生态发布、安全声明和 Agent 工具权限先规范化；WebUI 后续作为独立插件或独立项目，不进入核心。
+稳定消息 Runtime 继续遵守 ``1.x`` 合同；新增研究能力进入 provisional 的 ``iamai.harness``。
+短期顺序是先完成可回放的 headless Trial，再扩展受控执行、持久化 Experiment 与消息桥接。
+AGI 只是研究北极星，能力结论必须明确 Task/Environment 分布、seed、预算、组件版本和基线；
+WebUI 仍作为独立插件或独立项目，不进入核心。具体里程碑见 :doc:`roadmap`。

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -14,8 +14,13 @@
       :doc:`architecture` · :doc:`configuration`
 
    **构建业务能力**
-      插件、状态、会话和 Agent Runtime 的实践路径。
+      插件、状态、会话和消息侧 Agent helpers 的实践路径。
       :doc:`plugins` · :doc:`state-and-sessions` · :doc:`agent-runtime`
+
+   **运行研究 Trial**
+      用 headless Harness 组合 Task、Agent、Environment、Trajectory 与 Evaluation，并把持久化 Experiment
+      保存为可校验的 JSONL。
+      :doc:`research-harness` · :doc:`roadmap`
 
    **接入与上线**
       平台适配、Webhook、运维、安全和质量门禁。
@@ -37,6 +42,7 @@
    state-and-sessions
    adapters
    agent-runtime
+   research-harness
    operations
    migration-0.3-to-1.0
    ecosystem-comparison

--- a/docs/guides/research-harness.rst
+++ b/docs/guides/research-harness.rst
@@ -64,6 +64,178 @@ Event、SessionManager 或任何 LLM provider，也不会从顶层 ``iamai`` 重
 
    asyncio.run(main())
 
+受控 Tool 执行
+--------------------
+
+``ControlledToolEnvironment`` 是第一条受控异步 Tool 垂直切片。它仍然是一个 Environment：Agent
+只提出 Action，Environment 在调用 Tool 前完成声明校验、Policy、预算 reservation 和可选审批，再把
+``tool.call.outcome`` 与非终止 Transition 交回 Agent。每个 Trial 必须使用独立的
+``ControlledToolEnvironment`` 实例。
+
+.. code-block:: python
+
+   import asyncio
+   from collections.abc import Mapping
+
+   from iamai.harness import (
+       Action,
+       ApprovalDecision,
+       ApprovalRequest,
+       ControlledToolEnvironment,
+       ExactEvaluator,
+       ExecutionBudget,
+       ExecutionPolicy,
+       ScriptedAgent,
+       Task,
+       Tool,
+       ToolResult,
+       ToolSpec,
+       Trial,
+       TrialConfig,
+   )
+
+
+   class LocalApprover:
+       name = "local-review"
+       version = "1"
+       configuration = {"queue": "fixture"}
+
+       async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+           return ApprovalDecision.approve(request, reason="fixture approval")
+
+
+   async def lookup(arguments: Mapping[str, object]) -> ToolResult:
+       key = arguments["key"]
+       if not isinstance(key, str):
+           raise TypeError("lookup key must be a string")
+       return ToolResult(
+           output={"value": key},
+           tokens=2,
+           cost_microunits=5,
+       )
+
+
+   environment = ControlledToolEnvironment(
+       tools=(
+           Tool(
+               ToolSpec(
+                   name="lookup",
+                   version="1",
+                   description="Look up one value.",
+                   input_schema={
+                       "type": "object",
+                       "properties": {"key": {"type": "string"}},
+                       "required": ["key"],
+                       "additionalProperties": False,
+                   },
+                   permission_name="knowledge.read",
+                   runtime_capabilities=("network",),
+                   requires_approval=True,
+                   reserved_tokens=4,
+                   reserved_cost_microunits=10,
+               ),
+               lookup,
+           ),
+       ),
+       policy=ExecutionPolicy(
+           version="policy-1",
+           allowed_tools=("lookup",),
+           allowed_permissions=("knowledge.read",),
+           allowed_runtime_capabilities=("network",),
+       ),
+       budget=ExecutionBudget(
+           max_tool_calls=2,
+           max_tokens=8,
+           max_cost_microunits=20,
+           tool_timeout_seconds=2,
+           currency="USD",
+           pricing_version="fixture-1",
+       ),
+       approver=LocalApprover(),
+       name="controlled-lookup",
+       version="1",
+   )
+
+
+   async def controlled_main() -> None:
+       result = await Trial(
+           task=Task(id="controlled-lookup", input={"key": "answer"}),
+           agent=ScriptedAgent(
+               [
+                   Action.invoke("lookup", {"key": "answer"}),
+                   Action.finish("done"),
+               ],
+               name="controlled-lookup-agent",
+               version="1",
+           ),
+           environment=environment,
+           evaluator=ExactEvaluator("done", version="1"),
+           config=TrialConfig(
+               trial_id="controlled-lookup-1",
+               max_actions=2,
+           ),
+       ).run()
+
+       outcome = next(
+           record
+           for record in result.trajectory.records
+           if record.kind == "tool.call.outcome"
+       )
+       assert outcome.payload["status"] == "succeeded"
+
+
+   asyncio.run(controlled_main())
+
+``Tool`` 接受任何返回 awaitable ``ToolResult`` 的 callable。``ToolSpec`` 会冻结 Tool 身份、受支持的
+输入 schema、permission label、runtime capability 声明、审批要求和每次调用的 token/费用 reservation；
+调用方必须在实现变化时更新 Tool version，因为 Harness 不会自动指纹化 Python callable。
+
+输入 schema 使用 ``iamai-json-schema-subset-1``，根必须为 object。当前只支持 ``type``、``enum``、
+``properties``、``required``、``additionalProperties`` 和 ``items``；校验不会做类型 coercion、应用
+default 或解析 ``$ref``。schema 只验证输入形状，不证明 Tool 安全。
+
+``ExecutionPolicy`` 是静态、版本化、default-deny 的声明。Tool name 与 ``permission_name`` 必须分别
+列在 allowlist 中，并且 Tool 声明的全部 ``runtime_capabilities`` 都必须被允许。capability 只是
+metadata，不会限制 callable 在宿主 Python 进程中实际能做什么。ToolSpec 的 ``requires_approval``，
+或 Policy 的 approval-required Tool/permission，都可以触发 ``Approver``。公开 ``Approver`` interface
+要求 ``name``、``version``、JSON ``configuration`` 和异步 ``decide(request)``；
+``ApprovalDecision`` 只包含 request hash、是否批准与 reason。request hash 绑定每次 invocation 新生成的
+request nonce、Trial、Action index、Tool spec、arguments、Policy、Budget、Approver 声明和 reservation，
+因此缓存的旧请求或其它调用的决定会 fail closed。
+
+预算与 outcome
+~~~~~~~~~~~~~~
+
+- ``max_tool_calls`` 统计所有非 final Action attempt；unknown、invalid 和 denied attempt 也会消耗一次。
+  final Action 不经过 Tool schema、Policy、Approval 或 ``ExecutionBudget``，它仍由 Environment 提交
+  terminating Transition，并计入 ``TrialConfig.max_actions``。
+- ``max_tokens`` 与 ``max_cost_microunits`` 只对 ToolSpec 预先声明的 reservation 和可信
+  ``ToolResult`` usage 维护 ledger。reservation 在 callable 前检查；成功后按实际 usage 退回差额。
+  callable 开始后发生的 timeout、取消或 failure 会保留 reservation charge；Approval 阶段尚未开始
+  callable，因此这些 Approval outcome 的 usage charge 为零。若 ToolResult（包括 deadline 触发取消请求后的
+  晚返结果）超过声明 reservation，已发生的调用记录 ``failed``、``usage_exceeded_reservation`` 和实际
+  charge，并阻止后续已声明 Tool 继续执行；它不能倒退撤销已发生的 effect。外部 Trial cancellation
+  传播优先，其 outcome 只保留 reservation charge。``currency`` 和 ``pricing_version`` 是调用方声明，
+  Harness 不核对 provider 价格或账单。
+- ``tool_timeout_seconds`` 是每次 Tool invocation 的协作式 timeout，由 Approval 与 callable 共享；
+  它不是 Trial 总时限。超时后 Harness 会请求取消 coroutine；符合 reservation 的晚返结果仍记作
+  ``timed_out``，超过 reservation 的晚返结果按上述 contract violation 处理。吞掉取消、阻塞或已经
+  发出的外部请求仍可能继续，也不会自动 rollback。
+- 每个被处理的非 final Action 写一个 ``tool.call.outcome``。``ToolCallStatus`` 为 ``succeeded``、
+  ``invalid``、``denied``、``budget_exhausted``、``timed_out``、``failed`` 或 ``cancelled``。除
+  ``cancelled`` 外，这些状态都会进入非终止 Transition 的 ``tool_call`` Observation，让 Agent 在
+  Action 预算内恢复；它们不会新增 TrialStatus。外部取消则先记录 cancelled Tool outcome，再写
+  ``trial.cancelled`` 与 ``trial.terminated``，并继续传播 ``CancelledError``。
+- 上述 ``tool.call.outcome`` 与 Trajectory 顺序保证面向由 ``Trial`` 管理的执行。若直接调用
+  Environment 的 ``reset()``/``step()``，调用方只能取得 Transition；要获得公开审计证据，应通过
+  ``Trial`` 运行。
+
+.. warning::
+
+   Controlled Tool execution 不是 OS、进程、文件系统、网络或凭据沙箱，也不提供 effect rollback。
+   ``tool.call.outcome`` 是 Harness 状态机中的审计证据，不证明外部 effect 已发生、只发生一次或已经
+   停止。若需要运行不可信代码，应在 Harness 之外使用真正的进程隔离、网络策略和凭据边界。
+
 终态语义
 --------
 
@@ -85,12 +257,15 @@ Trajectory 与 Replay
 --------------------
 
 Trajectory 是不可变、从零连续编号的因果记录。配置哈希覆盖 Harness 配置版本、Agent、Environment、
-Evaluator 的声明身份与配置以及 Action 预算；Trial ID、Task、seed 和时间戳不属于配置哈希。
+Evaluator 的声明身份与配置以及 Action 预算；ControlledToolEnvironment 的 Tool specs、Policy、Budget
+和 Approver 声明因此也会进入哈希。Trial ID、Task、seed 和时间戳不属于配置哈希。
 记录的是决策所见输入与已提交结果，不声称保存模型的隐藏推理。
 
 ``replay(trajectory)`` 是纯 Replay：它校验格式、配置哈希、序号和状态专属记录，再重建
-``TrialResult``，不会重新调用 Agent、Environment 或 Evaluator。Re-execution 则是使用同一规范开始
-一个新的 Trial；只有所有参与组件和依赖都确定时，Re-execution 才应产生相同结果。
+``TrialResult``；对 controlled Trajectory 还会校验声明 hash、Action/outcome/Transition 因果配对、
+request binding 与记录内 ledger 的一致性。它不会重新调用 Agent、Environment、Tool、Approver、
+Policy、clock 或价格系统，也不能证明原外部 effect 真实发生。Re-execution 则是使用同一规范开始一个
+新的 Trial；只有所有参与组件和依赖都确定时，Re-execution 才应产生相同结果。
 
 持久化 Experiment
 ------------------
@@ -183,9 +358,10 @@ Trajectory；status、Evaluation 与 failure 都由 :func:`~iamai.harness.replay
 
 .. warning::
 
-   Harness JSONL 可能包含 Task 输入或 prompt、Observation、Action、错误消息、组件配置和调用方
-   provenance。调用方必须在写入前清理 secret，并保护目录、备份和传输路径。POSIX 上新建 artifact
-   使用私有文件权限，但 digest 只提供完整性检查，不提供机密性或真实性。
+   Harness JSONL 可能包含 Task 输入或 prompt、Observation、Action、Tool arguments/output、usage、
+   Approval reason、错误消息、组件配置和调用方 provenance。调用方必须在写入前清理 secret，并保护
+   目录、备份和传输路径。POSIX 上新建 artifact 使用私有文件权限，但 digest 只提供完整性检查，
+   不提供机密性或真实性。
 
 Harness JSONL 使用独立的 provisional 格式版本，不读取稳定消息合同的
 ``iamai.SERIALIZATION_CONTRACT_VERSION``。这两个格式可以独立演进；Harness plan hash 还覆盖
@@ -195,9 +371,14 @@ variant 顺序、baseline、Task、seed、预算、组件声明和调用方 prov
 --------
 
 - ``ScriptedAgent``、``LookupEnvironment`` 与 ``ExactEvaluator`` 是确定性基线，不是完整 Agent 产品。
-- 一个 ``Trial`` 只能运行一次；当前预算只限制 Action 数量。
+- 一个 ``Trial`` 只能运行一次。``TrialConfig.max_actions`` 限制全部 Action；
+  ``ControlledToolEnvironment`` 另行限制非 final Tool attempt、基于 reservation 的 token/费用 ledger，
+  以及每次调用中由 Approval 与 callable 共享的协作式 timeout。它不提供 Trial 总时限。
+- 每个 Trial 必须创建独立的 ``ControlledToolEnvironment``。Tool 与 Approver 是受信任的进程内 Python；
+  Harness 记录其声明但不自动指纹化实现，也不独立核验 ToolResult usage、provider 账单或外部 effect。
+- Tool schema 是固定的 JSON 子集；远程 ``$ref``、schema default/coercion 和完整 JSON Schema 尚未加入。
 - 当前 Store 是单文件本地 JSONL；跨 Experiment 查询、artifact manifest、统计汇总、schema migration、
-  mid-Trial resume、沙箱、模型 provider、学习器和消息桥接尚未加入。
+  mid-Trial resume、远程持久审批、分布式预算、沙箱、模型 provider、学习器和消息桥接尚未加入。
 - 恢复合同面向预先存在父目录上的本地文件系统与进程中断/末行撕裂；不声明断电、NFS、共享挂载或
   多主机 writer 的持久性保证。
 - Store 恢复不等于外部 Action exactly-once；start marker 只阻止不明确的 interrupted Trial 被自动重跑。

--- a/docs/guides/research-harness.rst
+++ b/docs/guides/research-harness.rst
@@ -1,0 +1,207 @@
+通用 Agent 研究 Harness
+========================
+
+iamai 正在稳定消息 Runtime 之外建立一条 headless、record-first 的研究执行面：
+
+``Task → Agent → Environment → Trajectory → Evaluation``
+
+第一条垂直切片位于 provisional 的 ``iamai.harness``。它的执行模型不构造或使用 Adapter、Plugin、
+Event、SessionManager 或任何 LLM provider，也不会从顶层 ``iamai`` 重新导出。``1.x`` 消息 API
+的含义保持不变；AGI 是长期研究方向，不是当前版本声明。
+
+运行一个确定性 Trial
+--------------------
+
+下面的 Trial 先查询一个非聊天 Environment，再提交最终答案。最终 Action 仍然必须经过
+``Environment.step()``；只有 Environment 返回 terminating Transition，Trial 才正常完成。
+
+.. code-block:: python
+
+   import asyncio
+
+   from iamai.harness import (
+       Action,
+       ExactEvaluator,
+       LookupEnvironment,
+       ScriptedAgent,
+       Task,
+       Trial,
+       TrialConfig,
+   )
+
+
+   async def main() -> None:
+       result = await Trial(
+           task=Task(
+               id="capital-of-france",
+               input={"question": "What is the capital of France?"},
+           ),
+           agent=ScriptedAgent(
+               [
+                   Action.invoke("lookup", {"key": "france"}),
+                   Action.finish("Paris"),
+               ],
+               name="scripted-capital-agent",
+               version="1",
+           ),
+           environment=LookupEnvironment(
+               {"france": "Paris"},
+               name="country-capitals",
+               version="1",
+           ),
+           evaluator=ExactEvaluator("Paris", version="1"),
+           config=TrialConfig(
+               trial_id="trial-capital-france",
+               seed=7,
+               max_actions=2,
+           ),
+       ).run()
+
+       assert result.status.value == "completed"
+       assert result.evaluation is not None
+       assert result.evaluation.passed
+
+
+   asyncio.run(main())
+
+终态语义
+--------
+
+``completed``
+   Environment 已提交 terminating Transition，Evaluator 也已记录判断。错误答案仍是 completed，
+   但 Evaluation 可以是 ``passed=False``。
+
+``budget_exhausted``
+   Action 预算用尽但 Environment 尚未终止。Trial 仍会接受 Evaluation，因此预算失败也能进入比较数据。
+
+``failed``
+   Agent、Environment 或 Evaluator 抛出普通异常。结果包含 ``TrialFailure``，Trajectory 会记录阶段、
+   错误码、异常类型和消息，然后只写入一个终止记录。
+
+``cancelled``
+   调用方取消了正在执行的 Trial。Trajectory 记录取消阶段与终态，``CancelledError`` 继续向调用方传播。
+
+Trajectory 与 Replay
+--------------------
+
+Trajectory 是不可变、从零连续编号的因果记录。配置哈希覆盖 Harness 配置版本、Agent、Environment、
+Evaluator 的声明身份与配置以及 Action 预算；Trial ID、Task、seed 和时间戳不属于配置哈希。
+记录的是决策所见输入与已提交结果，不声称保存模型的隐藏推理。
+
+``replay(trajectory)`` 是纯 Replay：它校验格式、配置哈希、序号和状态专属记录，再重建
+``TrialResult``，不会重新调用 Agent、Environment 或 Evaluator。Re-execution 则是使用同一规范开始
+一个新的 Trial；只有所有参与组件和依赖都确定时，Re-execution 才应产生相同结果。
+
+持久化 Experiment
+------------------
+
+``Experiment`` 把一组显式命名的 variant、baseline 和调用方 provenance 冻结为不可变
+``ExperimentPlan``。``JsonlTrajectoryStore`` 使用“一文件一个 Experiment”的 JSONL：先在任何
+Trial 副作用前 fsync plan，再为每个 Trial 写入 start marker 和完整终态 Trajectory。Store 只保存
+Trajectory；status、Evaluation 与 failure 都由 :func:`~iamai.harness.replay` 重建，不维护第二份真相。
+
+.. code-block:: python
+
+   import asyncio
+
+   from iamai.harness import (
+       Action,
+       ExactEvaluator,
+       Experiment,
+       JsonlTrajectoryStore,
+       LookupEnvironment,
+       ScriptedAgent,
+       Task,
+       Trial,
+       TrialConfig,
+   )
+
+
+   def candidate(trial_id: str, answer: str) -> Trial:
+       return Trial(
+           task=Task(id="capital-of-france", input={"question": "Capital?"}),
+           agent=ScriptedAgent(
+               [Action.finish(answer)],
+               name=f"{trial_id}-agent",
+               version="1",
+           ),
+           environment=LookupEnvironment(
+               {},
+               name="country-capitals",
+               version="1",
+           ),
+           evaluator=ExactEvaluator("Paris", version="1"),
+           config=TrialConfig(trial_id=trial_id, seed=7, max_actions=1),
+       )
+
+
+   async def compare() -> None:
+       store = JsonlTrajectoryStore("runs/capitals.jsonl")
+       result = await Experiment(
+           experiment_id="capitals",
+           version="1",
+           baseline="baseline",
+           provenance={"source_revision": "abc123"},
+           trials={
+               "baseline": (candidate("baseline-7", "Lyon"),),
+               "candidate": (candidate("candidate-7", "Paris"),),
+           },
+       ).run(store)
+
+       assert result.complete
+       assert not result.results["baseline"][0].evaluation.passed
+       assert result.results["candidate"][0].evaluation.passed
+       assert JsonlTrajectoryStore("runs/capitals.jsonl").load() == result
+
+
+   asyncio.run(compare())
+
+恢复与完整性语义
+~~~~~~~~~~~~~~~~
+
+- 相同 plan 再次运行时，已提交 Trial 通过 Replay 恢复，不再次调用 Agent、Environment 或 Evaluator；
+  同一文件出现不同 plan hash 时，会在新 Trial 副作用之前报冲突。
+- Store 为 full Trajectory、Trial spec 和每一行维护独立 digest/chain。digest 用于发现意外损坏，
+  不是签名或真实性证明；JSON reader 只接受 canonical JSON，并拒绝重复 key、NaN/Infinity、
+  错误版本和超限记录。
+- 非空文件必须以 LF 结束。未终止的最后一行不会被视为已提交；调用方可以显式调用
+  ``store.repair_tail()`` 截掉它。完整但损坏的中间行、坏 digest 或重排行会 fail closed。
+- Trial 执行前先持久化 start marker。载入时，只有 start、没有终态 Trajectory 的 Trial 出现在
+  ``started_trial_ids``；在没有活跃 writer 的载入 snapshot 中，它表示 interrupted Trial。
+  ``Experiment.run()`` 不会自动 Re-execution，以免重复外部 Action，但会继续执行同一 plan 中从未
+  开始的 Trial，并返回 ``complete=False`` 的结果。若终态写入失败而同一个 ``Experiment`` 对象仍
+  保有 replay-valid Trajectory，且该对象曾向同一路径持久化对应 start marker 并在终态复检组件声明，
+  再次运行只补交这次内存尝试，不重复 Agent 或 Environment 调用。artifact 被替换或回滚不在此保证内。
+- 当前实现顺序执行并强制 ``single writer``；第二个 writer 和并发尾修复会在任何新副作用前失败。
+  取消中的 Trial 会尝试先提交 cancelled Trajectory，再继续传播 ``CancelledError``；若提交本身失败，
+  取消仍是主异常，持久化错误会附在 exception note 中。
+- ``load()`` 通过 reader lock 取得一致 snapshot，并可读取不带可写 lock sidecar 的只读 artifact 副本。
+  POSIX 支持跨进程共享 reader lock；Windows CRT 路径会把跨进程 reader 串行化，busy 时 fail fast。
+- 行链可以发现可见前缀内部的修改、插入和重排，但单个 append-only 文件无法自行证明完整后缀未被
+  删除或回滚；若完整 start/commit 后缀被删除，fresh resume 可能把对应 slot 当作从未开始并再次执行。
+  它不提供真实性、抗回滚或外部 Action exactly-once；应保护 artifact 路径并保留独立备份。
+
+.. warning::
+
+   Harness JSONL 可能包含 Task 输入或 prompt、Observation、Action、错误消息、组件配置和调用方
+   provenance。调用方必须在写入前清理 secret，并保护目录、备份和传输路径。POSIX 上新建 artifact
+   使用私有文件权限，但 digest 只提供完整性检查，不提供机密性或真实性。
+
+Harness JSONL 使用独立的 provisional 格式版本，不读取稳定消息合同的
+``iamai.SERIALIZATION_CONTRACT_VERSION``。这两个格式可以独立演进；Harness plan hash 还覆盖
+variant 顺序、baseline、Task、seed、预算、组件声明和调用方 provenance。
+
+当前边界
+--------
+
+- ``ScriptedAgent``、``LookupEnvironment`` 与 ``ExactEvaluator`` 是确定性基线，不是完整 Agent 产品。
+- 一个 ``Trial`` 只能运行一次；当前预算只限制 Action 数量。
+- 当前 Store 是单文件本地 JSONL；跨 Experiment 查询、artifact manifest、统计汇总、schema migration、
+  mid-Trial resume、沙箱、模型 provider、学习器和消息桥接尚未加入。
+- 恢复合同面向预先存在父目录上的本地文件系统与进程中断/末行撕裂；不声明断电、NFS、共享挂载或
+  多主机 writer 的持久性保证。
+- Store 恢复不等于外部 Action exactly-once；start marker 只阻止不明确的 interrupted Trial 被自动重跑。
+- provisional namespace 可以在 ``1.x`` 内迭代；稳定消息 Runtime 的公共合同不随它改变。
+- 关于能力或通用性的结论必须同时报告 Task/Environment 分布、seed、预算、组件版本和基线。
+
+工程顺序见 :doc:`roadmap`；稳定消息执行面与旧有模型助手的区别见 :doc:`agent-runtime`。

--- a/docs/guides/roadmap.rst
+++ b/docs/guides/roadmap.rst
@@ -1,8 +1,8 @@
 路线图与设计决策
 ================
 
-这页把 :doc:`ecosystem-comparison` 的定位落到工程顺序。目标不是把 iamai 做成全功能平台，
-而是稳定一个安全、可测试、可嵌入的 Python + Rust runtime/agent runtime。
+这页把 :doc:`ecosystem-comparison` 的定位落到工程顺序。``1.0`` 已经稳定消息 Runtime；
+后续工作在不改变这些语义的前提下，把 iamai 演进为可复现的通用 Agent 研究 Harness。
 
 版本路线图
 ----------
@@ -15,35 +15,60 @@
    社区商店和管理命令。
 
 ``0.3``
-   |latest-stable| ``v0.3.0`` 提供 tool registry、agent permission、审计 trace、MCP gateway、管理 HTTP API
+   |shipped| ``v0.3.0`` 提供 tool registry、agent permission、审计 trace、MCP gateway、管理 HTTP API
    和多种 Agent runtime 示例；同时为 handler 并发和 Session backlog 加入可配置资源边界。
 
 ``0.4``
-   |implemented| 第三方适配器与插件的独立包发布规范、扩展 conformance tests 和配置 schema 导出已进入
-   ``dev``，并纳入 ``1.0`` 发布线，不单独承诺 ``v0.4.0`` tag。WebUI 不进入核心；如果需要 UI，
+   |integrated| 第三方适配器与插件的独立包发布规范、扩展 conformance tests 和配置 schema 导出
+   已纳入 ``1.0`` 发布线，没有单独发布 ``v0.4.0`` tag。WebUI 不进入核心；如果需要 UI，
    应作为独立插件或独立项目调用管理 API。
 
 ``1.0``
-   |release-candidate| 核心公共 API、兼容性规范和 ``0.x`` 到 ``1.x`` 迁移窗口已形成并通过 RC 验证，
-   当前仍是候选契约。
-   ``dev`` 当前为 ``1.0.0rc1``；稳定版仍需完成 `发布治理 #436
-   <https://github.com/retrofor/iamai/issues/436>`_ 和最终精确 revision 验证。
+   |shipped| ``v1.0.0`` 已发布。Runtime、Event、Context、SessionManager、Adapter、Plugin、
+   序列化格式、生命周期规则和扩展兼容性组成稳定的 ``1.x`` 合同。
 
 .. |shipped| raw:: html
 
    <span class="iamai-status-pill">shipped</span>
 
-.. |latest-stable| raw:: html
+.. |integrated| raw:: html
 
-   <span class="iamai-status-pill">latest stable</span>
+   <span class="iamai-status-pill">integrated</span>
 
 .. |implemented| raw:: html
 
    <span class="iamai-status-pill">implemented</span>
 
-.. |release-candidate| raw:: html
+能力里程碑（非版本承诺）
+------------------------
 
-   <span class="iamai-status-pill">release candidate</span>
+这些里程碑表达依赖顺序，不承诺版本号或日期。AGI 是研究方向，不是其中任意一项完成后的产品声明。
+
+语义与兼容性基线
+   保留 ``Runtime``、``Event``、``SessionManager`` 等 ``1.x`` 名称的既有含义；Harness 能力只进入
+   provisional 的 ``iamai.harness``，不从顶层 ``iamai`` 重新导出。
+
+Headless Trial
+   |implemented| 第一条 ``Task → Agent → Environment → Trajectory → Evaluation`` 垂直切片已经形成：
+   无消息平台依赖、有界 Action 预算、确定性基线组件、失败与取消归因、不可变 Trajectory 和无副作用 Replay。
+
+受控执行
+   在 Action 数量之外增加时间、token、费用和工具预算，并把审批、能力声明、隔离执行和取消传播变成
+   可验证策略。
+
+持久化 Experiment
+   |implemented| 第一条 JSONL 垂直切片已保存不可变 Experiment plan、调用方 provenance、variant/baseline
+   标签、Trial start marker 与完整终态 Trajectory；支持完整性链、显式尾修复、已提交 Trial 的幂等恢复、
+   start-only Trial 防重跑、计划冲突检测和 single-writer 纪律。聚合基线统计、artifact manifest、跨
+   Experiment 查询和 schema migration 仍属后续工作。
+
+消息桥接
+   通过独立桥接把稳定消息 Runtime 作为一种 Environment 接入；``Event`` 不改名为 Observation，
+   ``SessionManager`` 也不承担 Trial 存储职责。
+
+离线学习闭环
+   在可复现 Experiment 之上研究数据筛选、策略检查点、回归评测和离线改进。任何“更通用”的结论都必须
+   明确 Task/Environment 分布、种子、预算、版本和基线。
 
 设计决策
 --------
@@ -61,8 +86,8 @@
    审核字段和审计 trace，不承诺完整隔离沙箱。
 
 管理面先 API 后 UI
-   候选端点包括 ``/health``、``/metrics``、``/adapters``、``/plugins``、``/sessions``、``/state``、
-   ``/schema``。WebUI 可以消费这些 API，但不绑定核心 runtime。
+   已有管理命令和观测接口继续保持窄合同；新增 HTTP 管理端点必须先定义权限与生命周期语义。
+   WebUI 可以消费这些 API，但不绑定核心 Runtime。
 
 Rust 只承接纯数据热路径
    消息段转换、规则字段匹配、签名校验和事件 schema validation 可以逐步下沉到 Rust。网络生命周期、

--- a/docs/guides/roadmap.rst
+++ b/docs/guides/roadmap.rst
@@ -53,8 +53,10 @@ Headless Trial
    无消息平台依赖、有界 Action 预算、确定性基线组件、失败与取消归因、不可变 Trajectory 和无副作用 Replay。
 
 受控执行
-   在 Action 数量之外增加时间、token、费用和工具预算，并把审批、能力声明、隔离执行和取消传播变成
-   可验证策略。
+   |implemented| 第一条受控异步 Tool 垂直切片已提供冻结声明与 schema 子集、静态 default-deny Policy、
+   绑定单次请求的 Approval、Tool attempt 预算、基于 reservation 的 token/费用上限、每次调用的协作式
+   timeout，以及 ``tool.call.outcome`` 审计证据。OS/进程/网络沙箱、Trial 总时限、远程持久审批、
+   独立 usage meter、分布式预算、effect rollback 和外部 exactly-once 仍属后续工作。
 
 持久化 Experiment
    |implemented| 第一条 JSONL 垂直切片已保存不可变 Experiment plan、调用方 provenance、variant/baseline

--- a/docs/reference/serialization-contract.rst
+++ b/docs/reference/serialization-contract.rst
@@ -6,6 +6,12 @@ Event 与 Message 序列化契约
 ``iamai.SERIALIZATION_CONTRACT_VERSION`` 标识。条款中的“必须”“不得”和“仅”是规范性要求；
 每条要求使用稳定 ID，验证映射见 :doc:`public-api-conformance`。
 
+.. note::
+
+   Provisional ``iamai.harness`` 使用独立版本的 Harness JSONL 来保存 Experiment 与 Trajectory。
+   它不读取或写入 ``SERIALIZATION_CONTRACT_VERSION``，也不属于本契约；Harness artifact 格式可以
+   在 ``1.x`` 内独立迭代，而不会改变稳定 Event/Message wire format。
+
 .. _ser-version-001:
 
 SER-VERSION-001：稳定入口与版本

--- a/python/iamai/harness/__init__.py
+++ b/python/iamai/harness/__init__.py
@@ -1,0 +1,43 @@
+"""Provisional headless harness for general-agent research trials."""
+
+from ._components import ExactEvaluator, LookupEnvironment, ScriptedAgent
+from ._experiment import Experiment, ExperimentPlan, ExperimentResult
+from ._jsonl import JsonlTrajectoryStore
+from ._model import (
+    Action,
+    Evaluation,
+    Observation,
+    Task,
+    TrialConfig,
+    TrialFailure,
+    TrialResult,
+    TrialStatus,
+    Trajectory,
+    TrajectoryRecord,
+    Transition,
+)
+from ._replay import replay
+from ._trial import Trial
+
+__all__ = [
+    "Action",
+    "Evaluation",
+    "ExactEvaluator",
+    "Experiment",
+    "ExperimentPlan",
+    "ExperimentResult",
+    "JsonlTrajectoryStore",
+    "LookupEnvironment",
+    "Observation",
+    "ScriptedAgent",
+    "Task",
+    "Trial",
+    "TrialConfig",
+    "TrialFailure",
+    "TrialResult",
+    "TrialStatus",
+    "Trajectory",
+    "TrajectoryRecord",
+    "Transition",
+    "replay",
+]

--- a/python/iamai/harness/__init__.py
+++ b/python/iamai/harness/__init__.py
@@ -1,6 +1,18 @@
 """Provisional headless harness for general-agent research trials."""
 
 from ._components import ExactEvaluator, LookupEnvironment, ScriptedAgent
+from ._controlled import (
+    Approver,
+    ApprovalDecision,
+    ApprovalRequest,
+    ControlledToolEnvironment,
+    ExecutionBudget,
+    ExecutionPolicy,
+    Tool,
+    ToolCallStatus,
+    ToolResult,
+    ToolSpec,
+)
 from ._experiment import Experiment, ExperimentPlan, ExperimentResult
 from ._jsonl import JsonlTrajectoryStore
 from ._model import (
@@ -21,16 +33,26 @@ from ._trial import Trial
 
 __all__ = [
     "Action",
+    "ApprovalDecision",
+    "ApprovalRequest",
+    "Approver",
+    "ControlledToolEnvironment",
     "Evaluation",
     "ExactEvaluator",
     "Experiment",
     "ExperimentPlan",
     "ExperimentResult",
+    "ExecutionBudget",
+    "ExecutionPolicy",
     "JsonlTrajectoryStore",
     "LookupEnvironment",
     "Observation",
     "ScriptedAgent",
     "Task",
+    "Tool",
+    "ToolCallStatus",
+    "ToolResult",
+    "ToolSpec",
     "Trial",
     "TrialConfig",
     "TrialFailure",

--- a/python/iamai/harness/_components.py
+++ b/python/iamai/harness/_components.py
@@ -1,0 +1,157 @@
+"""Deterministic reference adapters for headless Trials."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ._model import (
+    Action,
+    Evaluation,
+    FrozenJsonValue,
+    JsonValue,
+    Observation,
+    Task,
+    Trajectory,
+    Transition,
+    _action_payload,
+    _freeze_json,
+    _frozen_object,
+    _thaw_json,
+)
+
+
+class ScriptedAgent:
+    """Deterministic Agent Adapter for examples, tests, and baseline Trials."""
+
+    def __init__(self, actions: Sequence[Action], *, name: str, version: str) -> None:
+        self._name = name
+        self._version = version
+        self._actions = tuple(actions)
+        self._configuration = _frozen_object(
+            actions=[_thaw_json(_action_payload(action)) for action in self._actions]
+        )
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    async def decide(
+        self,
+        task: Task,
+        observation: Observation,
+        trajectory: Trajectory,
+        *,
+        seed: int,
+        action_index: int,
+    ) -> Action:
+        """Return the next predefined Action."""
+        del task, observation, trajectory, seed
+        if action_index >= len(self._actions):
+            raise RuntimeError("scripted agent ran out of actions")
+        return self._actions[action_index]
+
+
+class LookupEnvironment:
+    """Deterministic key/value Environment Adapter for headless reference Trials."""
+
+    def __init__(
+        self,
+        values: Mapping[str, JsonValue],
+        *,
+        name: str,
+        version: str,
+    ) -> None:
+        self._name = name
+        self._version = version
+        frozen_values = _freeze_json(values, path="$.environment.values")
+        if not isinstance(frozen_values, Mapping):
+            raise AssertionError("lookup values did not produce a mapping")
+        self._values = frozen_values
+        self._configuration = _frozen_object(values=frozen_values)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    async def reset(self, task: Task, *, seed: int) -> Observation:
+        """Expose the Task input as the initial Observation."""
+        del seed
+        return Observation(task.input)
+
+    async def step(self, action: Action, *, seed: int, action_index: int) -> Transition:
+        """Commit a lookup or conventional final-answer Action."""
+        del seed, action_index
+        if action.is_final:
+            return Transition(
+                observation=Observation(action.payload),
+                terminated=True,
+                output=action.payload,
+            )
+        if action.name != "lookup" or not isinstance(action.payload, Mapping):
+            raise ValueError(f"unsupported lookup action: {action.name}")
+        key = action.payload.get("key")
+        if not isinstance(key, str) or key not in self._values:
+            raise KeyError(f"unknown lookup key: {key}")
+        return Transition(observation=Observation(self._values[key]))
+
+
+class ExactEvaluator:
+    """Evaluator Adapter that requires an exact final value."""
+
+    def __init__(self, expected: JsonValue, *, version: str) -> None:
+        self._expected = _freeze_json(expected, path="$.evaluator.expected")
+        self._version = version
+        self._configuration = _frozen_object(expected=self._expected)
+
+    @property
+    def name(self) -> str:
+        return "exact"
+
+    @property
+    def expected(self) -> FrozenJsonValue:
+        return self._expected
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    async def evaluate(
+        self,
+        task: Task,
+        trajectory: Trajectory,
+        output: FrozenJsonValue,
+    ) -> Evaluation:
+        """Return a binary exact-match Evaluation."""
+        del task
+        has_committed_output = any(
+            record.kind == "environment.transition"
+            and record.payload.get("terminated") is True
+            for record in trajectory.records
+        )
+        passed = has_committed_output and output == self._expected
+        return Evaluation(
+            passed=passed,
+            score=1.0 if passed else 0.0,
+            evaluator=self.name,
+            evaluator_version=self.version,
+        )

--- a/python/iamai/harness/_controlled.py
+++ b/python/iamai/harness/_controlled.py
@@ -1,0 +1,1571 @@
+"""Fail-closed Tool execution for the provisional Harness Environment."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import math
+import secrets
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Protocol, TypeVar, cast
+
+from ._model import (
+    Action,
+    FrozenJsonValue,
+    Observation,
+    Task,
+    Transition,
+    _configuration_hash,
+    _freeze_json,
+    _frozen_object,
+)
+
+CONTROLLED_EXECUTION_VERSION = "1"
+TOOL_SPEC_VERSION = "1"
+TOOL_SCHEMA_VERSION = "iamai-json-schema-subset-1"
+
+_SCHEMA_TYPES = {"null", "boolean", "integer", "number", "string", "array", "object"}
+_SCHEMA_KEYS = {
+    "type",
+    "enum",
+    "properties",
+    "required",
+    "additionalProperties",
+    "items",
+}
+
+_T = TypeVar("_T")
+_NO_LATE_RESULT = object()
+
+
+class _ControlledDeadlineExceeded(Exception):
+    def __init__(self, late_result: object = _NO_LATE_RESULT) -> None:
+        super().__init__("controlled execution deadline exceeded")
+        self.late_result = late_result
+
+
+def _caller_cancellation_pending() -> bool:
+    current = asyncio.current_task()
+    return current is not None and current.cancelling() > 0
+
+
+async def _await_before_deadline(
+    awaitable_factory: Callable[[], Awaitable[_T]],
+    *,
+    deadline: float,
+) -> _T:
+    loop = asyncio.get_running_loop()
+    if loop.time() >= deadline:
+        raise _ControlledDeadlineExceeded
+    awaitable = awaitable_factory()
+    if loop.time() >= deadline:
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
+        elif isinstance(awaitable, asyncio.Future):
+            awaitable.cancel()
+        raise _ControlledDeadlineExceeded
+    task = asyncio.ensure_future(awaitable)
+    try:
+        done, _ = await asyncio.wait(
+            (task,),
+            timeout=max(0.0, deadline - loop.time()),
+        )
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except BaseException:
+            pass
+        raise
+    if task in done:
+        try:
+            result = task.result()
+        except BaseException:
+            if _caller_cancellation_pending():
+                raise asyncio.CancelledError from None
+            if loop.time() >= deadline:
+                raise _ControlledDeadlineExceeded from None
+            raise
+        if _caller_cancellation_pending():
+            raise asyncio.CancelledError
+        if loop.time() >= deadline:
+            raise _ControlledDeadlineExceeded(result)
+        return result
+
+    task.cancel()
+    try:
+        late_result = await task
+    except asyncio.CancelledError:
+        if _caller_cancellation_pending():
+            task.cancel()
+            try:
+                await task
+            except BaseException:
+                pass
+            raise
+        raise _ControlledDeadlineExceeded from None
+    except BaseException:
+        if _caller_cancellation_pending():
+            raise asyncio.CancelledError from None
+        raise _ControlledDeadlineExceeded from None
+    if _caller_cancellation_pending():
+        raise asyncio.CancelledError
+    raise _ControlledDeadlineExceeded(late_result)
+
+
+def _json_text(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    frozen = _freeze_json(value, path=f"$.{field_name}")
+    if not isinstance(frozen, str):
+        raise AssertionError("JSON string did not remain a string")
+    return frozen
+
+
+def _required_text(value: object, *, field_name: str) -> str:
+    text = _json_text(value, field_name=field_name)
+    if not text.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+    return text
+
+
+def _non_negative_integer(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{field_name} cannot be negative")
+    frozen = _freeze_json(value, path=f"$.{field_name}")
+    if isinstance(frozen, bool) or not isinstance(frozen, int):
+        raise AssertionError("JSON integer did not remain an integer")
+    return frozen
+
+
+def _canonical_names(values: Sequence[str], *, field_name: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError(f"{field_name} must be an array of strings")
+    names: list[str] = []
+    for value in values:
+        names.append(_required_text(value, field_name=field_name))
+    if len(names) != len(set(names)):
+        raise ValueError(f"{field_name} cannot contain duplicates")
+    return tuple(sorted(names))
+
+
+def _validate_schema_definition(schema: object, *, path: str = "$") -> None:
+    if not isinstance(schema, Mapping):
+        raise TypeError(f"{path} schema must be an object")
+    unsupported = set(schema) - _SCHEMA_KEYS
+    if unsupported:
+        keyword = sorted(unsupported)[0]
+        raise ValueError(f"{path} schema keyword is unsupported: {keyword}")
+    schema_type = schema.get("type")
+    if not isinstance(schema_type, str) or schema_type not in _SCHEMA_TYPES:
+        raise ValueError(f"{path}.type must name one supported JSON type")
+
+    enum = schema.get("enum")
+    if enum is not None:
+        if isinstance(enum, (str, bytes)) or not isinstance(enum, Sequence) or not enum:
+            raise ValueError(f"{path}.enum must be a non-empty array")
+        _freeze_json(enum, path=f"{path}.enum")
+
+    object_keywords = {"properties", "required", "additionalProperties"}
+    if schema_type != "object" and object_keywords.intersection(schema):
+        raise ValueError(f"{path} object keywords require type=object")
+    if schema_type == "object":
+        properties = schema.get("properties", {})
+        if not isinstance(properties, Mapping):
+            raise TypeError(f"{path}.properties must be an object")
+        for name, child in properties.items():
+            _required_text(name, field_name=f"{path}.properties key")
+            _validate_schema_definition(child, path=f"{path}.properties.{name}")
+        required = schema.get("required", ())
+        if isinstance(required, (str, bytes)) or not isinstance(required, Sequence):
+            raise TypeError(f"{path}.required must be an array")
+        required_names = _canonical_names(required, field_name=f"{path}.required item")
+        unknown_required = set(required_names) - set(properties)
+        if unknown_required:
+            name = sorted(unknown_required)[0]
+            raise ValueError(f"{path}.required names an undeclared property: {name}")
+        additional = schema.get("additionalProperties", True)
+        if not isinstance(additional, bool):
+            raise TypeError(f"{path}.additionalProperties must be a bool")
+
+    if schema_type != "array" and "items" in schema:
+        raise ValueError(f"{path}.items requires type=array")
+    if schema_type == "array" and "items" in schema:
+        _validate_schema_definition(schema["items"], path=f"{path}.items")
+
+
+def _same_json_value(left: FrozenJsonValue, right: FrozenJsonValue) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return left == right
+    if isinstance(left, Mapping) or isinstance(right, Mapping):
+        if not isinstance(left, Mapping) or not isinstance(right, Mapping):
+            return False
+        return set(left) == set(right) and all(
+            _same_json_value(left[key], right[key]) for key in left
+        )
+    if isinstance(left, tuple) or isinstance(right, tuple):
+        if not isinstance(left, tuple) or not isinstance(right, tuple):
+            return False
+        return len(left) == len(right) and all(
+            _same_json_value(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    return type(left) is type(right) and left == right
+
+
+def _validate_schema_instance(
+    value: FrozenJsonValue,
+    schema: Mapping[str, FrozenJsonValue],
+    *,
+    path: str = "$",
+) -> None:
+    schema_type = schema["type"]
+    valid = (
+        schema_type == "null"
+        and value is None
+        or schema_type == "boolean"
+        and isinstance(value, bool)
+        or schema_type == "integer"
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        or schema_type == "number"
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        or schema_type == "string"
+        and isinstance(value, str)
+        or schema_type == "array"
+        and isinstance(value, tuple)
+        or schema_type == "object"
+        and isinstance(value, Mapping)
+    )
+    if not valid:
+        raise ValueError(f"{path} must have JSON type {schema_type}")
+
+    enum = schema.get("enum")
+    if isinstance(enum, tuple) and not any(_same_json_value(value, item) for item in enum):
+        raise ValueError(f"{path} is not one of the declared enum values")
+
+    if schema_type == "object":
+        if not isinstance(value, Mapping):
+            raise AssertionError("validated object is not a mapping")
+        properties = schema.get("properties", MappingProxyType({}))
+        if not isinstance(properties, Mapping):
+            raise AssertionError("validated schema properties are not a mapping")
+        required = schema.get("required", ())
+        if not isinstance(required, tuple):
+            raise AssertionError("validated schema required is not a tuple")
+        for name in required:
+            if not isinstance(name, str):
+                raise AssertionError("validated schema required item is not a string")
+            if name not in value:
+                raise ValueError(f"{path} is missing required property: {name}")
+        if schema.get("additionalProperties", True) is False:
+            extra = set(value) - set(properties)
+            if extra:
+                name = sorted(extra)[0]
+                raise ValueError(f"{path} contains undeclared property: {name}")
+        for name, item in value.items():
+            child = properties.get(name)
+            if child is not None:
+                if not isinstance(child, Mapping):
+                    raise AssertionError("validated child schema is not a mapping")
+                _validate_schema_instance(item, child, path=f"{path}.{name}")
+
+    if schema_type == "array" and "items" in schema:
+        if not isinstance(value, tuple):
+            raise AssertionError("validated array is not a tuple")
+        items = schema["items"]
+        if not isinstance(items, Mapping):
+            raise AssertionError("validated array schema items are not a mapping")
+        for index, item in enumerate(value):
+            _validate_schema_instance(item, items, path=f"{path}[{index}]")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Frozen declaration used to validate and budget one Harness Tool."""
+
+    name: str
+    version: str
+    input_schema: Mapping[str, object]
+    permission_name: str
+    description: str = ""
+    runtime_capabilities: tuple[str, ...] = ()
+    requires_approval: bool = False
+    reserved_tokens: int = 0
+    reserved_cost_microunits: int = 0
+    spec_hash: str = field(init=False)
+    _configuration: Mapping[str, FrozenJsonValue] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        name = _required_text(self.name, field_name="ToolSpec name")
+        version = _required_text(self.version, field_name="ToolSpec version")
+        permission_name = _required_text(
+            self.permission_name,
+            field_name="ToolSpec permission_name",
+        )
+        if not isinstance(self.description, str):
+            raise TypeError("ToolSpec description must be a string")
+        if not isinstance(self.requires_approval, bool):
+            raise TypeError("ToolSpec requires_approval must be a bool")
+        capabilities = _canonical_names(
+            self.runtime_capabilities,
+            field_name="ToolSpec runtime_capabilities",
+        )
+        reserved_tokens = _non_negative_integer(
+            self.reserved_tokens,
+            field_name="ToolSpec reserved_tokens",
+        )
+        reserved_cost = _non_negative_integer(
+            self.reserved_cost_microunits,
+            field_name="ToolSpec reserved_cost_microunits",
+        )
+        _validate_schema_definition(self.input_schema)
+        frozen_schema = _freeze_json(self.input_schema, path="$.tool.input_schema")
+        if not isinstance(frozen_schema, Mapping):
+            raise AssertionError("Tool schema did not freeze to an object")
+        if frozen_schema.get("type") != "object":
+            raise ValueError("ToolSpec input_schema must have type=object")
+        configuration = _frozen_object(
+            tool_spec_version=TOOL_SPEC_VERSION,
+            name=name,
+            version=version,
+            description=self.description,
+            input_schema_version=TOOL_SCHEMA_VERSION,
+            input_schema=frozen_schema,
+            permission_name=permission_name,
+            runtime_capabilities=capabilities,
+            requires_approval=self.requires_approval,
+            reserved_tokens=reserved_tokens,
+            reserved_cost_microunits=reserved_cost,
+        )
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "version", version)
+        object.__setattr__(self, "permission_name", permission_name)
+        object.__setattr__(self, "runtime_capabilities", capabilities)
+        object.__setattr__(self, "reserved_tokens", reserved_tokens)
+        object.__setattr__(self, "reserved_cost_microunits", reserved_cost)
+        object.__setattr__(self, "input_schema", frozen_schema)
+        object.__setattr__(self, "_configuration", configuration)
+        object.__setattr__(self, "spec_hash", _configuration_hash(configuration))
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        """Return the declaration covered by ``spec_hash``."""
+        return self._configuration
+
+    def validate(self, arguments: Mapping[str, FrozenJsonValue]) -> None:
+        """Validate frozen arguments without coercion or applying defaults."""
+        _validate_schema_instance(
+            arguments,
+            cast(Mapping[str, FrozenJsonValue], self.input_schema),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResult:
+    """JSON output and trusted usage reported by a conforming Tool adapter."""
+
+    output: FrozenJsonValue
+    tokens: int = 0
+    cost_microunits: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "output",
+            _freeze_json(
+                self.output,
+                path="$.tool.output",
+                _depth=3,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "tokens",
+            _non_negative_integer(self.tokens, field_name="ToolResult tokens"),
+        )
+        object.__setattr__(
+            self,
+            "cost_microunits",
+            _non_negative_integer(
+                self.cost_microunits,
+                field_name="ToolResult cost_microunits",
+            ),
+        )
+
+
+ToolHandler = Callable[[Mapping[str, FrozenJsonValue]], Awaitable[ToolResult]]
+
+
+class Tool:
+    """Bind one frozen Tool declaration to an asynchronous implementation."""
+
+    __slots__ = ("_handler", "_spec")
+
+    def __init__(self, spec: ToolSpec, handler: ToolHandler) -> None:
+        if not isinstance(spec, ToolSpec):
+            raise TypeError("Tool spec must be a ToolSpec")
+        if not callable(handler):
+            raise TypeError("Tool handler must be callable")
+        self._spec = spec
+        self._handler = handler
+
+    @property
+    def spec(self) -> ToolSpec:
+        return self._spec
+
+    async def _invoke(self, arguments: Mapping[str, FrozenJsonValue]) -> ToolResult:
+        pending = self._handler(arguments)
+        if not inspect.isawaitable(pending):
+            raise TypeError("Tool handler must return an awaitable ToolResult")
+        result = await pending
+        if not isinstance(result, ToolResult):
+            raise TypeError("Tool handler must return ToolResult")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionPolicy:
+    """Versioned, static, default-deny policy for declared Harness Tools."""
+
+    version: str
+    allowed_tools: tuple[str, ...] = ()
+    allowed_permissions: tuple[str, ...] = ()
+    allowed_runtime_capabilities: tuple[str, ...] = ()
+    approval_required_tools: tuple[str, ...] = ()
+    approval_required_permissions: tuple[str, ...] = ()
+    policy_hash: str = field(init=False)
+    _configuration: Mapping[str, FrozenJsonValue] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        version = _required_text(self.version, field_name="ExecutionPolicy version")
+        values = {
+            name: _canonical_names(getattr(self, name), field_name=f"ExecutionPolicy {name}")
+            for name in (
+                "allowed_tools",
+                "allowed_permissions",
+                "allowed_runtime_capabilities",
+                "approval_required_tools",
+                "approval_required_permissions",
+            )
+        }
+        configuration = _frozen_object(version=version, **values)
+        object.__setattr__(self, "version", version)
+        for name, value in values.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "_configuration", configuration)
+        object.__setattr__(self, "policy_hash", _configuration_hash(configuration))
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    def _allows(self, spec: ToolSpec) -> bool:
+        return (
+            spec.name in self.allowed_tools
+            and spec.permission_name in self.allowed_permissions
+            and set(spec.runtime_capabilities).issubset(
+                self.allowed_runtime_capabilities
+            )
+        )
+
+    def _requires_approval(self, spec: ToolSpec) -> bool:
+        return (
+            spec.requires_approval
+            or spec.name in self.approval_required_tools
+            or spec.permission_name in self.approval_required_permissions
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionBudget:
+    """Run-scoped Tool limits plus a per-attempt cooperative timeout."""
+
+    max_tool_calls: int
+    max_tokens: int
+    max_cost_microunits: int
+    tool_timeout_seconds: float
+    currency: str
+    pricing_version: str
+    budget_hash: str = field(init=False)
+    _configuration: Mapping[str, FrozenJsonValue] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "max_tool_calls",
+            _non_negative_integer(self.max_tool_calls, field_name="ExecutionBudget max_tool_calls"),
+        )
+        object.__setattr__(
+            self,
+            "max_tokens",
+            _non_negative_integer(self.max_tokens, field_name="ExecutionBudget max_tokens"),
+        )
+        object.__setattr__(
+            self,
+            "max_cost_microunits",
+            _non_negative_integer(
+                self.max_cost_microunits,
+                field_name="ExecutionBudget max_cost_microunits",
+            ),
+        )
+        if isinstance(self.tool_timeout_seconds, bool) or not isinstance(
+            self.tool_timeout_seconds, (int, float)
+        ):
+            raise TypeError("ExecutionBudget tool_timeout_seconds must be a number")
+        timeout = float(self.tool_timeout_seconds)
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("ExecutionBudget tool_timeout_seconds must be finite and positive")
+        object.__setattr__(self, "tool_timeout_seconds", timeout)
+        object.__setattr__(
+            self,
+            "currency",
+            _required_text(self.currency, field_name="ExecutionBudget currency"),
+        )
+        object.__setattr__(
+            self,
+            "pricing_version",
+            _required_text(
+                self.pricing_version,
+                field_name="ExecutionBudget pricing_version",
+            ),
+        )
+        configuration = _frozen_object(
+            max_tool_calls=self.max_tool_calls,
+            max_tokens=self.max_tokens,
+            max_cost_microunits=self.max_cost_microunits,
+            tool_timeout_seconds=self.tool_timeout_seconds,
+            currency=self.currency,
+            pricing_version=self.pricing_version,
+        )
+        object.__setattr__(self, "_configuration", configuration)
+        object.__setattr__(self, "budget_hash", _configuration_hash(configuration))
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalRequest:
+    """Immutable approval request bound to exactly one Tool invocation."""
+
+    trial_id: str
+    call_id: str
+    request_nonce: str
+    action_index: int
+    tool_name: str
+    tool_version: str
+    tool_spec_hash: str
+    arguments: Mapping[str, FrozenJsonValue]
+    policy_hash: str
+    budget_hash: str
+    approver_hash: str | None
+    reserved_tokens: int
+    reserved_cost_microunits: int
+    request_hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "trial_id",
+            "call_id",
+            "request_nonce",
+            "tool_name",
+            "tool_version",
+            "tool_spec_hash",
+            "policy_hash",
+            "budget_hash",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _required_text(getattr(self, name), field_name=f"ApprovalRequest {name}"),
+            )
+        action_index = _non_negative_integer(
+            self.action_index,
+            field_name="ApprovalRequest action_index",
+        )
+        arguments = _freeze_json(self.arguments, path="$.approval.arguments")
+        if not isinstance(arguments, Mapping):
+            raise TypeError("ApprovalRequest arguments must be an object")
+        reserved_tokens = _non_negative_integer(
+            self.reserved_tokens,
+            field_name="ApprovalRequest reserved_tokens",
+        )
+        reserved_cost = _non_negative_integer(
+            self.reserved_cost_microunits,
+            field_name="ApprovalRequest reserved_cost_microunits",
+        )
+        approver_hash = self.approver_hash
+        if approver_hash is not None:
+            approver_hash = _required_text(
+                approver_hash,
+                field_name="ApprovalRequest approver_hash",
+            )
+        payload = _frozen_object(
+            trial_id=self.trial_id,
+            call_id=self.call_id,
+            request_nonce=self.request_nonce,
+            action_index=action_index,
+            tool_name=self.tool_name,
+            tool_version=self.tool_version,
+            tool_spec_hash=self.tool_spec_hash,
+            arguments=arguments,
+            policy_hash=self.policy_hash,
+            budget_hash=self.budget_hash,
+            approver_hash=approver_hash,
+            reserved_tokens=reserved_tokens,
+            reserved_cost_microunits=reserved_cost,
+        )
+        object.__setattr__(self, "action_index", action_index)
+        object.__setattr__(self, "arguments", arguments)
+        object.__setattr__(self, "reserved_tokens", reserved_tokens)
+        object.__setattr__(self, "reserved_cost_microunits", reserved_cost)
+        object.__setattr__(self, "approver_hash", approver_hash)
+        object.__setattr__(self, "request_hash", _configuration_hash(payload))
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDecision:
+    """An Approver decision content-hash bound to one ApprovalRequest."""
+
+    request_hash: str
+    approved: bool
+    reason: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "request_hash",
+            _required_text(
+                self.request_hash,
+                field_name="ApprovalDecision request_hash",
+            ),
+        )
+        if not isinstance(self.approved, bool):
+            raise TypeError("ApprovalDecision approved must be a bool")
+        object.__setattr__(
+            self,
+            "reason",
+            _json_text(
+                self.reason,
+                field_name="ApprovalDecision reason",
+            ),
+        )
+
+    @classmethod
+    def approve(
+        cls,
+        request: ApprovalRequest,
+        *,
+        reason: str = "",
+    ) -> ApprovalDecision:
+        return cls(request.request_hash, True, reason)
+
+    @classmethod
+    def deny(
+        cls,
+        request: ApprovalRequest,
+        *,
+        reason: str = "",
+    ) -> ApprovalDecision:
+        return cls(request.request_hash, False, reason)
+
+
+class Approver(Protocol):
+    """Declared asynchronous decision source for exact ApprovalRequests."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+    @property
+    def configuration(self) -> Mapping[str, object]: ...
+
+    async def decide(self, request: ApprovalRequest) -> ApprovalDecision: ...
+
+
+class ToolCallStatus(str, Enum):
+    """Harness-visible outcome of one controlled Tool invocation attempt."""
+
+    SUCCEEDED = "succeeded"
+    INVALID = "invalid"
+    DENIED = "denied"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    TIMED_OUT = "timed_out"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+def _approval_evidence(
+    status: str,
+    *,
+    approver: str | None = None,
+    approver_version: str | None = None,
+    reason: str = "",
+) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        status=status,
+        approver=approver,
+        approver_version=approver_version,
+        reason=reason,
+    )
+
+
+class ControlledToolEnvironment:
+    """Environment that validates, authorizes, budgets, and audits async Tools."""
+
+    def __init__(
+        self,
+        *,
+        tools: Sequence[Tool],
+        policy: ExecutionPolicy,
+        budget: ExecutionBudget,
+        name: str,
+        version: str,
+        approver: Approver | None = None,
+    ) -> None:
+        self._name = _required_text(name, field_name="ControlledToolEnvironment name")
+        self._version = _required_text(
+            version,
+            field_name="ControlledToolEnvironment version",
+        )
+        if not isinstance(policy, ExecutionPolicy):
+            raise TypeError("ControlledToolEnvironment policy must be ExecutionPolicy")
+        if not isinstance(budget, ExecutionBudget):
+            raise TypeError("ControlledToolEnvironment budget must be ExecutionBudget")
+        declared_tools: dict[str, Tool] = {}
+        for tool in tools:
+            if not isinstance(tool, Tool):
+                raise TypeError("ControlledToolEnvironment tools must contain Tool values")
+            if tool.spec.name in declared_tools:
+                raise ValueError(f"duplicate Tool name: {tool.spec.name}")
+            declared_tools[tool.spec.name] = tool
+        declared_tools = dict(sorted(declared_tools.items()))
+        if not set(policy.allowed_tools).issubset(declared_tools):
+            raise ValueError("ExecutionPolicy allowed_tools must name declared Tools")
+        if not set(policy.approval_required_tools).issubset(policy.allowed_tools):
+            raise ValueError(
+                "ExecutionPolicy approval_required_tools must be allowed Tools"
+            )
+        if not set(policy.approval_required_permissions).issubset(
+            policy.allowed_permissions
+        ):
+            raise ValueError(
+                "ExecutionPolicy approval_required_permissions must be allowed permissions"
+            )
+        self._tools = MappingProxyType(declared_tools)
+        self._policy = policy
+        self._budget = budget
+        self._approver = approver
+        self._approver_name: str | None = None
+        self._approver_version: str | None = None
+        self._approver_configuration: Mapping[str, FrozenJsonValue] | None = None
+        self._approver_hash: str | None = None
+        approver_declaration: Mapping[str, FrozenJsonValue] | None = None
+        if approver is not None:
+            approver_name = _required_text(
+                getattr(approver, "name", None),
+                field_name="Approver name",
+            )
+            approver_version = _required_text(
+                getattr(approver, "version", None),
+                field_name="Approver version",
+            )
+            approver_config = getattr(approver, "configuration", None)
+            if not isinstance(approver_config, Mapping):
+                raise TypeError("Approver configuration must be an object")
+            approver_declaration = _frozen_object(
+                name=approver_name,
+                version=approver_version,
+                config=approver_config,
+            )
+            declared_config = approver_declaration["config"]
+            if not isinstance(declared_config, Mapping):
+                raise AssertionError("Approver config did not freeze to an object")
+            self._approver_name = approver_name
+            self._approver_version = approver_version
+            self._approver_configuration = declared_config
+            self._approver_hash = _configuration_hash(approver_declaration)
+        self._configuration = _frozen_object(
+            kind="controlled_tool",
+            controlled_execution_version=CONTROLLED_EXECUTION_VERSION,
+            schema_version=TOOL_SCHEMA_VERSION,
+            tools=[tool.spec.configuration for tool in declared_tools.values()],
+            policy=policy.configuration,
+            policy_hash=policy.policy_hash,
+            budget=budget.configuration,
+            budget_hash=budget.budget_hash,
+            approver=approver_declaration,
+            approver_hash=self._approver_hash,
+            single_use=True,
+        )
+        self._calls = 0
+        self._tokens = 0
+        self._cost_microunits = 0
+        self._budget_poisoned = False
+        self._request_nonces: dict[str, str] = {}
+        self._records: list[tuple[str, Mapping[str, FrozenJsonValue]]] = []
+        self._direct_trial_id: str | None = None
+        self._reset_generation = 0
+        self._has_reset = False
+        self._bound_trial_id: str | None = None
+        self._next_action_index = 0
+        self._terminated = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    def _bind_trial(self, trial_id: str) -> None:
+        if self._bound_trial_id is not None:
+            raise RuntimeError(
+                "ControlledToolEnvironment can be bound to only one Trial"
+            )
+        self._bound_trial_id = _required_text(
+            trial_id,
+            field_name="ControlledToolEnvironment trial_id",
+        )
+
+    async def reset(self, task: Task, *, seed: int) -> Observation:
+        """Reset run-local counters and expose the Task input."""
+        if self._has_reset:
+            raise RuntimeError(
+                "ControlledToolEnvironment is single-use; create one instance per Trial"
+            )
+        if self._records:
+            raise RuntimeError("controlled Tool audit records were not drained")
+        self._has_reset = True
+        self._calls = 0
+        self._tokens = 0
+        self._cost_microunits = 0
+        self._budget_poisoned = False
+        self._request_nonces.clear()
+        self._next_action_index = 0
+        self._terminated = False
+        self._reset_generation += 1
+        self._direct_trial_id = (
+            f"direct:{task.id}:{seed}:{self._reset_generation}"
+        )
+        return Observation(task.input)
+
+    async def step(self, action: Action, *, seed: int, action_index: int) -> Transition:
+        """Apply an Action directly without retaining Trial-only audit evidence."""
+        if self._direct_trial_id is None:
+            raise RuntimeError("ControlledToolEnvironment must be reset before step")
+        try:
+            return await self._step_with_audit(
+                action,
+                trial_id=self._direct_trial_id,
+                seed=seed,
+                action_index=action_index,
+            )
+        finally:
+            self._drain_trajectory_records()
+
+    async def _step_with_audit(
+        self,
+        action: Action,
+        *,
+        trial_id: str,
+        seed: int,
+        action_index: int,
+    ) -> Transition:
+        del seed
+        call_id: str | None = None
+        try:
+            async with self._lock:
+                if not self._has_reset:
+                    raise RuntimeError(
+                        "ControlledToolEnvironment must be reset before step"
+                    )
+                if self._terminated:
+                    raise RuntimeError(
+                        "ControlledToolEnvironment has already terminated"
+                    )
+                if self._bound_trial_id is not None and trial_id != self._bound_trial_id:
+                    raise RuntimeError(
+                        "ControlledToolEnvironment Trial binding does not match"
+                    )
+                if action_index != self._next_action_index:
+                    raise RuntimeError(
+                        "ControlledToolEnvironment action_index must be contiguous from zero"
+                    )
+                self._next_action_index += 1
+                call_id = f"tool-{action_index}"
+                if action.is_final:
+                    self._terminated = True
+                    return Transition(
+                        observation=Observation(action.payload),
+                        terminated=True,
+                        output=action.payload,
+                    )
+                return await self._invoke(
+                    action,
+                    trial_id=trial_id,
+                    call_id=call_id,
+                    action_index=action_index,
+                )
+        except asyncio.CancelledError:
+            if (
+                call_id is not None
+                and not action.is_final
+                and not self._has_outcome(call_id)
+            ):
+                tool = self._tools.get(action.name)
+                self._record_outcome(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.CANCELLED,
+                    tool=tool,
+                    request_hash=None,
+                    approval_required=(
+                        False
+                        if tool is None
+                        else self._policy._requires_approval(tool.spec)
+                    ),
+                    usage_tokens=0,
+                    usage_cost=0,
+                    charged_tokens=0,
+                    charged_cost=0,
+                    error_code="cancelled",
+                    message="controlled Tool call was cancelled",
+                    approval=None,
+                )
+            raise
+
+    def _has_outcome(self, call_id: str) -> bool:
+        return any(record[1].get("call_id") == call_id for record in self._records)
+
+    def _drain_trajectory_records(
+        self,
+    ) -> tuple[tuple[str, Mapping[str, FrozenJsonValue]], ...]:
+        records = tuple(self._records)
+        self._records.clear()
+        return records
+
+    def _request(
+        self,
+        *,
+        trial_id: str,
+        call_id: str,
+        action_index: int,
+        tool: Tool,
+        arguments: Mapping[str, FrozenJsonValue],
+    ) -> ApprovalRequest:
+        request = ApprovalRequest(
+            trial_id=trial_id,
+            call_id=call_id,
+            request_nonce=secrets.token_hex(16),
+            action_index=action_index,
+            tool_name=tool.spec.name,
+            tool_version=tool.spec.version,
+            tool_spec_hash=tool.spec.spec_hash,
+            arguments=arguments,
+            policy_hash=self._policy.policy_hash,
+            budget_hash=self._budget.budget_hash,
+            approver_hash=self._approver_hash,
+            reserved_tokens=tool.spec.reserved_tokens,
+            reserved_cost_microunits=tool.spec.reserved_cost_microunits,
+        )
+        self._request_nonces[request.request_hash] = request.request_nonce
+        return request
+
+    def _approver_declaration_is_current(self) -> bool:
+        if (
+            self._approver is None
+            or self._approver_name is None
+            or self._approver_version is None
+            or self._approver_configuration is None
+            or self._approver_hash is None
+        ):
+            return False
+        try:
+            live_name = _required_text(
+                self._approver.name,
+                field_name="Approver name",
+            )
+            live_version = _required_text(
+                self._approver.version,
+                field_name="Approver version",
+            )
+            live_configuration = _freeze_json(
+                self._approver.configuration,
+                path="$.approver.configuration",
+            )
+            if not isinstance(live_configuration, Mapping):
+                return False
+            live_declaration = _frozen_object(
+                name=live_name,
+                version=live_version,
+                config=live_configuration,
+            )
+            return _configuration_hash(live_declaration) == self._approver_hash
+        except BaseException:
+            return False
+
+    async def _invoke(
+        self,
+        action: Action,
+        *,
+        trial_id: str,
+        call_id: str,
+        action_index: int,
+    ) -> Transition:
+        tool = self._tools.get(action.name)
+        approval_required = (
+            False if tool is None else self._policy._requires_approval(tool.spec)
+        )
+        if self._calls >= self._budget.max_tool_calls:
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.BUDGET_EXHAUSTED,
+                tool=tool,
+                request_hash=None,
+                approval_required=approval_required,
+                error_code="call_budget_exhausted",
+                message="controlled Tool call budget is exhausted",
+            )
+        self._calls += 1
+        if tool is None:
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.DENIED,
+                tool=None,
+                request_hash=None,
+                approval_required=False,
+                error_code="unknown_tool",
+                message=f"Tool is not declared: {action.name}",
+            )
+        if self._budget_poisoned:
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.BUDGET_EXHAUSTED,
+                tool=tool,
+                request_hash=None,
+                approval_required=approval_required,
+                error_code="usage_budget_exhausted",
+                message="execution budget is exhausted after a Tool contract violation",
+            )
+        if not isinstance(action.payload, Mapping):
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.INVALID,
+                tool=tool,
+                request_hash=None,
+                approval_required=approval_required,
+                error_code="invalid_arguments",
+                message="Tool arguments must be an object",
+            )
+        arguments = action.payload
+        try:
+            tool.spec.validate(arguments)
+        except (TypeError, ValueError) as error:
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.INVALID,
+                tool=tool,
+                request_hash=None,
+                approval_required=approval_required,
+                error_code="invalid_arguments",
+                message=str(error),
+            )
+        request = self._request(
+            trial_id=trial_id,
+            call_id=call_id,
+            action_index=action_index,
+            tool=tool,
+            arguments=arguments,
+        )
+        if not self._policy._allows(tool.spec):
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.DENIED,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                error_code="policy_denied",
+                message="ExecutionPolicy denied the Tool",
+            )
+        if (
+            self._tokens + tool.spec.reserved_tokens > self._budget.max_tokens
+            or self._cost_microunits + tool.spec.reserved_cost_microunits
+            > self._budget.max_cost_microunits
+        ):
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.BUDGET_EXHAUSTED,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                error_code="usage_budget_exhausted",
+                message="Tool reservation exceeds the remaining execution budget",
+            )
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._budget.tool_timeout_seconds
+        approval: Mapping[str, FrozenJsonValue] | None = None
+        if approval_required:
+            if self._approver is None:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("missing"),
+                    error_code="approval_missing",
+                    message="Tool requires an Approver",
+                )
+            approver = self._approver
+            if not self._approver_declaration_is_current():
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("invalid"),
+                    error_code="approval_drift",
+                    message="Approver declaration drifted before execution",
+                )
+            try:
+                decision: object = await _await_before_deadline(
+                    lambda: approver.decide(request),
+                    deadline=deadline,
+                )
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is None or current.cancelling() == 0:
+                    return self._finish(
+                        call_id=call_id,
+                        tool_name=action.name,
+                        status=ToolCallStatus.DENIED,
+                        tool=tool,
+                        request_hash=request.request_hash,
+                        approval_required=True,
+                        approval=_approval_evidence("failed"),
+                        error_code="approval_failed",
+                        message="Approver failed: CancelledError",
+                    )
+                self._record_outcome(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.CANCELLED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    usage_tokens=0,
+                    usage_cost=0,
+                    charged_tokens=0,
+                    charged_cost=0,
+                    error_code="cancelled",
+                    message="approval wait was cancelled",
+                    approval=_approval_evidence("cancelled"),
+                )
+                raise
+            except _ControlledDeadlineExceeded:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.TIMED_OUT,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("timed_out"),
+                    error_code="approval_timed_out",
+                    message="approval exceeded the Tool timeout",
+                )
+            except BaseException as error:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("failed"),
+                    error_code="approval_failed",
+                    message=f"Approver failed: {type(error).__name__}",
+                )
+            if loop.time() >= deadline:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.TIMED_OUT,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("timed_out"),
+                    error_code="approval_timed_out",
+                    message="approval exceeded the Tool timeout",
+                )
+            if not self._approver_declaration_is_current():
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("invalid"),
+                    error_code="approval_drift",
+                    message="Approver declaration drifted during approval",
+                )
+            if loop.time() >= deadline:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.TIMED_OUT,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("timed_out"),
+                    error_code="approval_timed_out",
+                    message="approval exceeded the Tool timeout",
+                )
+            if not isinstance(decision, ApprovalDecision):
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("invalid"),
+                    error_code="approval_invalid",
+                    message="Approver must return ApprovalDecision",
+                )
+            if decision.request_hash != request.request_hash:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence("invalid"),
+                    error_code="approval_mismatch",
+                    message="ApprovalDecision does not match this request",
+                )
+            if not decision.approved:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.DENIED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=True,
+                    approval=_approval_evidence(
+                        "denied",
+                        approver=self._approver_name,
+                        approver_version=self._approver_version,
+                        reason=decision.reason,
+                    ),
+                    error_code="approval_denied",
+                    message=decision.reason or "Approver denied the Tool",
+                )
+            approval = _approval_evidence(
+                "approved",
+                approver=self._approver_name,
+                approver_version=self._approver_version,
+                reason=decision.reason,
+            )
+
+        reserved_tokens = tool.spec.reserved_tokens
+        reserved_cost = tool.spec.reserved_cost_microunits
+        self._tokens += reserved_tokens
+        self._cost_microunits += reserved_cost
+        try:
+            result = await _await_before_deadline(
+                lambda: tool._invoke(arguments),
+                deadline=deadline,
+            )
+        except asyncio.CancelledError:
+            current = asyncio.current_task()
+            if current is None or current.cancelling() == 0:
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.FAILED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=approval_required,
+                    approval=approval,
+                    charged_tokens=reserved_tokens,
+                    charged_cost=reserved_cost,
+                    error_code="tool_failed",
+                    message="Tool failed: CancelledError",
+                )
+            self._record_outcome(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.CANCELLED,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                usage_tokens=0,
+                usage_cost=0,
+                charged_tokens=reserved_tokens,
+                charged_cost=reserved_cost,
+                error_code="cancelled",
+                message="Tool wait was cancelled",
+                approval=approval,
+            )
+            raise
+        except _ControlledDeadlineExceeded as error:
+            late_result = error.late_result
+            if isinstance(late_result, ToolResult) and (
+                late_result.tokens > reserved_tokens
+                or late_result.cost_microunits > reserved_cost
+            ):
+                self._tokens += late_result.tokens - reserved_tokens
+                self._cost_microunits += (
+                    late_result.cost_microunits - reserved_cost
+                )
+                self._budget_poisoned = True
+                return self._finish(
+                    call_id=call_id,
+                    tool_name=action.name,
+                    status=ToolCallStatus.FAILED,
+                    tool=tool,
+                    request_hash=request.request_hash,
+                    approval_required=approval_required,
+                    approval=approval,
+                    usage_tokens=late_result.tokens,
+                    usage_cost=late_result.cost_microunits,
+                    charged_tokens=late_result.tokens,
+                    charged_cost=late_result.cost_microunits,
+                    error_code="usage_exceeded_reservation",
+                    message="Tool usage exceeded its declared reservation",
+                )
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.TIMED_OUT,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                approval=approval,
+                charged_tokens=reserved_tokens,
+                charged_cost=reserved_cost,
+                error_code="tool_timed_out",
+                message="Tool exceeded the execution timeout",
+            )
+        except BaseException as error:
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.FAILED,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                approval=approval,
+                charged_tokens=reserved_tokens,
+                charged_cost=reserved_cost,
+                error_code="tool_failed",
+                message=f"Tool failed: {type(error).__name__}",
+            )
+        if (
+            result.tokens > reserved_tokens
+            or result.cost_microunits > reserved_cost
+        ):
+            self._tokens += result.tokens - reserved_tokens
+            self._cost_microunits += result.cost_microunits - reserved_cost
+            self._budget_poisoned = True
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.FAILED,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                approval=approval,
+                usage_tokens=result.tokens,
+                usage_cost=result.cost_microunits,
+                charged_tokens=result.tokens,
+                charged_cost=result.cost_microunits,
+                error_code="usage_exceeded_reservation",
+                message="Tool usage exceeded its declared reservation",
+            )
+        if loop.time() >= deadline:
+            return self._finish(
+                call_id=call_id,
+                tool_name=action.name,
+                status=ToolCallStatus.TIMED_OUT,
+                tool=tool,
+                request_hash=request.request_hash,
+                approval_required=approval_required,
+                approval=approval,
+                charged_tokens=reserved_tokens,
+                charged_cost=reserved_cost,
+                error_code="tool_timed_out",
+                message="Tool exceeded the execution timeout",
+            )
+        self._tokens -= reserved_tokens - result.tokens
+        self._cost_microunits -= reserved_cost - result.cost_microunits
+        return self._finish(
+            call_id=call_id,
+            tool_name=action.name,
+            status=ToolCallStatus.SUCCEEDED,
+            tool=tool,
+            request_hash=request.request_hash,
+            approval_required=approval_required,
+            approval=approval,
+            output=result.output,
+            usage_tokens=result.tokens,
+            usage_cost=result.cost_microunits,
+            charged_tokens=result.tokens,
+            charged_cost=result.cost_microunits,
+        )
+
+    def _record_outcome(
+        self,
+        *,
+        call_id: str,
+        tool_name: str,
+        status: ToolCallStatus,
+        tool: Tool | None,
+        request_hash: str | None,
+        approval_required: bool,
+        usage_tokens: int,
+        usage_cost: int,
+        charged_tokens: int,
+        charged_cost: int,
+        error_code: str | None,
+        message: str | None,
+        approval: Mapping[str, FrozenJsonValue] | None,
+        observation_hash: str | None = None,
+    ) -> None:
+        if self._has_outcome(call_id):
+            raise RuntimeError(f"duplicate controlled Tool outcome: {call_id}")
+        if approval is None:
+            approval = _approval_evidence(
+                "not_obtained" if approval_required else "not_required"
+            )
+        request_nonce = (
+            None
+            if request_hash is None
+            else self._request_nonces.pop(request_hash)
+        )
+        self._records.append(
+            (
+                "tool.call.outcome",
+                _frozen_object(
+                    call_id=call_id,
+                    tool_name=tool_name,
+                    tool_version=None if tool is None else tool.spec.version,
+                    status=status.value,
+                    tool_spec_hash=None if tool is None else tool.spec.spec_hash,
+                    policy_hash=self._policy.policy_hash,
+                    request_hash=request_hash,
+                    request_nonce=request_nonce,
+                    observation_hash=observation_hash,
+                    approval_required=approval_required,
+                    approval=approval,
+                    usage={"tokens": usage_tokens, "cost_microunits": usage_cost},
+                    budget_charged={
+                        "tokens": charged_tokens,
+                        "cost_microunits": charged_cost,
+                    },
+                    error_code=error_code,
+                    message=message,
+                ),
+            )
+        )
+
+    def _finish(
+        self,
+        *,
+        call_id: str,
+        tool_name: str,
+        status: ToolCallStatus,
+        tool: Tool | None,
+        request_hash: str | None,
+        approval_required: bool,
+        output: FrozenJsonValue = None,
+        usage_tokens: int = 0,
+        usage_cost: int = 0,
+        charged_tokens: int = 0,
+        charged_cost: int = 0,
+        error_code: str | None = None,
+        message: str | None = None,
+        approval: Mapping[str, FrozenJsonValue] | None = None,
+    ) -> Transition:
+        observation = Observation(
+            {
+                "tool_call": {
+                    "call_id": call_id,
+                    "tool_name": tool_name,
+                    "status": status.value,
+                    "output": output,
+                    "usage": {
+                        "tokens": usage_tokens,
+                        "cost_microunits": usage_cost,
+                    },
+                    "error_code": error_code,
+                    "message": message,
+                }
+            }
+        )
+        observation_hash = _configuration_hash(
+            _frozen_object(observation=observation.value)
+        )
+        self._record_outcome(
+            call_id=call_id,
+            tool_name=tool_name,
+            status=status,
+            tool=tool,
+            request_hash=request_hash,
+            approval_required=approval_required,
+            usage_tokens=usage_tokens,
+            usage_cost=usage_cost,
+            charged_tokens=charged_tokens,
+            charged_cost=charged_cost,
+            error_code=error_code,
+            message=message,
+            approval=approval,
+            observation_hash=observation_hash,
+        )
+        return Transition(observation=observation)

--- a/python/iamai/harness/_experiment.py
+++ b/python/iamai/harness/_experiment.py
@@ -1,0 +1,435 @@
+"""Versioned comparison Experiments for the provisional harness."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from ._model import (
+    FrozenJsonValue,
+    JsonValue,
+    TRAJECTORY_FORMAT_VERSION,
+    Trajectory,
+    TrialResult,
+    _configuration_hash,
+    _freeze_json,
+    _frozen_object,
+)
+from ._replay import _validate_configuration, replay
+from ._trial import Trial, _configuration_snapshot
+
+if TYPE_CHECKING:
+    from ._jsonl import JsonlTrajectoryStore
+
+
+def _trajectory_spec(trajectory: Trajectory) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        format_version=trajectory.format_version,
+        trial_id=trajectory.trial_id,
+        task={"id": trajectory.task.id, "input": trajectory.task.input},
+        seed=trajectory.seed,
+        configuration=trajectory.configuration,
+        config_hash=trajectory.config_hash,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ExperimentPlan:
+    """Immutable, serializable specification for one comparison Experiment."""
+
+    experiment_id: str
+    version: str
+    trial_specs: Mapping[str, tuple[Trajectory, ...]]
+    baseline: str | None
+    provenance: Mapping[str, JsonValue | FrozenJsonValue] = field(default_factory=dict)
+    plan_hash: str = field(init=False)
+    _payload: Mapping[str, FrozenJsonValue] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.experiment_id, str) or not self.experiment_id.strip():
+            raise ValueError("ExperimentPlan experiment_id cannot be empty")
+        if not isinstance(self.version, str) or not self.version.strip():
+            raise ValueError("ExperimentPlan version cannot be empty")
+        if self.baseline is not None and (
+            not isinstance(self.baseline, str) or not self.baseline.strip()
+        ):
+            raise ValueError("ExperimentPlan baseline must be a non-empty string or None")
+        if not isinstance(self.trial_specs, Mapping) or not self.trial_specs:
+            raise ValueError("ExperimentPlan must contain at least one variant")
+
+        frozen_variants: dict[str, tuple[Trajectory, ...]] = {}
+        all_trial_ids: set[str] = set()
+        variant_payloads: list[Mapping[str, FrozenJsonValue]] = []
+        for variant, raw_specs in self.trial_specs.items():
+            if not isinstance(variant, str) or not variant.strip():
+                raise ValueError("ExperimentPlan variant names cannot be empty")
+            specs = tuple(raw_specs)
+            if not specs:
+                raise ValueError("ExperimentPlan variants must contain a Trial spec")
+            spec_payloads: list[Mapping[str, FrozenJsonValue]] = []
+            for position, spec in enumerate(specs):
+                if not isinstance(spec, Trajectory):
+                    raise TypeError("ExperimentPlan trial_specs must contain Trajectories")
+                if spec.records:
+                    raise ValueError("ExperimentPlan Trial specs cannot contain records")
+                if spec.format_version != TRAJECTORY_FORMAT_VERSION:
+                    raise ValueError(
+                        f"unsupported ExperimentPlan Trajectory format: {spec.format_version}"
+                    )
+                if spec.config_hash != _configuration_hash(spec.configuration):
+                    raise ValueError(
+                        "ExperimentPlan Trial spec configuration hash does not match"
+                    )
+                _validate_configuration(spec)
+                max_actions = spec.configuration.get("max_actions")
+                if (
+                    isinstance(max_actions, bool)
+                    or not isinstance(max_actions, int)
+                    or max_actions <= 0
+                ):
+                    raise ValueError(
+                        "ExperimentPlan Trial spec must declare positive max_actions"
+                    )
+                if spec.trial_id in all_trial_ids:
+                    raise ValueError("ExperimentPlan Trial ids must be globally unique")
+                all_trial_ids.add(spec.trial_id)
+                payload = _trajectory_spec(spec)
+                spec_payloads.append(
+                    _frozen_object(
+                        position=position,
+                        spec=payload,
+                        spec_hash=_configuration_hash(payload),
+                    )
+                )
+            frozen_variants[variant] = specs
+            variant_payloads.append(_frozen_object(name=variant, trials=spec_payloads))
+
+        if self.baseline is not None and self.baseline not in frozen_variants:
+            raise ValueError("ExperimentPlan baseline must name a planned variant")
+        provenance = _freeze_json(
+            self.provenance,
+            path="$.experiment.provenance",
+        )
+        if not isinstance(provenance, Mapping):
+            raise TypeError("ExperimentPlan provenance must be an object")
+        payload = _frozen_object(
+            experiment_id=self.experiment_id,
+            version=self.version,
+            baseline=self.baseline,
+            provenance=provenance,
+            variants=variant_payloads,
+        )
+        object.__setattr__(self, "trial_specs", MappingProxyType(frozen_variants))
+        object.__setattr__(self, "provenance", provenance)
+        object.__setattr__(self, "_payload", payload)
+        object.__setattr__(self, "plan_hash", _configuration_hash(payload))
+
+    @property
+    def planned_trial_ids(self) -> Mapping[str, tuple[str, ...]]:
+        """Return the planned Trial ids in semantic variant and slot order."""
+        return MappingProxyType(
+            {
+                variant: tuple(spec.trial_id for spec in specs)
+                for variant, specs in self.trial_specs.items()
+            }
+        )
+
+    def _spec_hash(self, variant: str, position: int) -> str:
+        return _configuration_hash(_trajectory_spec(self.trial_specs[variant][position]))
+
+
+@dataclass(frozen=True, slots=True)
+class _TrialSlot:
+    variant: str
+    position: int
+    trial: Trial
+
+
+@dataclass(frozen=True, slots=True)
+class ExperimentResult:
+    """Immutable projection of a persisted Experiment plan and Trial results."""
+
+    plan: ExperimentPlan
+    results: Mapping[str, tuple[TrialResult, ...]]
+    started_trial_ids: Mapping[str, tuple[str, ...]]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.plan, ExperimentPlan):
+            raise TypeError("ExperimentResult plan must be an ExperimentPlan")
+        planned = dict(self.plan.planned_trial_ids)
+        results = {
+            variant: tuple(variant_results)
+            for variant, variant_results in self.results.items()
+        }
+        started = {
+            variant: tuple(trial_ids)
+            for variant, trial_ids in self.started_trial_ids.items()
+        }
+        if set(planned) != set(results) or set(planned) != set(started):
+            raise ValueError("ExperimentResult plan and result variants must match")
+
+        for variant, trial_ids in planned.items():
+            positions = {trial_id: index for index, trial_id in enumerate(trial_ids)}
+            if any(not isinstance(result, TrialResult) for result in results[variant]):
+                raise TypeError("ExperimentResult results must contain TrialResult values")
+            result_ids = [result.trial_id for result in results[variant]]
+            if len(set(result_ids)) != len(result_ids) or any(
+                trial_id not in positions for trial_id in result_ids
+            ):
+                raise ValueError("ExperimentResult contains an unplanned or duplicate Trial")
+            if result_ids != sorted(result_ids, key=positions.__getitem__):
+                raise ValueError("ExperimentResult Trial results must follow plan order")
+            for result in results[variant]:
+                position = positions[result.trial_id]
+                if (
+                    _configuration_hash(_trajectory_spec(result.trajectory))
+                    != self.plan._spec_hash(variant, position)
+                ):
+                    raise ValueError(
+                        "ExperimentResult Trial does not match its planned provenance"
+                    )
+                if replay(result.trajectory) != result:
+                    raise ValueError(
+                        "ExperimentResult projection does not match its Trajectory"
+                    )
+            started_ids = started[variant]
+            if (
+                len(set(started_ids)) != len(started_ids)
+                or any(trial_id not in positions for trial_id in started_ids)
+                or set(started_ids).intersection(result_ids)
+                or list(started_ids) != sorted(started_ids, key=positions.__getitem__)
+            ):
+                raise ValueError(
+                    "ExperimentResult started Trials must be uncommitted and follow plan order"
+                )
+
+        object.__setattr__(self, "results", MappingProxyType(results))
+        object.__setattr__(self, "started_trial_ids", MappingProxyType(started))
+
+    @property
+    def experiment_id(self) -> str:
+        return self.plan.experiment_id
+
+    @property
+    def version(self) -> str:
+        return self.plan.version
+
+    @property
+    def baseline(self) -> str | None:
+        return self.plan.baseline
+
+    @property
+    def plan_hash(self) -> str:
+        return self.plan.plan_hash
+
+    @property
+    def planned_trial_ids(self) -> Mapping[str, tuple[str, ...]]:
+        return self.plan.planned_trial_ids
+
+    @property
+    def complete(self) -> bool:
+        """Return whether every planned Trial has one committed result."""
+        return all(
+            len(self.results[variant]) == len(trial_ids)
+            for variant, trial_ids in self.planned_trial_ids.items()
+        )
+
+
+class Experiment:
+    """Run and persist an explicit set of comparison Trial variants."""
+
+    def __init__(
+        self,
+        *,
+        experiment_id: str,
+        version: str,
+        trials: Mapping[str, Sequence[Trial]],
+        baseline: str | None = None,
+        provenance: Mapping[str, JsonValue] | None = None,
+    ) -> None:
+        if not isinstance(trials, Mapping) or not trials:
+            raise ValueError("Experiment trials must contain at least one variant")
+        slots_by_variant: dict[str, tuple[_TrialSlot, ...]] = {}
+        specs_by_variant: dict[str, tuple[Trajectory, ...]] = {}
+        for variant, variant_trials in trials.items():
+            if not isinstance(variant, str) or not variant.strip():
+                raise ValueError("Experiment variant names cannot be empty")
+            planned_trials = tuple(variant_trials)
+            if not planned_trials:
+                raise ValueError("Experiment variants must contain at least one Trial")
+            slots: list[_TrialSlot] = []
+            specs: list[Trajectory] = []
+            for position, trial in enumerate(planned_trials):
+                if not isinstance(trial, Trial):
+                    raise TypeError("Experiment variants must contain Trial values")
+                spec = trial.trajectory
+                if spec.records:
+                    raise ValueError("Experiment Trials must not have started")
+                slots.append(_TrialSlot(variant=variant, position=position, trial=trial))
+                specs.append(spec)
+            slots_by_variant[variant] = tuple(slots)
+            specs_by_variant[variant] = tuple(specs)
+        self._slots = MappingProxyType(slots_by_variant)
+        self._recoverable_terminal_slots: set[tuple[str, str]] = set()
+        self._plan = ExperimentPlan(
+            experiment_id=experiment_id,
+            version=version,
+            trial_specs=specs_by_variant,
+            baseline=baseline,
+            provenance={} if provenance is None else provenance,
+        )
+
+    @property
+    def plan(self) -> ExperimentPlan:
+        return self._plan
+
+    @property
+    def experiment_id(self) -> str:
+        return self.plan.experiment_id
+
+    @property
+    def version(self) -> str:
+        return self.plan.version
+
+    @property
+    def baseline(self) -> str | None:
+        return self.plan.baseline
+
+    @property
+    def plan_hash(self) -> str:
+        return self.plan.plan_hash
+
+    def _validate_pending_slot(self, slot: _TrialSlot) -> None:
+        current_spec = slot.trial.trajectory
+        if current_spec.records:
+            raise RuntimeError(
+                f"planned Trial has already started: {current_spec.trial_id}"
+            )
+        if (
+            _configuration_hash(_trajectory_spec(current_spec))
+            != self.plan._spec_hash(slot.variant, slot.position)
+        ):
+            raise ValueError(
+                f"planned Trial binding drifted before execution: {current_spec.trial_id}"
+            )
+        self._validate_live_declarations(slot)
+
+    def _validate_live_declarations(self, slot: _TrialSlot) -> None:
+        planned_spec = self.plan.trial_specs[slot.variant][slot.position]
+        live_configuration = _configuration_snapshot(
+            agent=slot.trial.agent,
+            environment=slot.trial.environment,
+            evaluator=slot.trial.evaluator,
+            max_actions=slot.trial.config.max_actions,
+        )
+        if live_configuration != planned_spec.configuration:
+            raise ValueError(
+                "planned Trial declarations drifted: "
+                f"{slot.trial.config.trial_id}"
+            )
+
+    def _slots_by_trial_id(self) -> Mapping[str, _TrialSlot]:
+        return MappingProxyType(
+            {
+                slot.trial.config.trial_id: slot
+                for variant_slots in self._slots.values()
+                for slot in variant_slots
+            }
+        )
+
+    async def run(self, store: JsonlTrajectoryStore) -> ExperimentResult:
+        """Run missing Trials sequentially and durably commit each terminal result."""
+        with store._writer():
+            existing = store._prepare(self.plan)
+            started_ids = {
+                trial_id
+                for variant_ids in existing.started_trial_ids.values()
+                for trial_id in variant_ids
+            }
+            slots_by_trial_id = self._slots_by_trial_id()
+
+            # A prior terminal append may have failed after the in-memory Trial
+            # reached a replay-valid terminal state. Finalize that exact outcome;
+            # never invoke a started Trial or a replacement Trial automatically.
+            for trial_id in started_ids:
+                slot = slots_by_trial_id[trial_id]
+                started_slot = (str(store.path), trial_id)
+                if started_slot not in self._recoverable_terminal_slots:
+                    continue
+                trajectory = slot.trial.trajectory
+                if not trajectory.records:
+                    continue
+                try:
+                    replay(trajectory)
+                except ValueError:
+                    continue
+                store._commit(self.plan, slot, trajectory)
+                self._recoverable_terminal_slots.discard(started_slot)
+
+            current = store._load_unlocked()
+            if current is None:
+                raise RuntimeError("Experiment Store lost its persisted plan")
+            committed_ids = {
+                result.trial_id
+                for variant_results in current.results.values()
+                for result in variant_results
+            }
+            blocked_ids = {
+                trial_id
+                for variant_ids in current.started_trial_ids.values()
+                for trial_id in variant_ids
+            }
+            pending_slots = tuple(
+                slot
+                for variant_slots in self._slots.values()
+                for slot in variant_slots
+                if slot.trial.config.trial_id not in committed_ids | blocked_ids
+            )
+
+            # Validate the whole pending batch before emitting any start marker or
+            # invoking any Environment effect.
+            for slot in pending_slots:
+                self._validate_pending_slot(slot)
+
+            for slot in pending_slots:
+                self._validate_pending_slot(slot)
+                store._start(self.plan, slot)
+                started_slot = (str(store.path), slot.trial.config.trial_id)
+                try:
+                    trial_result = await slot.trial.run()
+                except asyncio.CancelledError as cancellation:
+                    try:
+                        self._validate_live_declarations(slot)
+                    except Exception as validation_error:
+                        cancellation.add_note(
+                            "cancelled Trial declarations drifted; terminal state was "
+                            f"not persisted: {validation_error!r}"
+                        )
+                    else:
+                        self._recoverable_terminal_slots.add(started_slot)
+                        try:
+                            store._commit(self.plan, slot, slot.trial.trajectory)
+                        except Exception as persistence_error:
+                            cancellation.add_note(
+                                "failed to persist the cancelled Trial terminal state: "
+                                f"{persistence_error!r}"
+                            )
+                        else:
+                            self._recoverable_terminal_slots.discard(started_slot)
+                    raise
+                self._validate_live_declarations(slot)
+                self._recoverable_terminal_slots.add(started_slot)
+                store._commit(self.plan, slot, trial_result.trajectory)
+                self._recoverable_terminal_slots.discard(started_slot)
+
+            experiment_result = store._load_unlocked()
+            if experiment_result is None:
+                raise RuntimeError("Experiment Store lost its persisted plan")
+            return experiment_result

--- a/python/iamai/harness/_jsonl.py
+++ b/python/iamai/harness/_jsonl.py
@@ -1,0 +1,749 @@
+"""Append-only JSONL persistence for provisional harness Experiments."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import sys
+import threading
+from collections.abc import Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO, Iterator, cast
+
+from ._experiment import (
+    ExperimentPlan,
+    ExperimentResult,
+    _TrialSlot,
+    _trajectory_spec,
+)
+from ._model import (
+    FrozenJsonValue,
+    Task,
+    Trajectory,
+    TrajectoryRecord,
+    TrialResult,
+    _configuration_hash,
+    _thaw_json,
+)
+from ._replay import replay
+
+EXPERIMENT_STORE_FORMAT_VERSION = "1"
+MAX_JSONL_RECORD_BYTES = 16 * 1024 * 1024
+
+_ACTIVE_WRITERS: set[Path] = set()
+_ACTIVE_READERS: dict[Path, int] = {}
+_ACTIVE_WRITERS_GUARD = threading.Lock()
+
+
+def _lock_stream(stream: BinaryIO) -> None:
+    stream.seek(0, os.SEEK_END)
+    if stream.tell() == 0:
+        stream.write(b"\0")
+        stream.flush()
+    stream.seek(0)
+    if os.name == "nt":
+        msvcrt = importlib.import_module("msvcrt")
+        msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+        return
+    fcntl = importlib.import_module("fcntl")
+    fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_stream(stream: BinaryIO) -> None:
+    if os.name == "nt":
+        msvcrt = importlib.import_module("msvcrt")
+        stream.seek(0)
+        msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+    fcntl = importlib.import_module("fcntl")
+    fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+def _lock_reader_stream(stream: BinaryIO) -> None:
+    if os.name == "nt":
+        msvcrt = importlib.import_module("msvcrt")
+        stream.seek(0, os.SEEK_END)
+        if stream.tell() == 0:
+            if not stream.writable():
+                raise OSError("empty JSONL Store lock file is not readable on Windows")
+            stream.write(b"\0")
+            stream.flush()
+        stream.seek(0)
+        msvcrt.locking(stream.fileno(), msvcrt.LK_NBRLCK, 1)
+        return
+    fcntl = importlib.import_module("fcntl")
+    fcntl.flock(stream.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+
+
+def _open_reader_lock(path: Path) -> BinaryIO | None:
+    binary = getattr(os, "O_BINARY", 0)
+    writable = False
+    try:
+        descriptor = os.open(
+            path,
+            (os.O_RDWR if os.name == "nt" else os.O_RDONLY) | binary,
+        )
+        writable = os.name == "nt"
+    except FileNotFoundError:
+        try:
+            descriptor = os.open(
+                path,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | binary,
+                0o600,
+            )
+            writable = True
+        except FileExistsError:
+            descriptor = os.open(
+                path,
+                (os.O_RDWR if os.name == "nt" else os.O_RDONLY) | binary,
+            )
+            writable = os.name == "nt"
+        except PermissionError:
+            return None
+    except PermissionError:
+        if os.name != "nt":
+            raise
+        descriptor = os.open(path, os.O_RDONLY | binary)
+        if os.fstat(descriptor).st_size == 0:
+            os.close(descriptor)
+            return None
+    try:
+        return os.fdopen(descriptor, "a+b" if writable else "rb", buffering=0)
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _release_lock_stream(
+    stream: BinaryIO,
+    *,
+    locked: bool,
+    active_error: BaseException | None,
+) -> None:
+    cleanup_error: BaseException | None = None
+    if locked:
+        try:
+            _unlock_stream(stream)
+        except BaseException as error:
+            cleanup_error = error
+    try:
+        stream.close()
+    except BaseException as error:
+        if cleanup_error is None:
+            cleanup_error = error
+        else:
+            cleanup_error.add_note(f"also failed to close lock stream: {error!r}")
+    if cleanup_error is None:
+        return
+    if active_error is not None:
+        active_error.add_note(f"failed to release JSONL Store lock: {cleanup_error!r}")
+        return
+    raise cleanup_error
+
+
+def _path_signature(path: Path) -> tuple[int, int, int, int] | None:
+    try:
+        metadata = path.stat()
+    except FileNotFoundError:
+        return None
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _digest(value: object) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(value)).hexdigest()}"
+
+
+def _reject_json_constant(value: str) -> object:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+def _decode_entry(raw_line: bytes, *, path: Path, line_number: int) -> Mapping[str, object]:
+    if len(raw_line) > MAX_JSONL_RECORD_BYTES:
+        raise ValueError(f"JSONL Store record is too large at {path}:{line_number}")
+    try:
+        value = json.loads(
+            raw_line.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_json_constant,
+        )
+        entry = _object(value, field=f"record at line {line_number}")
+        if _canonical_json(entry) != raw_line:
+            raise ValueError("record is not canonical JSON")
+        return entry
+    except (UnicodeError, json.JSONDecodeError, ValueError) as error:
+        raise ValueError(
+            f"invalid JSONL Store record at {path}:{line_number}: {error}"
+        ) from error
+
+
+def _validate_entry_chain(
+    entries: list[Mapping[str, object]],
+    *,
+    path: Path,
+) -> None:
+    previous_digest: str | None = None
+    for expected_sequence, entry in enumerate(entries):
+        entry_digest = entry.get("entry_digest")
+        entry_sequence = entry.get("entry_sequence")
+        digest_payload = dict(entry)
+        digest_payload.pop("entry_digest", None)
+        if (
+            isinstance(entry_sequence, bool)
+            or not isinstance(entry_sequence, int)
+            or entry_sequence != expected_sequence
+            or entry.get("previous_entry_digest") != previous_digest
+            or not isinstance(entry_digest, str)
+            or entry_digest != _digest(digest_payload)
+        ):
+            raise ValueError(
+                f"invalid JSONL Store entry chain at {path}:{expected_sequence + 1}"
+            )
+        previous_digest = entry_digest
+
+
+def _trajectory_payload(trajectory: Trajectory) -> dict[str, object]:
+    return {
+        "format_version": trajectory.format_version,
+        "trial_id": trajectory.trial_id,
+        "task": {
+            "id": trajectory.task.id,
+            "input": _thaw_json(trajectory.task.input),
+        },
+        "seed": trajectory.seed,
+        "configuration": _thaw_json(trajectory.configuration),
+        "config_hash": trajectory.config_hash,
+        "records": [
+            {
+                "sequence": record.sequence,
+                "kind": record.kind,
+                "payload": _thaw_json(record.payload),
+            }
+            for record in trajectory.records
+        ],
+    }
+
+
+def _object(value: object, *, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"JSONL {field} must be an object")
+    return value
+
+
+def _trajectory_from_payload(value: object) -> Trajectory:
+    payload = _object(value, field="Trajectory")
+    task_payload = _object(payload.get("task"), field="Trajectory task")
+    records_payload = payload.get("records")
+    if not isinstance(records_payload, list):
+        raise ValueError("JSONL Trajectory records must be an array")
+    records: list[TrajectoryRecord] = []
+    for raw_record in records_payload:
+        record = _object(raw_record, field="Trajectory record")
+        records.append(
+            TrajectoryRecord(
+                sequence=record.get("sequence"),  # type: ignore[arg-type]
+                kind=record.get("kind"),  # type: ignore[arg-type]
+                payload=cast(
+                    Mapping[str, FrozenJsonValue],
+                    _object(
+                        record.get("payload"),
+                        field="Trajectory record payload",
+                    ),
+                ),
+            )
+        )
+    return Trajectory(
+        format_version=payload.get("format_version"),  # type: ignore[arg-type]
+        trial_id=payload.get("trial_id"),  # type: ignore[arg-type]
+        task=Task(
+            id=task_payload.get("id"),  # type: ignore[arg-type]
+            input=cast(FrozenJsonValue, task_payload.get("input")),
+        ),
+        seed=payload.get("seed"),  # type: ignore[arg-type]
+        configuration=cast(
+            Mapping[str, FrozenJsonValue],
+            _object(
+                payload.get("configuration"),
+                field="Trajectory configuration",
+            ),
+        ),
+        config_hash=payload.get("config_hash"),  # type: ignore[arg-type]
+        records=tuple(records),
+    )
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+class JsonlTrajectoryStore:
+    """Persist one Experiment manifest and its terminal Trajectories as JSONL."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path).expanduser().resolve()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @contextmanager
+    def _writer(self) -> Iterator[None]:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with _ACTIVE_WRITERS_GUARD:
+            if self.path in _ACTIVE_WRITERS:
+                raise RuntimeError(
+                    f"JSONL Store already has an active writer: {self.path}"
+                )
+            if _ACTIVE_READERS.get(self.path, 0):
+                raise RuntimeError(
+                    f"JSONL Store already has an active reader: {self.path}"
+                )
+            _ACTIVE_WRITERS.add(self.path)
+        lock_path = self.path.with_name(f"{self.path.name}.lock")
+        stream: BinaryIO | None = None
+        locked = False
+        try:
+            descriptor = os.open(
+                lock_path,
+                os.O_RDWR | os.O_CREAT | getattr(os, "O_BINARY", 0),
+                0o600,
+            )
+            stream = os.fdopen(descriptor, "a+b", buffering=0)
+            try:
+                _lock_stream(stream)
+            except OSError as error:
+                raise RuntimeError(
+                    f"JSONL Store already has an active writer: {self.path}"
+                ) from error
+            locked = True
+            yield
+        finally:
+            active_error = sys.exception()
+            try:
+                if stream is not None:
+                    _release_lock_stream(
+                        stream,
+                        locked=locked,
+                        active_error=active_error,
+                    )
+            finally:
+                with _ACTIVE_WRITERS_GUARD:
+                    _ACTIVE_WRITERS.discard(self.path)
+
+    @contextmanager
+    def _reader(self) -> Iterator[None]:
+        with _ACTIVE_WRITERS_GUARD:
+            if self.path in _ACTIVE_WRITERS:
+                raise RuntimeError(
+                    f"JSONL Store already has an active writer: {self.path}"
+                )
+            _ACTIVE_READERS[self.path] = _ACTIVE_READERS.get(self.path, 0) + 1
+        lock_path = self.path.with_name(f"{self.path.name}.lock")
+        stream: BinaryIO | None = None
+        locked = False
+        try:
+            stream = _open_reader_lock(lock_path)
+            fallback_signature = None
+            if stream is None:
+                fallback_signature = _path_signature(lock_path)
+                if fallback_signature is not None and fallback_signature[2] > 0:
+                    stream = _open_reader_lock(lock_path)
+                    if stream is None:
+                        fallback_signature = _path_signature(lock_path)
+            if stream is not None:
+                try:
+                    _lock_reader_stream(stream)
+                except OSError as error:
+                    raise RuntimeError(
+                        f"JSONL Store already has an active writer: {self.path}"
+                    ) from error
+                locked = True
+            yield
+            if stream is None and _path_signature(lock_path) != fallback_signature:
+                raise RuntimeError(
+                    f"JSONL Store lock changed while being read: {self.path}"
+                )
+        finally:
+            active_error = sys.exception()
+            try:
+                if stream is not None:
+                    _release_lock_stream(
+                        stream,
+                        locked=locked,
+                        active_error=active_error,
+                    )
+            finally:
+                with _ACTIVE_WRITERS_GUARD:
+                    remaining = _ACTIVE_READERS[self.path] - 1
+                    if remaining:
+                        _ACTIVE_READERS[self.path] = remaining
+                    else:
+                        del _ACTIVE_READERS[self.path]
+
+    def _append(self, payload: Mapping[str, object]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        previous_digest: str | None = None
+        sequence = 0
+        if self.path.exists() and self.path.stat().st_size:
+            content = self.path.read_bytes()
+            if not content.endswith(b"\n"):
+                raise ValueError(f"torn JSONL Store record at {self.path}")
+            entries: list[Mapping[str, object]] = []
+            for line_number, raw_line in enumerate(
+                content[:-1].split(b"\n"),
+                start=1,
+            ):
+                entries.append(
+                    _decode_entry(
+                        raw_line,
+                        path=self.path,
+                        line_number=line_number,
+                    )
+                )
+            _validate_entry_chain(entries, path=self.path)
+            sequence = len(entries)
+            last_digest = entries[-1].get("entry_digest")
+            if not isinstance(last_digest, str):
+                raise AssertionError("validated JSONL entry digest was not a string")
+            previous_digest = last_digest
+        envelope = {
+            **payload,
+            "entry_sequence": sequence,
+            "previous_entry_digest": previous_digest,
+        }
+        envelope["entry_digest"] = _digest(envelope)
+        encoded = _canonical_json(envelope) + b"\n"
+        if len(encoded) - 1 > MAX_JSONL_RECORD_BYTES:
+            raise ValueError(f"JSONL Store record is too large: {len(encoded) - 1} bytes")
+        descriptor = os.open(
+            self.path,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        with os.fdopen(descriptor, "ab", buffering=0) as stream:
+            written = stream.write(encoded)
+            if written != len(encoded):
+                raise OSError("short JSONL write")
+            os.fsync(stream.fileno())
+        _fsync_directory(self.path.parent)
+
+    def _sync_unlocked(self) -> None:
+        flags = os.O_RDONLY if os.name != "nt" else os.O_RDWR
+        descriptor = os.open(self.path, flags | getattr(os, "O_BINARY", 0))
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        _fsync_directory(self.path.parent)
+
+    def repair_tail(self) -> bool:
+        """Discard one unterminated final record after validating the complete prefix."""
+        with self._writer():
+            return self._repair_tail()
+
+    def _repair_tail(self) -> bool:
+        if not self.path.exists():
+            return False
+        content = self.path.read_bytes()
+        if not content or content.endswith(b"\n"):
+            return False
+        prefix_end = content.rfind(b"\n") + 1
+        prefix = content[:prefix_end]
+        entries: list[Mapping[str, object]] = []
+        raw_lines = prefix[:-1].split(b"\n") if prefix else []
+        for line_number, raw_line in enumerate(raw_lines, start=1):
+            entries.append(
+                _decode_entry(
+                    raw_line,
+                    path=self.path,
+                    line_number=line_number,
+                )
+            )
+        _validate_entry_chain(entries, path=self.path)
+        with self.path.open("r+b") as stream:
+            stream.truncate(prefix_end)
+            stream.flush()
+            os.fsync(stream.fileno())
+        _fsync_directory(self.path.parent)
+        return True
+
+    def _prepare(self, plan: ExperimentPlan) -> ExperimentResult:
+        existing = self._load_unlocked()
+        if existing is not None:
+            if existing.plan_hash != plan.plan_hash:
+                raise ValueError("JSONL Store contains a different Experiment plan")
+            self._sync_unlocked()
+            return existing
+        self._append(
+            {
+                "record_type": "experiment.plan",
+                "store_format_version": EXPERIMENT_STORE_FORMAT_VERSION,
+                "plan": _thaw_json(plan._payload),
+                "plan_hash": plan.plan_hash,
+            }
+        )
+        prepared = self._load_unlocked()
+        if prepared is None:
+            raise RuntimeError("JSONL Store did not persist the Experiment plan")
+        return prepared
+
+    def _commit(
+        self,
+        plan: ExperimentPlan,
+        slot: _TrialSlot,
+        trajectory: Trajectory,
+    ) -> None:
+        planned_spec = plan.trial_specs[slot.variant][slot.position]
+        spec_hash = plan._spec_hash(slot.variant, slot.position)
+        if trajectory.trial_id != planned_spec.trial_id:
+            raise ValueError("Trajectory does not match its Experiment slot")
+        if _configuration_hash(_trajectory_spec(trajectory)) != spec_hash:
+            raise ValueError("Trajectory provenance does not match its Experiment plan")
+        replay(trajectory)
+        trajectory_payload = _trajectory_payload(trajectory)
+        self._append(
+            {
+                "record_type": "trajectory.committed",
+                "store_format_version": EXPERIMENT_STORE_FORMAT_VERSION,
+                "experiment_id": plan.experiment_id,
+                "plan_hash": plan.plan_hash,
+                "variant": slot.variant,
+                "position": slot.position,
+                "trial_id": trajectory.trial_id,
+                "spec_hash": spec_hash,
+                "trajectory": trajectory_payload,
+                "trajectory_digest": _digest(trajectory_payload),
+            }
+        )
+
+    def _start(self, plan: ExperimentPlan, slot: _TrialSlot) -> None:
+        planned_spec = plan.trial_specs[slot.variant][slot.position]
+        self._append(
+            {
+                "record_type": "trial.started",
+                "store_format_version": EXPERIMENT_STORE_FORMAT_VERSION,
+                "experiment_id": plan.experiment_id,
+                "plan_hash": plan.plan_hash,
+                "variant": slot.variant,
+                "position": slot.position,
+                "trial_id": planned_spec.trial_id,
+                "spec_hash": plan._spec_hash(slot.variant, slot.position),
+            }
+        )
+
+    def load(self) -> ExperimentResult | None:
+        """Load and validate the Experiment results currently committed to this Store."""
+        with _ACTIVE_WRITERS_GUARD:
+            if self.path in _ACTIVE_WRITERS:
+                raise RuntimeError(
+                    f"JSONL Store already has an active writer: {self.path}"
+                )
+        if not self.path.exists() or self.path.stat().st_size == 0:
+            return None
+        with self._reader():
+            return self._load_unlocked()
+
+    def _load_unlocked(self) -> ExperimentResult | None:
+        if not self.path.exists() or self.path.stat().st_size == 0:
+            return None
+        before = self.path.stat()
+        content = self.path.read_bytes()
+        after = self.path.stat()
+        if (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        ) != (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+        ):
+            raise RuntimeError(f"JSONL Store changed while being read: {self.path}")
+        if not content.endswith(b"\n"):
+            line_number = content.count(b"\n") + 1
+            raise ValueError(
+                f"torn JSONL Store record at {self.path}:{line_number}"
+            )
+        raw_lines = content[:-1].split(b"\n")
+        if not raw_lines:
+            return None
+        entries: list[Mapping[str, object]] = []
+        for line_number, raw_line in enumerate(raw_lines, start=1):
+            entries.append(
+                _decode_entry(
+                    raw_line,
+                    path=self.path,
+                    line_number=line_number,
+                )
+            )
+        _validate_entry_chain(entries, path=self.path)
+
+        manifest = entries[0]
+        if manifest.get("record_type") != "experiment.plan":
+            raise ValueError("JSONL Store must start with an Experiment plan")
+        if manifest.get("store_format_version") != EXPERIMENT_STORE_FORMAT_VERSION:
+            raise ValueError("unsupported JSONL Store format version")
+        plan_payload = _object(manifest.get("plan"), field="Experiment plan")
+        stored_plan_hash = manifest.get("plan_hash")
+        if not isinstance(stored_plan_hash, str):
+            raise ValueError("JSONL Store Experiment plan hash is invalid")
+        experiment_id = plan_payload.get("experiment_id")
+        version = plan_payload.get("version")
+        baseline = plan_payload.get("baseline")
+        provenance = plan_payload.get("provenance")
+        variants_payload = plan_payload.get("variants")
+        if not isinstance(experiment_id, str) or not isinstance(version, str):
+            raise ValueError("JSONL Store Experiment identity is invalid")
+        if baseline is not None and not isinstance(baseline, str):
+            raise ValueError("JSONL Store Experiment baseline is invalid")
+        if not isinstance(provenance, Mapping):
+            raise ValueError("JSONL Store Experiment provenance is invalid")
+        if not isinstance(variants_payload, list) or not variants_payload:
+            raise ValueError("JSONL Store Experiment variants are invalid")
+
+        trial_specs: dict[str, tuple[Trajectory, ...]] = {}
+        slots: dict[tuple[str, int], tuple[str, str]] = {}
+        for raw_variant in variants_payload:
+            variant_payload = _object(raw_variant, field="Experiment variant")
+            variant = variant_payload.get("name")
+            raw_trials = variant_payload.get("trials")
+            if not isinstance(variant, str) or not isinstance(raw_trials, list):
+                raise ValueError("JSONL Store Experiment variant is invalid")
+            if variant in trial_specs:
+                raise ValueError("JSONL Store Experiment variant is duplicate")
+            specs: list[Trajectory] = []
+            for raw_slot in raw_trials:
+                slot_payload = _object(raw_slot, field="Experiment Trial slot")
+                position = slot_payload.get("position")
+                spec = _object(slot_payload.get("spec"), field="Experiment Trial spec")
+                spec_hash = slot_payload.get("spec_hash")
+                trial_id = spec.get("trial_id")
+                if (
+                    isinstance(position, bool)
+                    or not isinstance(position, int)
+                    or position != len(specs)
+                    or not isinstance(trial_id, str)
+                    or not isinstance(spec_hash, str)
+                    or spec_hash
+                    != _configuration_hash(cast(Mapping[str, FrozenJsonValue], spec))
+                ):
+                    raise ValueError("JSONL Store Experiment Trial slot is invalid")
+                if "records" in spec:
+                    raise ValueError("JSONL Store Experiment Trial spec is invalid")
+                trajectory_spec = _trajectory_from_payload({**spec, "records": []})
+                slots[(variant, position)] = (trial_id, spec_hash)
+                specs.append(trajectory_spec)
+            trial_specs[variant] = tuple(specs)
+
+        plan = ExperimentPlan(
+            experiment_id=experiment_id,
+            version=version,
+            trial_specs=trial_specs,
+            baseline=baseline,
+            provenance=cast(Mapping[str, FrozenJsonValue], provenance),
+        )
+        if plan.plan_hash != stored_plan_hash:
+            raise ValueError("JSONL Store Experiment plan hash does not match")
+        planned = dict(plan.planned_trial_ids)
+
+        collected: dict[str, list[tuple[int, TrialResult]]] = {
+            variant: [] for variant in planned
+        }
+        started_slots: set[tuple[str, int]] = set()
+        committed_trial_ids: set[str] = set()
+        for line_number, entry in enumerate(entries[1:], start=2):
+            record_type = entry.get("record_type")
+            if record_type not in {"trial.started", "trajectory.committed"}:
+                raise ValueError(f"invalid JSONL Store record type at {self.path}:{line_number}")
+            if entry.get("store_format_version") != EXPERIMENT_STORE_FORMAT_VERSION:
+                raise ValueError("unsupported JSONL Store format version")
+            if (
+                entry.get("experiment_id") != experiment_id
+                or entry.get("plan_hash") != stored_plan_hash
+            ):
+                raise ValueError("JSONL Store Trajectory does not match its Experiment")
+            variant = entry.get("variant")
+            position = entry.get("position")
+            trial_id = entry.get("trial_id")
+            if not isinstance(variant, str) or isinstance(position, bool) or not isinstance(
+                position, int
+            ):
+                raise ValueError("JSONL Store Trajectory slot is invalid")
+            declared_slot = slots.get((variant, position))
+            if (
+                declared_slot is None
+                or not isinstance(trial_id, str)
+                or declared_slot[0] != trial_id
+                or entry.get("spec_hash") != declared_slot[1]
+            ):
+                raise ValueError("JSONL Store Trial record is unplanned")
+            slot_key = (variant, position)
+            if record_type == "trial.started":
+                if slot_key in started_slots or trial_id in committed_trial_ids:
+                    raise ValueError("JSONL Store Trial start is duplicate")
+                started_slots.add(slot_key)
+                continue
+            if slot_key not in started_slots or trial_id in committed_trial_ids:
+                raise ValueError("JSONL Store Trajectory is duplicate or was not started")
+            trajectory_payload = _object(entry.get("trajectory"), field="Trajectory")
+            if entry.get("trajectory_digest") != _digest(trajectory_payload):
+                raise ValueError("JSONL Store Trajectory digest does not match")
+            trajectory = _trajectory_from_payload(trajectory_payload)
+            if _configuration_hash(_trajectory_spec(trajectory)) != declared_slot[1]:
+                raise ValueError("JSONL Store Trajectory provenance does not match its plan")
+            result = replay(trajectory)
+            committed_trial_ids.add(trial_id)
+            collected[variant].append((position, result))
+
+        return ExperimentResult(
+            plan=plan,
+            results={
+                variant: tuple(
+                    result for _, result in sorted(variant_results, key=lambda item: item[0])
+                )
+                for variant, variant_results in collected.items()
+            },
+            started_trial_ids={
+                variant: tuple(
+                    trial_id
+                    for position, trial_id in enumerate(trial_ids)
+                    if (variant, position) in started_slots
+                    and trial_id not in committed_trial_ids
+                )
+                for variant, trial_ids in planned.items()
+            },
+        )

--- a/python/iamai/harness/_model.py
+++ b/python/iamai/harness/_model.py
@@ -1,0 +1,354 @@
+"""Immutable domain values for the provisional general-agent harness."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import TypeAlias
+
+JsonValue: TypeAlias = (
+    None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+)
+FrozenJsonValue: TypeAlias = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | tuple["FrozenJsonValue", ...]
+    | Mapping[str, "FrozenJsonValue"]
+)
+
+TRAJECTORY_FORMAT_VERSION = "1"
+HARNESS_CONFIGURATION_VERSION = "1"
+
+
+def _freeze_json(value: object, *, path: str = "$") -> FrozenJsonValue:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} must contain a finite JSON number")
+        return value
+    if isinstance(value, Mapping):
+        frozen: dict[str, FrozenJsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} must contain string object keys")
+            frozen[key] = _freeze_json(item, path=f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _freeze_json(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        )
+    raise TypeError(f"{path} must contain only JSON-compatible values")
+
+
+def _thaw_json(value: FrozenJsonValue) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _frozen_object(**values: object) -> Mapping[str, FrozenJsonValue]:
+    frozen = _freeze_json(values)
+    if not isinstance(frozen, Mapping):
+        raise AssertionError("frozen object did not produce a mapping")
+    return frozen
+
+
+def _configuration_hash(configuration: Mapping[str, FrozenJsonValue]) -> str:
+    canonical = json.dumps(
+        _thaw_json(configuration),
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+@dataclass(frozen=True, slots=True)
+class Task:
+    """Goal and initial input for one Trial."""
+
+    id: str
+    input: FrozenJsonValue
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str):
+            raise TypeError("task id must be a string")
+        if not self.id.strip():
+            raise ValueError("task id cannot be empty")
+        object.__setattr__(self, "input", _freeze_json(self.input, path="$.task.input"))
+
+
+@dataclass(frozen=True, slots=True)
+class TrialConfig:
+    """Identity, deterministic seed, and Action budget for one Trial."""
+
+    trial_id: str
+    seed: int = 0
+    max_actions: int = 8
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.trial_id, str):
+            raise TypeError("trial_id must be a string")
+        if not self.trial_id.strip():
+            raise ValueError("trial id cannot be empty")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise TypeError("seed must be an integer")
+        if isinstance(self.max_actions, bool) or not isinstance(self.max_actions, int):
+            raise TypeError("max_actions must be an integer")
+        if self.max_actions <= 0:
+            raise ValueError("max_actions must be greater than zero")
+
+
+class TrialStatus(str, Enum):
+    """Terminal state of a Trial."""
+
+    COMPLETED = "completed"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """Information exposed by an Environment for the next Agent decision."""
+
+    value: FrozenJsonValue
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "value", _freeze_json(self.value, path="$.observation"))
+
+
+@dataclass(frozen=True, slots=True)
+class Action:
+    """An Environment interaction or final answer proposed by an Agent."""
+
+    name: str
+    payload: FrozenJsonValue = None
+    is_final: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str):
+            raise TypeError("action name must be a string")
+        if not self.name.strip():
+            raise ValueError("action name cannot be empty")
+        if not isinstance(self.is_final, bool):
+            raise TypeError("action is_final must be a bool")
+        object.__setattr__(
+            self,
+            "payload",
+            _freeze_json(self.payload, path="$.action.payload"),
+        )
+
+    @classmethod
+    def invoke(
+        cls,
+        name: str,
+        arguments: Mapping[str, JsonValue] | None = None,
+    ) -> "Action":
+        """Create an Environment invocation."""
+        return cls(name=name, payload=_freeze_json(arguments or {}))
+
+    @classmethod
+    def finish(cls, output: JsonValue) -> "Action":
+        """Create a conventional final-answer Action for compatible Environments."""
+        return cls(name="final", payload=_freeze_json(output), is_final=True)
+
+
+@dataclass(frozen=True, slots=True)
+class Transition:
+    """Committed outcome of applying one Action to an Environment."""
+
+    observation: Observation
+    terminated: bool = False
+    output: FrozenJsonValue = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.observation, Observation):
+            raise TypeError("Transition observation must be an Observation")
+        if not isinstance(self.terminated, bool):
+            raise TypeError("Transition terminated must be a bool")
+        object.__setattr__(
+            self,
+            "output",
+            _freeze_json(self.output, path="$.transition.output"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Evaluation:
+    """Versioned judgment of a committed Trial Trajectory."""
+
+    passed: bool
+    score: float
+    evaluator: str
+    evaluator_version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.passed, bool):
+            raise TypeError("Evaluation passed must be a bool")
+        if isinstance(self.score, bool) or not isinstance(self.score, (int, float)):
+            raise TypeError("Evaluation score must be a number")
+        score = float(self.score)
+        if not math.isfinite(score):
+            raise ValueError("Evaluation score must be finite")
+        if not isinstance(self.evaluator, str) or not self.evaluator.strip():
+            raise ValueError("Evaluation evaluator cannot be empty")
+        if not isinstance(self.evaluator_version, str) or not self.evaluator_version.strip():
+            raise ValueError("Evaluation evaluator_version cannot be empty")
+        object.__setattr__(self, "score", score)
+
+
+@dataclass(frozen=True, slots=True)
+class TrajectoryRecord:
+    """One immutable, causally ordered fact in a Trajectory."""
+
+    sequence: int
+    kind: str
+    payload: Mapping[str, FrozenJsonValue]
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.sequence, bool)
+            or not isinstance(self.sequence, int)
+            or self.sequence < 0
+        ):
+            raise ValueError("Trajectory record sequence must be a non-negative integer")
+        if not isinstance(self.kind, str) or not self.kind.strip():
+            raise ValueError("Trajectory record kind cannot be empty")
+        payload = _freeze_json(self.payload, path="$.trajectory.record.payload")
+        if not isinstance(payload, Mapping):
+            raise TypeError("Trajectory record payload must be an object")
+        object.__setattr__(self, "payload", payload)
+
+
+@dataclass(frozen=True, slots=True)
+class Trajectory:
+    """Immutable source of truth for one Trial."""
+
+    format_version: str
+    trial_id: str
+    task: Task
+    seed: int
+    configuration: Mapping[str, FrozenJsonValue]
+    config_hash: str
+    records: tuple[TrajectoryRecord, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.format_version, str) or not self.format_version.strip():
+            raise ValueError("Trajectory format version cannot be empty")
+        if not isinstance(self.trial_id, str) or not self.trial_id.strip():
+            raise ValueError("Trajectory trial id cannot be empty")
+        if not isinstance(self.task, Task):
+            raise TypeError("Trajectory task must be a Task")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise TypeError("Trajectory seed must be an integer")
+        configuration = _freeze_json(
+            self.configuration,
+            path="$.trajectory.configuration",
+        )
+        if not isinstance(configuration, Mapping):
+            raise TypeError("Trajectory configuration must be an object")
+        records = tuple(self.records)
+        if not all(isinstance(record, TrajectoryRecord) for record in records):
+            raise TypeError("Trajectory records must contain TrajectoryRecord values")
+        if not isinstance(self.config_hash, str) or not self.config_hash.strip():
+            raise ValueError("Trajectory configuration hash cannot be empty")
+        object.__setattr__(self, "configuration", configuration)
+        object.__setattr__(self, "records", records)
+
+
+@dataclass(frozen=True, slots=True)
+class TrialFailure:
+    """Attributed failure captured while running one Trial phase."""
+
+    phase: str
+    code: str
+    exception_type: str
+    message: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("phase", "code", "exception_type"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"TrialFailure {field_name} cannot be empty")
+        if not isinstance(self.message, str):
+            raise TypeError("TrialFailure message must be a string")
+
+
+@dataclass(frozen=True, slots=True)
+class TrialResult:
+    """Terminal public result returned by a Trial."""
+
+    trial_id: str
+    status: TrialStatus
+    final_output: FrozenJsonValue
+    evaluation: Evaluation | None
+    trajectory: Trajectory
+    failure: TrialFailure | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.trial_id, str) or not self.trial_id.strip():
+            raise ValueError("TrialResult trial_id cannot be empty")
+        if not isinstance(self.status, TrialStatus):
+            raise TypeError("TrialResult status must be a TrialStatus")
+        if not isinstance(self.trajectory, Trajectory):
+            raise TypeError("TrialResult trajectory must be a Trajectory")
+        if self.trial_id != self.trajectory.trial_id:
+            raise ValueError("TrialResult trial_id must match its Trajectory")
+        if self.evaluation is not None and not isinstance(self.evaluation, Evaluation):
+            raise TypeError("TrialResult evaluation must be an Evaluation or None")
+        if self.failure is not None and not isinstance(self.failure, TrialFailure):
+            raise TypeError("TrialResult failure must be a TrialFailure or None")
+        if self.status in {TrialStatus.COMPLETED, TrialStatus.BUDGET_EXHAUSTED}:
+            if self.evaluation is None or self.failure is not None:
+                raise ValueError("evaluated TrialResult has inconsistent outcome fields")
+        elif self.status is TrialStatus.FAILED:
+            if self.evaluation is not None or self.failure is None:
+                raise ValueError("failed TrialResult has inconsistent outcome fields")
+        elif self.evaluation is not None or self.failure is not None:
+            raise ValueError("cancelled TrialResult cannot contain Evaluation or failure")
+        if self.status is not TrialStatus.COMPLETED and self.final_output is not None:
+            raise ValueError("only a completed TrialResult can contain final output")
+        object.__setattr__(
+            self,
+            "final_output",
+            _freeze_json(self.final_output, path="$.trial_result.final_output"),
+        )
+
+
+def _action_payload(action: Action) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        name=action.name,
+        payload=action.payload,
+        is_final=action.is_final,
+    )
+
+
+def _transition_payload(transition: Transition) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        observation=transition.observation.value,
+        terminated=transition.terminated,
+        output=transition.output,
+    )
+
+
+def _evaluation_payload(evaluation: Evaluation) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        passed=evaluation.passed,
+        score=evaluation.score,
+        evaluator=evaluation.evaluator,
+        evaluator_version=evaluation.evaluator_version,
+    )

--- a/python/iamai/harness/_model.py
+++ b/python/iamai/harness/_model.py
@@ -26,10 +26,33 @@ FrozenJsonValue: TypeAlias = (
 
 TRAJECTORY_FORMAT_VERSION = "1"
 HARNESS_CONFIGURATION_VERSION = "1"
+_MAX_JSON_NESTING_DEPTH = 128
 
 
-def _freeze_json(value: object, *, path: str = "$") -> FrozenJsonValue:
-    if value is None or isinstance(value, (bool, int, str)):
+def _freeze_json(
+    value: object,
+    *,
+    path: str = "$",
+    _depth: int = 0,
+) -> FrozenJsonValue:
+    if _depth > _MAX_JSON_NESTING_DEPTH:
+        raise ValueError(
+            f"{path} exceeds the maximum JSON nesting depth "
+            f"of {_MAX_JSON_NESTING_DEPTH}"
+        )
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ValueError(f"{path} contains a string that is not valid Unicode") from exc
+        return value
+    if isinstance(value, int):
+        try:
+            json.dumps(value, allow_nan=False)
+        except ValueError as exc:
+            raise ValueError(f"{path} contains a JSON integer that is too large") from exc
         return value
     if isinstance(value, float):
         if not math.isfinite(value):
@@ -40,11 +63,25 @@ def _freeze_json(value: object, *, path: str = "$") -> FrozenJsonValue:
         for key, item in value.items():
             if not isinstance(key, str):
                 raise TypeError(f"{path} must contain string object keys")
-            frozen[key] = _freeze_json(item, path=f"{path}.{key}")
+            try:
+                key.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                raise ValueError(
+                    f"{path} contains an object key that is not valid Unicode"
+                ) from exc
+            frozen[key] = _freeze_json(
+                item,
+                path=f"{path}.{key}",
+                _depth=_depth + 1,
+            )
         return MappingProxyType(frozen)
     if isinstance(value, (list, tuple)):
         return tuple(
-            _freeze_json(item, path=f"{path}[{index}]")
+            _freeze_json(
+                item,
+                path=f"{path}[{index}]",
+                _depth=_depth + 1,
+            )
             for index, item in enumerate(value)
         )
     raise TypeError(f"{path} must contain only JSON-compatible values")
@@ -88,6 +125,7 @@ class Task:
             raise TypeError("task id must be a string")
         if not self.id.strip():
             raise ValueError("task id cannot be empty")
+        _freeze_json(self.id, path="$.task.id")
         object.__setattr__(self, "input", _freeze_json(self.input, path="$.task.input"))
 
 
@@ -104,12 +142,15 @@ class TrialConfig:
             raise TypeError("trial_id must be a string")
         if not self.trial_id.strip():
             raise ValueError("trial id cannot be empty")
+        _freeze_json(self.trial_id, path="$.trial_config.trial_id")
         if isinstance(self.seed, bool) or not isinstance(self.seed, int):
             raise TypeError("seed must be an integer")
+        _freeze_json(self.seed, path="$.trial_config.seed")
         if isinstance(self.max_actions, bool) or not isinstance(self.max_actions, int):
             raise TypeError("max_actions must be an integer")
         if self.max_actions <= 0:
             raise ValueError("max_actions must be greater than zero")
+        _freeze_json(self.max_actions, path="$.trial_config.max_actions")
 
 
 class TrialStatus(str, Enum):
@@ -144,6 +185,7 @@ class Action:
             raise TypeError("action name must be a string")
         if not self.name.strip():
             raise ValueError("action name cannot be empty")
+        _freeze_json(self.name, path="$.action.name")
         if not isinstance(self.is_final, bool):
             raise TypeError("action is_final must be a bool")
         object.__setattr__(
@@ -208,6 +250,11 @@ class Evaluation:
             raise ValueError("Evaluation evaluator cannot be empty")
         if not isinstance(self.evaluator_version, str) or not self.evaluator_version.strip():
             raise ValueError("Evaluation evaluator_version cannot be empty")
+        _freeze_json(self.evaluator, path="$.evaluation.evaluator")
+        _freeze_json(
+            self.evaluator_version,
+            path="$.evaluation.evaluator_version",
+        )
         object.__setattr__(self, "score", score)
 
 
@@ -226,8 +273,10 @@ class TrajectoryRecord:
             or self.sequence < 0
         ):
             raise ValueError("Trajectory record sequence must be a non-negative integer")
+        _freeze_json(self.sequence, path="$.trajectory.record.sequence")
         if not isinstance(self.kind, str) or not self.kind.strip():
             raise ValueError("Trajectory record kind cannot be empty")
+        _freeze_json(self.kind, path="$.trajectory.record.kind")
         payload = _freeze_json(self.payload, path="$.trajectory.record.payload")
         if not isinstance(payload, Mapping):
             raise TypeError("Trajectory record payload must be an object")
@@ -251,10 +300,13 @@ class Trajectory:
             raise ValueError("Trajectory format version cannot be empty")
         if not isinstance(self.trial_id, str) or not self.trial_id.strip():
             raise ValueError("Trajectory trial id cannot be empty")
+        _freeze_json(self.format_version, path="$.trajectory.format_version")
+        _freeze_json(self.trial_id, path="$.trajectory.trial_id")
         if not isinstance(self.task, Task):
             raise TypeError("Trajectory task must be a Task")
         if isinstance(self.seed, bool) or not isinstance(self.seed, int):
             raise TypeError("Trajectory seed must be an integer")
+        _freeze_json(self.seed, path="$.trajectory.seed")
         configuration = _freeze_json(
             self.configuration,
             path="$.trajectory.configuration",
@@ -266,6 +318,7 @@ class Trajectory:
             raise TypeError("Trajectory records must contain TrajectoryRecord values")
         if not isinstance(self.config_hash, str) or not self.config_hash.strip():
             raise ValueError("Trajectory configuration hash cannot be empty")
+        _freeze_json(self.config_hash, path="$.trajectory.config_hash")
         object.__setattr__(self, "configuration", configuration)
         object.__setattr__(self, "records", records)
 
@@ -284,8 +337,10 @@ class TrialFailure:
             value = getattr(self, field_name)
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"TrialFailure {field_name} cannot be empty")
+            _freeze_json(value, path=f"$.trial_failure.{field_name}")
         if not isinstance(self.message, str):
             raise TypeError("TrialFailure message must be a string")
+        _freeze_json(self.message, path="$.trial_failure.message")
 
 
 @dataclass(frozen=True, slots=True)
@@ -302,6 +357,7 @@ class TrialResult:
     def __post_init__(self) -> None:
         if not isinstance(self.trial_id, str) or not self.trial_id.strip():
             raise ValueError("TrialResult trial_id cannot be empty")
+        _freeze_json(self.trial_id, path="$.trial_result.trial_id")
         if not isinstance(self.status, TrialStatus):
             raise TypeError("TrialResult status must be a TrialStatus")
         if not isinstance(self.trajectory, Trajectory):

--- a/python/iamai/harness/_replay.py
+++ b/python/iamai/harness/_replay.py
@@ -3,7 +3,20 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
+import math
+from typing import cast
 
+from ._controlled import (
+    CONTROLLED_EXECUTION_VERSION,
+    TOOL_SCHEMA_VERSION,
+    TOOL_SPEC_VERSION,
+    ApprovalRequest,
+    ToolCallStatus,
+    _canonical_names,
+    _validate_schema_definition,
+    _validate_schema_instance,
+)
 from ._model import (
     HARNESS_CONFIGURATION_VERSION,
     TRAJECTORY_FORMAT_VERSION,
@@ -14,11 +27,438 @@ from ._model import (
     TrialResult,
     TrialStatus,
     _configuration_hash,
+    _frozen_object,
 )
 
 
 def _causal_error(reason: str) -> ValueError:
     return ValueError(f"invalid Trajectory causal order: {reason}")
+
+
+@dataclass(slots=True)
+class _ControlledReplayLedger:
+    max_tool_calls: int
+    max_tokens: int
+    max_cost_microunits: int
+    calls: int = 0
+    tokens: int = 0
+    cost_microunits: int = 0
+    poisoned: bool = False
+
+
+def _declared_names(
+    declaration: Mapping[str, FrozenJsonValue],
+    field_name: str,
+) -> tuple[str, ...]:
+    value = declaration.get(field_name)
+    if not isinstance(value, tuple) or not all(
+        isinstance(item, str) for item in value
+    ):
+        raise _causal_error(f"controlled declaration {field_name} is invalid")
+    names = cast(tuple[str, ...], value)
+    try:
+        canonical = _canonical_names(names, field_name=field_name)
+    except (TypeError, ValueError) as exc:
+        raise _causal_error(
+            f"controlled declaration {field_name} is invalid"
+        ) from exc
+    if names != canonical:
+        raise _causal_error(
+            f"controlled declaration {field_name} is not canonical"
+        )
+    return names
+
+
+def _require_exact_fields(
+    declaration: Mapping[str, FrozenJsonValue],
+    expected: set[str],
+    *,
+    field_name: str,
+) -> None:
+    if set(declaration) != expected:
+        raise _causal_error(f"controlled {field_name} fields are invalid")
+
+
+def _non_negative_record_int(value: FrozenJsonValue, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise _causal_error(f"{field_name} must be a non-negative integer")
+    return value
+
+
+def _expect_tool_outcome(
+    *,
+    actual_status: ToolCallStatus,
+    actual_error: FrozenJsonValue,
+    expected_status: ToolCallStatus,
+    expected_errors: str | tuple[str, ...] | None,
+    stage: str,
+) -> None:
+    if actual_status is not expected_status:
+        raise _causal_error(f"Tool Call status does not match {stage}")
+    if expected_errors is None:
+        if actual_error is not None:
+            raise _causal_error(f"Tool Call error does not match {stage}")
+        return
+    errors = (expected_errors,) if isinstance(expected_errors, str) else expected_errors
+    if actual_error not in errors:
+        raise _causal_error(f"Tool Call error does not match {stage}")
+
+
+def _zero_tool_usage(
+    usage: Mapping[str, FrozenJsonValue],
+    charged: Mapping[str, FrozenJsonValue],
+    *,
+    stage: str,
+) -> None:
+    if any(
+        payload.get(field_name) != 0
+        for payload in (usage, charged)
+        for field_name in ("tokens", "cost_microunits")
+    ):
+        raise _causal_error(f"Tool Call usage must be zero at {stage}")
+
+
+def _expect_preapproval_evidence(
+    outcome: Mapping[str, FrozenJsonValue],
+    approval: Mapping[str, FrozenJsonValue],
+    *,
+    stage: str,
+) -> None:
+    approval_required = outcome.get("approval_required")
+    expected_status = "not_obtained" if approval_required is True else "not_required"
+    if (
+        approval.get("status") != expected_status
+        or approval.get("approver") is not None
+        or approval.get("approver_version") is not None
+        or approval.get("reason") != ""
+    ):
+        raise _causal_error(f"Tool Call approval evidence does not match {stage}")
+
+
+def _validate_controlled_tool_semantics(
+    *,
+    trajectory: Trajectory,
+    action_index: int,
+    arguments: FrozenJsonValue,
+    tool_name: str,
+    declared_tool: Mapping[str, FrozenJsonValue] | None,
+    policy: Mapping[str, FrozenJsonValue],
+    policy_hash: str,
+    budget_hash: str,
+    approver_hash: str | None,
+    outcome: Mapping[str, FrozenJsonValue],
+    ledger: _ControlledReplayLedger,
+) -> None:
+    status_value = outcome.get("status")
+    if not isinstance(status_value, str):
+        raise _causal_error("Tool Call status must be a string")
+    try:
+        tool_status = ToolCallStatus(status_value)
+    except ValueError as exc:
+        raise _causal_error("Tool Call status is unsupported") from exc
+    error_code = outcome.get("error_code")
+    request_hash = outcome.get("request_hash")
+    request_nonce = outcome.get("request_nonce")
+    usage = outcome.get("usage")
+    charged = outcome.get("budget_charged")
+    approval = outcome.get("approval")
+    if (
+        not isinstance(usage, Mapping)
+        or not isinstance(charged, Mapping)
+        or not isinstance(approval, Mapping)
+    ):
+        raise _causal_error("Tool Call semantic evidence is incomplete")
+    approval_status = approval.get("status")
+    if not isinstance(approval_status, str):
+        raise _causal_error("Tool Call approval status is invalid")
+
+    if ledger.calls >= ledger.max_tool_calls:
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.BUDGET_EXHAUSTED,
+            expected_errors="call_budget_exhausted",
+            stage="call budget exhaustion",
+        )
+        if request_hash is not None or request_nonce is not None:
+            raise _causal_error("call-budget outcome cannot contain request evidence")
+        _zero_tool_usage(usage, charged, stage="call budget exhaustion")
+        _expect_preapproval_evidence(
+            outcome,
+            approval,
+            stage="call budget exhaustion",
+        )
+        return
+    ledger.calls += 1
+
+    if declared_tool is None:
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.DENIED,
+            expected_errors="unknown_tool",
+            stage="unknown Tool rejection",
+        )
+        if request_hash is not None or request_nonce is not None:
+            raise _causal_error("unknown Tool outcome cannot contain request evidence")
+        _zero_tool_usage(usage, charged, stage="unknown Tool rejection")
+        _expect_preapproval_evidence(
+            outcome,
+            approval,
+            stage="unknown Tool rejection",
+        )
+        return
+
+    if ledger.poisoned:
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.BUDGET_EXHAUSTED,
+            expected_errors="usage_budget_exhausted",
+            stage="poisoned execution budget",
+        )
+        if request_hash is not None or request_nonce is not None:
+            raise _causal_error(
+                "poisoned-budget outcome cannot contain request evidence"
+            )
+        _zero_tool_usage(usage, charged, stage="poisoned execution budget")
+        _expect_preapproval_evidence(
+            outcome,
+            approval,
+            stage="poisoned execution budget",
+        )
+        return
+
+    input_schema = declared_tool.get("input_schema")
+    schema_valid = isinstance(arguments, Mapping) and isinstance(input_schema, Mapping)
+    if schema_valid:
+        try:
+            _validate_schema_instance(
+                cast(Mapping[str, FrozenJsonValue], arguments),
+                cast(Mapping[str, FrozenJsonValue], input_schema),
+            )
+        except (TypeError, ValueError, AssertionError):
+            schema_valid = False
+    if not schema_valid:
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.INVALID,
+            expected_errors="invalid_arguments",
+            stage="schema validation",
+        )
+        if request_hash is not None or request_nonce is not None:
+            raise _causal_error("schema-invalid outcome cannot contain request evidence")
+        _zero_tool_usage(usage, charged, stage="schema validation")
+        _expect_preapproval_evidence(outcome, approval, stage="schema validation")
+        return
+    if not isinstance(arguments, Mapping) or not isinstance(input_schema, Mapping):
+        raise AssertionError("schema-valid Tool arguments were not objects")
+
+    tool_version = declared_tool.get("version")
+    tool_spec_hash = outcome.get("tool_spec_hash")
+    reserved_tokens = _non_negative_record_int(
+        declared_tool.get("reserved_tokens"),
+        field_name="Tool reserved_tokens",
+    )
+    reserved_cost = _non_negative_record_int(
+        declared_tool.get("reserved_cost_microunits"),
+        field_name="Tool reserved_cost_microunits",
+    )
+    if (
+        not isinstance(tool_version, str)
+        or not isinstance(tool_spec_hash, str)
+        or not isinstance(request_nonce, str)
+        or not request_nonce.strip()
+    ):
+        raise _causal_error("Tool reservation declaration is invalid")
+    expected_request = ApprovalRequest(
+        trial_id=trajectory.trial_id,
+        call_id=f"tool-{action_index}",
+        request_nonce=request_nonce,
+        action_index=action_index,
+        tool_name=tool_name,
+        tool_version=tool_version,
+        tool_spec_hash=tool_spec_hash,
+        arguments=arguments,
+        policy_hash=policy_hash,
+        budget_hash=budget_hash,
+        approver_hash=approver_hash,
+        reserved_tokens=reserved_tokens,
+        reserved_cost_microunits=reserved_cost,
+    )
+    if request_hash != expected_request.request_hash:
+        raise _causal_error("Tool Call request hash does not bind this Action")
+
+    permission_name = declared_tool.get("permission_name")
+    runtime_capabilities = declared_tool.get("runtime_capabilities")
+    if not isinstance(permission_name, str) or not isinstance(
+        runtime_capabilities, tuple
+    ):
+        raise _causal_error("Tool policy declaration is invalid")
+    allowed = (
+        tool_name in _declared_names(policy, "allowed_tools")
+        and permission_name in _declared_names(policy, "allowed_permissions")
+        and set(runtime_capabilities).issubset(
+            _declared_names(policy, "allowed_runtime_capabilities")
+        )
+    )
+    if not allowed:
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.DENIED,
+            expected_errors="policy_denied",
+            stage="ExecutionPolicy",
+        )
+        _zero_tool_usage(usage, charged, stage="ExecutionPolicy")
+        _expect_preapproval_evidence(outcome, approval, stage="ExecutionPolicy")
+        return
+
+    if (
+        ledger.tokens + reserved_tokens > ledger.max_tokens
+        or ledger.cost_microunits + reserved_cost > ledger.max_cost_microunits
+    ):
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.BUDGET_EXHAUSTED,
+            expected_errors="usage_budget_exhausted",
+            stage="usage reservation",
+        )
+        _zero_tool_usage(usage, charged, stage="usage reservation")
+        _expect_preapproval_evidence(outcome, approval, stage="usage reservation")
+        return
+
+    if approval_status == "missing":
+        if approver_hash is not None:
+            raise _causal_error(
+                "Tool Call claims a missing Approver despite its declaration"
+            )
+    elif approval_status in {
+        "cancelled",
+        "timed_out",
+        "failed",
+        "invalid",
+        "denied",
+        "approved",
+    } and approver_hash is None:
+        raise _causal_error(
+            "Tool Call claims an Approver outcome without a declaration"
+        )
+
+    if approval_status != "not_required" and approval_status != "approved":
+        approval_outcomes = {
+            "missing": (ToolCallStatus.DENIED, ("approval_missing",)),
+            "cancelled": (ToolCallStatus.CANCELLED, ("cancelled",)),
+            "timed_out": (ToolCallStatus.TIMED_OUT, ("approval_timed_out",)),
+            "failed": (ToolCallStatus.DENIED, ("approval_failed",)),
+            "invalid": (
+                ToolCallStatus.DENIED,
+                (
+                    "approval_invalid",
+                    "approval_mismatch",
+                    "approval_drift",
+                ),
+            ),
+            "denied": (ToolCallStatus.DENIED, ("approval_denied",)),
+        }
+        expected = approval_outcomes.get(approval_status)
+        if expected is None:
+            raise _causal_error("Tool Call did not resolve required Approval")
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=expected[0],
+            expected_errors=expected[1],
+            stage="Approval",
+        )
+        _zero_tool_usage(usage, charged, stage="Approval")
+        return
+
+    usage_tokens = _non_negative_record_int(
+        usage.get("tokens"),
+        field_name="Tool usage tokens",
+    )
+    usage_cost = _non_negative_record_int(
+        usage.get("cost_microunits"),
+        field_name="Tool usage cost_microunits",
+    )
+    charged_tokens = _non_negative_record_int(
+        charged.get("tokens"),
+        field_name="Tool charged tokens",
+    )
+    charged_cost = _non_negative_record_int(
+        charged.get("cost_microunits"),
+        field_name="Tool charged cost_microunits",
+    )
+
+    if tool_status is ToolCallStatus.SUCCEEDED:
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.SUCCEEDED,
+            expected_errors=None,
+            stage="successful Tool execution",
+        )
+        if (
+            usage_tokens != charged_tokens
+            or usage_cost != charged_cost
+            or usage_tokens > reserved_tokens
+            or usage_cost > reserved_cost
+        ):
+            raise _causal_error("successful Tool usage exceeds its reservation")
+        ledger.tokens += usage_tokens
+        ledger.cost_microunits += usage_cost
+        return
+
+    if error_code == "usage_exceeded_reservation":
+        _expect_tool_outcome(
+            actual_status=tool_status,
+            actual_error=error_code,
+            expected_status=ToolCallStatus.FAILED,
+            expected_errors="usage_exceeded_reservation",
+            stage="Tool usage contract violation",
+        )
+        if (
+            usage_tokens != charged_tokens
+            or usage_cost != charged_cost
+            or not (
+                usage_tokens > reserved_tokens or usage_cost > reserved_cost
+            )
+        ):
+            raise _causal_error("Tool usage violation evidence is inconsistent")
+        ledger.tokens += usage_tokens
+        ledger.cost_microunits += usage_cost
+        ledger.poisoned = True
+        return
+
+    handler_outcomes = {
+        "tool_failed": (ToolCallStatus.FAILED, "Tool failure"),
+        "tool_timed_out": (ToolCallStatus.TIMED_OUT, "Tool timeout"),
+        "cancelled": (ToolCallStatus.CANCELLED, "Tool cancellation"),
+    }
+    if not isinstance(error_code, str):
+        raise _causal_error("Tool handler error code is invalid")
+    expected_handler = handler_outcomes.get(error_code)
+    if expected_handler is None:
+        raise _causal_error("Tool Call outcome does not match an execution stage")
+    _expect_tool_outcome(
+        actual_status=tool_status,
+        actual_error=error_code,
+        expected_status=expected_handler[0],
+        expected_errors=error_code,
+        stage=expected_handler[1],
+    )
+    if (
+        usage_tokens != 0
+        or usage_cost != 0
+        or charged_tokens != reserved_tokens
+        or charged_cost != reserved_cost
+    ):
+        raise _causal_error("failed Tool execution charge does not match reservation")
+    ledger.tokens += reserved_tokens
+    ledger.cost_microunits += reserved_cost
 
 
 def _validate_configuration(
@@ -60,6 +500,243 @@ def _validate_causal_order(
     ):
         raise _causal_error("configuration must declare a positive integer max_actions")
 
+    environment = trajectory.configuration.get("environment")
+    if not isinstance(environment, Mapping):
+        raise _causal_error("configuration must declare an Environment")
+    environment_config = environment.get("config")
+    if not isinstance(environment_config, Mapping):
+        raise _causal_error("configuration must declare Environment config")
+    controlled = environment_config.get("kind") == "controlled_tool"
+    if controlled and (
+        environment_config.get("controlled_execution_version")
+        != CONTROLLED_EXECUTION_VERSION
+    ):
+        raise _causal_error("controlled execution version is unsupported")
+    if controlled and environment_config.get("schema_version") != TOOL_SCHEMA_VERSION:
+        raise _causal_error("controlled Tool schema version is unsupported")
+    if controlled and environment_config.get("single_use") is not True:
+        raise _causal_error("controlled Environment lifecycle declaration is invalid")
+    controlled_tools: dict[str, Mapping[str, FrozenJsonValue]] = {}
+    controlled_policy: Mapping[str, FrozenJsonValue] | None = None
+    controlled_policy_hash: str | None = None
+    controlled_budget_hash: str | None = None
+    controlled_approver: Mapping[str, FrozenJsonValue] | None = None
+    controlled_approver_hash: str | None = None
+    controlled_ledger: _ControlledReplayLedger | None = None
+    if controlled:
+        _require_exact_fields(
+            environment_config,
+            {
+                "kind",
+                "controlled_execution_version",
+                "schema_version",
+                "tools",
+                "policy",
+                "policy_hash",
+                "budget",
+                "budget_hash",
+                "approver",
+                "approver_hash",
+                "single_use",
+            },
+            field_name="Environment declaration",
+        )
+        raw_tools = environment_config.get("tools")
+        raw_policy = environment_config.get("policy")
+        raw_policy_hash = environment_config.get("policy_hash")
+        raw_budget = environment_config.get("budget")
+        raw_budget_hash = environment_config.get("budget_hash")
+        raw_approver = environment_config.get("approver")
+        raw_approver_hash = environment_config.get("approver_hash")
+        if (
+            not isinstance(raw_tools, tuple)
+            or not isinstance(raw_policy, Mapping)
+            or not isinstance(raw_budget, Mapping)
+        ):
+            raise _causal_error("controlled execution declaration is incomplete")
+        if not isinstance(raw_policy_hash, str):
+            raise _causal_error("controlled policy hash is invalid")
+        if _configuration_hash(raw_policy) != raw_policy_hash:
+            raise _causal_error("controlled policy hash does not match its declaration")
+        if (
+            not isinstance(raw_budget_hash, str)
+            or _configuration_hash(raw_budget) != raw_budget_hash
+        ):
+            raise _causal_error("controlled budget hash does not match its declaration")
+        if raw_approver is not None and not isinstance(raw_approver, Mapping):
+            raise _causal_error("controlled Approver declaration is invalid")
+        if raw_approver is None:
+            if raw_approver_hash is not None:
+                raise _causal_error("controlled Approver hash has no declaration")
+        elif (
+            not isinstance(raw_approver_hash, str)
+            or _configuration_hash(raw_approver) != raw_approver_hash
+        ):
+            raise _causal_error("controlled Approver hash does not match declaration")
+        controlled_policy = raw_policy
+        controlled_policy_hash = raw_policy_hash
+        controlled_budget_hash = raw_budget_hash
+        controlled_approver = raw_approver
+        controlled_approver_hash = raw_approver_hash
+        _require_exact_fields(
+            raw_policy,
+            {
+                "version",
+                "allowed_tools",
+                "allowed_permissions",
+                "allowed_runtime_capabilities",
+                "approval_required_tools",
+                "approval_required_permissions",
+            },
+            field_name="ExecutionPolicy declaration",
+        )
+        policy_version = raw_policy.get("version")
+        if not isinstance(policy_version, str) or not policy_version.strip():
+            raise _causal_error("controlled policy version is invalid")
+        policy_names = {
+            field_name: _declared_names(raw_policy, field_name)
+            for field_name in (
+                "allowed_tools",
+                "allowed_permissions",
+                "allowed_runtime_capabilities",
+                "approval_required_tools",
+                "approval_required_permissions",
+            )
+        }
+        _require_exact_fields(
+            raw_budget,
+            {
+                "max_tool_calls",
+                "max_tokens",
+                "max_cost_microunits",
+                "tool_timeout_seconds",
+                "currency",
+                "pricing_version",
+            },
+            field_name="ExecutionBudget declaration",
+        )
+        timeout = raw_budget.get("tool_timeout_seconds")
+        currency = raw_budget.get("currency")
+        pricing_version = raw_budget.get("pricing_version")
+        if (
+            not isinstance(timeout, float)
+            or not math.isfinite(timeout)
+            or timeout <= 0
+            or not isinstance(currency, str)
+            or not currency.strip()
+            or not isinstance(pricing_version, str)
+            or not pricing_version.strip()
+        ):
+            raise _causal_error("controlled execution budget declaration is invalid")
+        if raw_approver is not None:
+            _require_exact_fields(
+                raw_approver,
+                {"name", "version", "config"},
+                field_name="Approver declaration",
+            )
+            approver_name = raw_approver.get("name")
+            approver_version = raw_approver.get("version")
+            approver_config = raw_approver.get("config")
+            if (
+                not isinstance(approver_name, str)
+                or not approver_name.strip()
+                or not isinstance(approver_version, str)
+                or not approver_version.strip()
+                or not isinstance(approver_config, Mapping)
+            ):
+                raise _causal_error("controlled Approver declaration is invalid")
+        max_tool_calls = _non_negative_record_int(
+            raw_budget.get("max_tool_calls"),
+            field_name="controlled max_tool_calls",
+        )
+        max_tokens = _non_negative_record_int(
+            raw_budget.get("max_tokens"),
+            field_name="controlled max_tokens",
+        )
+        max_cost = _non_negative_record_int(
+            raw_budget.get("max_cost_microunits"),
+            field_name="controlled max_cost_microunits",
+        )
+        controlled_ledger = _ControlledReplayLedger(
+            max_tool_calls=max_tool_calls,
+            max_tokens=max_tokens,
+            max_cost_microunits=max_cost,
+        )
+        declared_tool_names: list[str] = []
+        for raw_tool in raw_tools:
+            if not isinstance(raw_tool, Mapping):
+                raise _causal_error("controlled Tool declaration must be an object")
+            _require_exact_fields(
+                raw_tool,
+                {
+                    "tool_spec_version",
+                    "name",
+                    "version",
+                    "description",
+                    "input_schema_version",
+                    "input_schema",
+                    "permission_name",
+                    "runtime_capabilities",
+                    "requires_approval",
+                    "reserved_tokens",
+                    "reserved_cost_microunits",
+                },
+                field_name="Tool declaration",
+            )
+            tool_name = raw_tool.get("name")
+            tool_version = raw_tool.get("version")
+            if (
+                not isinstance(tool_name, str)
+                or not tool_name.strip()
+                or not isinstance(tool_version, str)
+                or not tool_version.strip()
+                or tool_name in controlled_tools
+            ):
+                raise _causal_error("controlled Tool declaration identity is invalid")
+            input_schema = raw_tool.get("input_schema")
+            runtime_capabilities = raw_tool.get("runtime_capabilities")
+            if (
+                raw_tool.get("tool_spec_version") != TOOL_SPEC_VERSION
+                or raw_tool.get("input_schema_version") != TOOL_SCHEMA_VERSION
+                or not isinstance(raw_tool.get("description"), str)
+                or not isinstance(raw_tool.get("permission_name"), str)
+                or not str(raw_tool.get("permission_name")).strip()
+                or not isinstance(runtime_capabilities, tuple)
+                or not isinstance(raw_tool.get("requires_approval"), bool)
+            ):
+                raise _causal_error("controlled Tool declaration is invalid")
+            _declared_names(raw_tool, "runtime_capabilities")
+            try:
+                _validate_schema_definition(input_schema)
+            except (TypeError, ValueError) as exc:
+                raise _causal_error("controlled Tool schema is invalid") from exc
+            if not isinstance(input_schema, Mapping) or input_schema.get("type") != "object":
+                raise _causal_error("controlled Tool schema root must be an object")
+            _non_negative_record_int(
+                raw_tool.get("reserved_tokens"),
+                field_name="Tool reserved_tokens",
+            )
+            _non_negative_record_int(
+                raw_tool.get("reserved_cost_microunits"),
+                field_name="Tool reserved_cost_microunits",
+            )
+            controlled_tools[tool_name] = raw_tool
+            declared_tool_names.append(tool_name)
+        if declared_tool_names != sorted(declared_tool_names):
+            raise _causal_error("controlled Tool declarations are not canonical")
+        if not set(policy_names["allowed_tools"]).issubset(controlled_tools):
+            raise _causal_error("ExecutionPolicy allows an undeclared Tool")
+        if not set(policy_names["approval_required_tools"]).issubset(
+            policy_names["allowed_tools"]
+        ):
+            raise _causal_error("ExecutionPolicy requires Approval for a denied Tool")
+        if not set(policy_names["approval_required_permissions"]).issubset(
+            policy_names["allowed_permissions"]
+        ):
+            raise _causal_error(
+                "ExecutionPolicy requires Approval for a denied permission"
+            )
+
     middle = trajectory.records[1:-1]
     if not middle:
         raise _causal_error("terminal record has no preceding outcome")
@@ -79,8 +756,28 @@ def _validate_causal_order(
     reset_seen = bool(body and body[0].kind == "environment.reset")
     if reset_seen and "observation" not in body[0].payload:
         raise _causal_error("Environment reset observation is missing")
+    if reset_seen and controlled:
+        _require_exact_fields(
+            body[0].payload,
+            {"observation"},
+            field_name="reset evidence",
+        )
+        reset_hash = _configuration_hash(
+            _frozen_object(value=body[0].payload.get("observation"))
+        )
+        task_input_hash = _configuration_hash(
+            _frozen_object(value=trajectory.task.input)
+        )
+        if reset_hash != task_input_hash:
+            raise _causal_error(
+                "controlled Environment reset does not match Task input"
+            )
     position = 1 if reset_seen else 0
     pending_action = False
+    pending_action_name: str | None = None
+    pending_action_final = False
+    pending_action_payload: FrozenJsonValue = None
+    pending_tool_outcome: Mapping[str, FrozenJsonValue] | None = None
     terminated = False
     budget_exhausted = False
     action_count = 0
@@ -100,9 +797,202 @@ def _validate_causal_order(
             ):
                 raise _causal_error("Agent Action payload is invalid")
             pending_action = True
+            pending_action_name = name
+            pending_action_final = is_final
+            pending_action_payload = record.payload.get("payload")
+            pending_tool_outcome = None
             action_count += 1
             if action_count > max_actions:
                 raise _causal_error("Action count exceeds max_actions")
+            continue
+
+        if record.kind == "tool.call.outcome":
+            if (
+                not controlled
+                or not pending_action
+                or pending_action_final
+                or pending_tool_outcome is not None
+                or terminated
+                or budget_exhausted
+            ):
+                raise _causal_error("Tool Call outcome has no pending controlled Action")
+            _require_exact_fields(
+                record.payload,
+                {
+                    "call_id",
+                    "tool_name",
+                    "tool_version",
+                    "status",
+                    "tool_spec_hash",
+                    "policy_hash",
+                    "request_hash",
+                    "request_nonce",
+                    "observation_hash",
+                    "approval_required",
+                    "approval",
+                    "usage",
+                    "budget_charged",
+                    "error_code",
+                    "message",
+                },
+                field_name="Tool Call outcome",
+            )
+            call_id = record.payload.get("call_id")
+            tool_name = record.payload.get("tool_name")
+            status_value = record.payload.get("status")
+            if call_id != f"tool-{action_count - 1}":
+                raise _causal_error("Tool Call id does not match the pending Action")
+            if not isinstance(tool_name, str) or tool_name != pending_action_name:
+                raise _causal_error("Tool Call name does not match the pending Action")
+            if not isinstance(status_value, str):
+                raise _causal_error("Tool Call status must be a string")
+            try:
+                tool_status = ToolCallStatus(status_value)
+            except ValueError as exc:
+                raise _causal_error("Tool Call status is unsupported") from exc
+            declared_tool = controlled_tools.get(tool_name)
+            tool_version = record.payload.get("tool_version")
+            tool_spec_hash = record.payload.get("tool_spec_hash")
+            if declared_tool is None:
+                if tool_version is not None or tool_spec_hash is not None:
+                    raise _causal_error("unknown Tool Call has forged Tool declaration")
+            else:
+                if tool_version != declared_tool.get("version"):
+                    raise _causal_error("Tool Call version does not match its declaration")
+                if tool_spec_hash != _configuration_hash(declared_tool):
+                    raise _causal_error("Tool Call spec hash does not match its declaration")
+            if record.payload.get("policy_hash") != controlled_policy_hash:
+                raise _causal_error("Tool Call policy hash does not match its declaration")
+            usage = record.payload.get("usage")
+            charged = record.payload.get("budget_charged")
+            if not isinstance(usage, Mapping) or not isinstance(charged, Mapping):
+                raise _causal_error("Tool Call usage evidence is missing")
+            _require_exact_fields(
+                usage,
+                {"tokens", "cost_microunits"},
+                field_name="Tool usage evidence",
+            )
+            _require_exact_fields(
+                charged,
+                {"tokens", "cost_microunits"},
+                field_name="Tool charge evidence",
+            )
+            for usage_payload in (usage, charged):
+                for field_name in ("tokens", "cost_microunits"):
+                    value = usage_payload.get(field_name)
+                    if (
+                        isinstance(value, bool)
+                        or not isinstance(value, int)
+                        or value < 0
+                    ):
+                        raise _causal_error("Tool Call usage evidence is invalid")
+            approval_required = record.payload.get("approval_required")
+            policy_hash = record.payload.get("policy_hash")
+            if not isinstance(approval_required, bool) or not isinstance(
+                policy_hash, str
+            ):
+                raise _causal_error("Tool Call policy evidence is invalid")
+            if controlled_policy is None:
+                raise AssertionError("controlled policy was not initialized")
+            expected_approval = False
+            if declared_tool is not None:
+                required_tools = controlled_policy.get("approval_required_tools", ())
+                required_permissions = controlled_policy.get(
+                    "approval_required_permissions", ()
+                )
+                expected_approval = (
+                    declared_tool.get("requires_approval") is True
+                    or isinstance(required_tools, tuple)
+                    and tool_name in required_tools
+                    or isinstance(required_permissions, tuple)
+                    and declared_tool.get("permission_name") in required_permissions
+                )
+            if approval_required is not expected_approval:
+                raise _causal_error("Tool Call approval requirement was forged")
+            approval = record.payload.get("approval")
+            if not isinstance(approval, Mapping):
+                raise _causal_error("Tool Call approval evidence is missing")
+            _require_exact_fields(
+                approval,
+                {"status", "approver", "approver_version", "reason"},
+                field_name="Approval evidence",
+            )
+            approval_status = approval.get("status")
+            approver_name = approval.get("approver")
+            approver_version = approval.get("approver_version")
+            approval_reason = approval.get("reason")
+            if not isinstance(approval_status, str) or not isinstance(
+                approval_reason, str
+            ):
+                raise _causal_error("Tool Call approval evidence is invalid")
+            if not approval_required:
+                if (
+                    approval_status != "not_required"
+                    or approver_name is not None
+                    or approver_version is not None
+                    or approval_reason != ""
+                ):
+                    raise _causal_error("Tool Call contains forged approval evidence")
+            else:
+                allowed_approval_statuses = {
+                    "not_obtained",
+                    "missing",
+                    "cancelled",
+                    "timed_out",
+                    "failed",
+                    "invalid",
+                    "denied",
+                    "approved",
+                }
+                if approval_status not in allowed_approval_statuses:
+                    raise _causal_error("Tool Call approval status is unsupported")
+                if tool_status is ToolCallStatus.SUCCEEDED and approval_status != "approved":
+                    raise _causal_error("successful Tool Call is missing approval evidence")
+                if approval_status in {"approved", "denied"}:
+                    if controlled_approver is None or (
+                        approver_name != controlled_approver.get("name")
+                        or approver_version != controlled_approver.get("version")
+                    ):
+                        raise _causal_error("Tool Call Approver identity was forged")
+                elif approver_name is not None or approver_version is not None:
+                    raise _causal_error("Tool Call has unexpected Approver identity")
+                elif approval_reason != "":
+                    raise _causal_error("Tool Call has unexpected Approval reason")
+
+            error_code = record.payload.get("error_code")
+            message = record.payload.get("message")
+            observation_hash = record.payload.get("observation_hash")
+            if tool_status is ToolCallStatus.SUCCEEDED:
+                if error_code is not None or message is not None:
+                    raise _causal_error("successful Tool Call cannot contain an error")
+            elif not isinstance(error_code, str) or not isinstance(message, str):
+                raise _causal_error("unsuccessful Tool Call must contain an error")
+            if tool_status is ToolCallStatus.CANCELLED:
+                if observation_hash is not None:
+                    raise _causal_error("cancelled Tool Call cannot bind an Observation")
+            elif not isinstance(observation_hash, str):
+                raise _causal_error("Tool Call outcome is missing its Observation hash")
+            if (
+                controlled_ledger is None
+                or controlled_policy is None
+                or controlled_policy_hash is None
+                or controlled_budget_hash is None
+            ):
+                raise AssertionError("controlled Replay state was not initialized")
+            _validate_controlled_tool_semantics(
+                trajectory=trajectory,
+                action_index=action_count - 1,
+                arguments=pending_action_payload,
+                tool_name=tool_name,
+                declared_tool=declared_tool,
+                policy=controlled_policy,
+                policy_hash=controlled_policy_hash,
+                budget_hash=controlled_budget_hash,
+                approver_hash=controlled_approver_hash,
+                outcome=record.payload,
+                ledger=controlled_ledger,
+            )
+            pending_tool_outcome = record.payload
             continue
 
         if record.kind == "environment.transition":
@@ -113,7 +1003,120 @@ def _validate_causal_order(
                 raise _causal_error("Environment Transition termination flag is invalid")
             if "observation" not in record.payload or "output" not in record.payload:
                 raise _causal_error("Environment Transition payload is incomplete")
+            if controlled:
+                _require_exact_fields(
+                    record.payload,
+                    {"observation", "terminated", "output"},
+                    field_name="Environment Transition",
+                )
+                if pending_action_final:
+                    if pending_tool_outcome is not None or not transition_terminated:
+                        raise _causal_error(
+                            "final controlled Action must terminate without Tool evidence"
+                        )
+                    action_hash = _configuration_hash(
+                        _frozen_object(value=pending_action_payload)
+                    )
+                    observation_hash = _configuration_hash(
+                        _frozen_object(value=record.payload.get("observation"))
+                    )
+                    output_hash = _configuration_hash(
+                        _frozen_object(value=record.payload.get("output"))
+                    )
+                    if observation_hash != action_hash or output_hash != action_hash:
+                        raise _causal_error(
+                            "final controlled Transition does not match its Action"
+                        )
+                else:
+                    if pending_tool_outcome is None:
+                        raise _causal_error(
+                            "controlled Action is missing its Tool Call outcome"
+                        )
+                    if pending_tool_outcome.get("status") == ToolCallStatus.CANCELLED.value:
+                        raise _causal_error(
+                            "cancelled Tool Call cannot have an Environment Transition"
+                        )
+                    observation = record.payload.get("observation")
+                    tool_call = (
+                        observation.get("tool_call")
+                        if isinstance(observation, Mapping)
+                        else None
+                    )
+                    if not isinstance(tool_call, Mapping):
+                        raise _causal_error(
+                            "controlled Transition is missing Tool Call Observation"
+                        )
+                    if not isinstance(observation, Mapping):
+                        raise AssertionError(
+                            "controlled Tool Call Observation was not an object"
+                        )
+                    _require_exact_fields(
+                        observation,
+                        {"tool_call"},
+                        field_name="Tool Call Observation",
+                    )
+                    _require_exact_fields(
+                        tool_call,
+                        {
+                            "call_id",
+                            "tool_name",
+                            "status",
+                            "output",
+                            "usage",
+                            "error_code",
+                            "message",
+                        },
+                        field_name="Tool Call Observation payload",
+                    )
+                    expected_observation_hash = _configuration_hash(
+                        _frozen_object(observation=observation)
+                    )
+                    if (
+                        pending_tool_outcome.get("observation_hash")
+                        != expected_observation_hash
+                    ):
+                        raise _causal_error(
+                            "controlled Transition Observation hash does not match outcome"
+                        )
+                    for field_name in (
+                        "call_id",
+                        "tool_name",
+                        "status",
+                        "usage",
+                        "error_code",
+                        "message",
+                    ):
+                        transition_field_hash = _configuration_hash(
+                            _frozen_object(value=tool_call.get(field_name))
+                        )
+                        outcome_field_hash = _configuration_hash(
+                            _frozen_object(
+                                value=pending_tool_outcome.get(field_name)
+                            )
+                        )
+                        if transition_field_hash != outcome_field_hash:
+                            raise _causal_error(
+                                "controlled Transition does not match Tool Call outcome"
+                            )
+                    if (
+                        pending_tool_outcome.get("status")
+                        != ToolCallStatus.SUCCEEDED.value
+                        and tool_call.get("output") is not None
+                    ):
+                        raise _causal_error(
+                            "unsuccessful Tool Call Observation cannot contain output"
+                        )
+                    if transition_terminated:
+                        raise _causal_error("Tool invocation Transition cannot terminate Trial")
+                    if record.payload.get("output") is not None:
+                        raise _causal_error(
+                            "Tool invocation Transition cannot contain final output"
+                        )
             pending_action = False
+            pending_action_name = None
+            pending_action_final = False
+            pending_action_payload = None
+            pending_tool_outcome = None
             if transition_terminated:
                 terminated = True
                 final_output = record.payload.get("output")
@@ -122,7 +1125,10 @@ def _validate_causal_order(
         if record.kind == "budget.exhausted":
             declared_budget = record.payload.get("max_actions")
             if (
-                not reset_seen
+                set(record.payload) != {"max_actions"}
+                or isinstance(declared_budget, bool)
+                or not isinstance(declared_budget, int)
+                or not reset_seen
                 or pending_action
                 or terminated
                 or budget_exhausted
@@ -185,6 +1191,16 @@ def _validate_causal_order(
         )
         if not valid_failure_state:
             raise _causal_error("failure code does not match the committed execution prefix")
+        if (
+            controlled
+            and code == "environment_step_error"
+            and pending_action
+            and not pending_action_final
+            and pending_tool_outcome is not None
+        ):
+            raise _causal_error(
+                "failed controlled Action cannot follow a committed Tool Call outcome"
+            )
         return None
 
     operation = marker.payload.get("operation")
@@ -212,6 +1228,19 @@ def _validate_causal_order(
         and not pending_action
         and (terminated or budget_exhausted)
     )
+    if (
+        valid_cancellation_state
+        and controlled
+        and operation == "environment.step"
+        and not pending_action_final
+        and (
+            pending_tool_outcome is None
+            or pending_tool_outcome.get("status") != ToolCallStatus.CANCELLED.value
+        )
+    ):
+        raise _causal_error(
+            "cancelled controlled Action requires a cancelled Tool Call outcome"
+        )
     if not valid_cancellation_state:
         raise _causal_error("cancellation operation does not match the execution prefix")
     return None

--- a/python/iamai/harness/_replay.py
+++ b/python/iamai/harness/_replay.py
@@ -1,0 +1,344 @@
+"""Pure reconstruction and causal validation of committed Trajectories."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ._model import (
+    HARNESS_CONFIGURATION_VERSION,
+    TRAJECTORY_FORMAT_VERSION,
+    Evaluation,
+    FrozenJsonValue,
+    Trajectory,
+    TrialFailure,
+    TrialResult,
+    TrialStatus,
+    _configuration_hash,
+)
+
+
+def _causal_error(reason: str) -> ValueError:
+    return ValueError(f"invalid Trajectory causal order: {reason}")
+
+
+def _validate_configuration(
+    trajectory: Trajectory,
+) -> Mapping[str, FrozenJsonValue]:
+    configuration = trajectory.configuration
+    if (
+        configuration.get("harness_configuration_version")
+        != HARNESS_CONFIGURATION_VERSION
+    ):
+        raise ValueError("Trajectory configuration version is missing or unsupported")
+    declared_components: dict[str, Mapping[str, FrozenJsonValue]] = {}
+    for role in ("agent", "environment", "evaluator"):
+        declared = configuration.get(role)
+        if not isinstance(declared, Mapping):
+            raise ValueError(f"Trajectory configuration is missing declared {role}")
+        name = declared.get("name")
+        version = declared.get("version")
+        component_config = declared.get("config")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"Trajectory configuration {role} name is invalid")
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError(f"Trajectory configuration {role} version is invalid")
+        if not isinstance(component_config, Mapping):
+            raise ValueError(f"Trajectory configuration {role} config is invalid")
+        declared_components[role] = declared
+    return declared_components["evaluator"]
+
+
+def _validate_causal_order(
+    trajectory: Trajectory,
+    status: TrialStatus,
+) -> FrozenJsonValue:
+    max_actions = trajectory.configuration.get("max_actions")
+    if (
+        isinstance(max_actions, bool)
+        or not isinstance(max_actions, int)
+        or max_actions <= 0
+    ):
+        raise _causal_error("configuration must declare a positive integer max_actions")
+
+    middle = trajectory.records[1:-1]
+    if not middle:
+        raise _causal_error("terminal record has no preceding outcome")
+    marker_kind = {
+        TrialStatus.COMPLETED: "evaluation.recorded",
+        TrialStatus.BUDGET_EXHAUSTED: "evaluation.recorded",
+        TrialStatus.FAILED: "trial.failure",
+        TrialStatus.CANCELLED: "trial.cancelled",
+    }[status]
+    marker = middle[-1]
+    if marker.kind != marker_kind:
+        raise _causal_error(
+            f"{status.value} must place {marker_kind} immediately before termination"
+        )
+    body = middle[:-1]
+
+    reset_seen = bool(body and body[0].kind == "environment.reset")
+    if reset_seen and "observation" not in body[0].payload:
+        raise _causal_error("Environment reset observation is missing")
+    position = 1 if reset_seen else 0
+    pending_action = False
+    terminated = False
+    budget_exhausted = False
+    action_count = 0
+    final_output: FrozenJsonValue = None
+
+    for record in body[position:]:
+        if record.kind == "agent.action":
+            if not reset_seen or pending_action or terminated or budget_exhausted:
+                raise _causal_error("Agent Action is outside an active Environment state")
+            name = record.payload.get("name")
+            is_final = record.payload.get("is_final")
+            if (
+                not isinstance(name, str)
+                or not name.strip()
+                or not isinstance(is_final, bool)
+                or "payload" not in record.payload
+            ):
+                raise _causal_error("Agent Action payload is invalid")
+            pending_action = True
+            action_count += 1
+            if action_count > max_actions:
+                raise _causal_error("Action count exceeds max_actions")
+            continue
+
+        if record.kind == "environment.transition":
+            if not pending_action or terminated or budget_exhausted:
+                raise _causal_error("Environment Transition has no pending Agent Action")
+            transition_terminated = record.payload.get("terminated")
+            if not isinstance(transition_terminated, bool):
+                raise _causal_error("Environment Transition termination flag is invalid")
+            if "observation" not in record.payload or "output" not in record.payload:
+                raise _causal_error("Environment Transition payload is incomplete")
+            pending_action = False
+            if transition_terminated:
+                terminated = True
+                final_output = record.payload.get("output")
+            continue
+
+        if record.kind == "budget.exhausted":
+            declared_budget = record.payload.get("max_actions")
+            if (
+                not reset_seen
+                or pending_action
+                or terminated
+                or budget_exhausted
+                or declared_budget != max_actions
+                or action_count != max_actions
+            ):
+                raise _causal_error(
+                    "budget exhaustion does not follow a bounded Action loop"
+                )
+            budget_exhausted = True
+            continue
+
+        raise _causal_error(f"unexpected record kind: {record.kind}")
+
+    if status is TrialStatus.COMPLETED:
+        if not reset_seen or pending_action or not terminated or budget_exhausted:
+            raise _causal_error(
+                "completed Trial requires a paired terminating Environment Transition"
+            )
+        return final_output
+
+    if status is TrialStatus.BUDGET_EXHAUSTED:
+        if (
+            not reset_seen
+            or pending_action
+            or terminated
+            or not budget_exhausted
+            or action_count != max_actions
+        ):
+            raise _causal_error(
+                "budget-exhausted Trial requires exactly max_actions non-terminal pairs"
+            )
+        return None
+
+    if status is TrialStatus.FAILED:
+        code = marker.payload.get("code")
+        phase = marker.payload.get("phase")
+        valid_failure_state = (
+            code == "environment_reset_error"
+            and phase == "environment"
+            and not reset_seen
+            and not body
+            or code == "agent_decide_error"
+            and phase == "agent"
+            and reset_seen
+            and not pending_action
+            and not terminated
+            and not budget_exhausted
+            and action_count < max_actions
+            or code == "environment_step_error"
+            and phase == "environment"
+            and pending_action
+            and not terminated
+            and not budget_exhausted
+            or code == "evaluator_evaluate_error"
+            and phase == "evaluator"
+            and reset_seen
+            and not pending_action
+            and (terminated or budget_exhausted)
+        )
+        if not valid_failure_state:
+            raise _causal_error("failure code does not match the committed execution prefix")
+        return None
+
+    operation = marker.payload.get("operation")
+    phase = marker.payload.get("phase")
+    valid_cancellation_state = (
+        operation == "environment.reset"
+        and phase == "environment"
+        and not reset_seen
+        and not body
+        or operation == "agent.decide"
+        and phase == "agent"
+        and reset_seen
+        and not pending_action
+        and not terminated
+        and not budget_exhausted
+        and action_count < max_actions
+        or operation == "environment.step"
+        and phase == "environment"
+        and pending_action
+        and not terminated
+        and not budget_exhausted
+        or operation == "evaluator.evaluate"
+        and phase == "evaluator"
+        and reset_seen
+        and not pending_action
+        and (terminated or budget_exhausted)
+    )
+    if not valid_cancellation_state:
+        raise _causal_error("cancellation operation does not match the execution prefix")
+    return None
+
+
+def replay(trajectory: Trajectory) -> TrialResult:
+    """Reconstruct a TrialResult without invoking Agent or Environment effects."""
+    if trajectory.format_version != TRAJECTORY_FORMAT_VERSION:
+        raise ValueError(f"unsupported Trajectory format: {trajectory.format_version}")
+    if trajectory.config_hash != _configuration_hash(trajectory.configuration):
+        raise ValueError("Trajectory configuration hash does not match its snapshot")
+    declared_evaluator = _validate_configuration(trajectory)
+    if not trajectory.records:
+        raise ValueError("Trajectory has no records")
+    if [record.sequence for record in trajectory.records] != list(
+        range(len(trajectory.records))
+    ):
+        raise ValueError("Trajectory record sequence must be contiguous from zero")
+    if trajectory.records[0].kind != "trial.started":
+        raise ValueError("Trajectory must start with trial.started")
+    terminal_records = [
+        record for record in trajectory.records if record.kind == "trial.terminated"
+    ]
+    if len(terminal_records) != 1 or trajectory.records[-1] is not terminal_records[0]:
+        raise ValueError("Trajectory must end with exactly one trial.terminated record")
+
+    status_value = terminal_records[0].payload.get("status")
+    if not isinstance(status_value, str):
+        raise ValueError("terminal Trial status must be a string")
+    try:
+        status = TrialStatus(status_value)
+    except ValueError as exc:
+        raise ValueError(f"unsupported terminal Trial status: {status_value}") from exc
+    final_output = _validate_causal_order(trajectory, status)
+
+    evaluation_records = [
+        record for record in trajectory.records if record.kind == "evaluation.recorded"
+    ]
+    failure_records = [
+        record for record in trajectory.records if record.kind == "trial.failure"
+    ]
+    cancelled_records = [
+        record for record in trajectory.records if record.kind == "trial.cancelled"
+    ]
+
+    evaluation: Evaluation | None = None
+    failure: TrialFailure | None = None
+    if status in {TrialStatus.COMPLETED, TrialStatus.BUDGET_EXHAUSTED}:
+        if len(evaluation_records) != 1:
+            raise ValueError(
+                "completed or budget-exhausted Trajectory must contain exactly one "
+                "evaluation.recorded record"
+            )
+        if failure_records or cancelled_records:
+            raise ValueError("evaluated Trajectory cannot contain failure or cancellation")
+        evaluation_payload = evaluation_records[0].payload
+        passed = evaluation_payload.get("passed")
+        score = evaluation_payload.get("score")
+        evaluator = evaluation_payload.get("evaluator")
+        evaluator_version = evaluation_payload.get("evaluator_version")
+        if not isinstance(passed, bool):
+            raise ValueError("recorded Evaluation passed value must be a bool")
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
+            raise ValueError("recorded Evaluation score must be a number")
+        if not isinstance(evaluator, str) or not isinstance(evaluator_version, str):
+            raise ValueError("recorded Evaluation identity must be strings")
+        if (
+            evaluator != declared_evaluator["name"]
+            or evaluator_version != declared_evaluator["version"]
+        ):
+            raise ValueError(
+                "recorded Evaluation identity does not match Trajectory configuration"
+            )
+        evaluation = Evaluation(
+            passed=passed,
+            score=float(score),
+            evaluator=evaluator,
+            evaluator_version=evaluator_version,
+        )
+    elif status is TrialStatus.FAILED:
+        if evaluation_records or cancelled_records or len(failure_records) != 1:
+            raise ValueError(
+                "failed Trajectory must contain exactly one failure and no "
+                "Evaluation or cancellation"
+            )
+        failure_payload = failure_records[0].payload
+        phase = failure_payload.get("phase")
+        code = failure_payload.get("code")
+        exception_type = failure_payload.get("exception_type")
+        message = failure_payload.get("message")
+        if (
+            not isinstance(phase, str)
+            or not isinstance(code, str)
+            or not isinstance(exception_type, str)
+            or not isinstance(message, str)
+        ):
+            raise ValueError("recorded Trial failure fields must be strings")
+        failure = TrialFailure(
+            phase=phase,
+            code=code,
+            exception_type=exception_type,
+            message=message,
+        )
+        if terminal_records[0].payload.get("phase") != failure.phase:
+            raise ValueError("terminal Trial phase does not match recorded failure")
+    else:
+        if evaluation_records or failure_records or len(cancelled_records) != 1:
+            raise ValueError(
+                "cancelled Trajectory must contain exactly one cancellation and no "
+                "Evaluation or failure"
+            )
+        cancelled_phase = cancelled_records[0].payload.get("phase")
+        cancelled_operation = cancelled_records[0].payload.get("operation")
+        if not isinstance(cancelled_phase, str) or not isinstance(
+            cancelled_operation, str
+        ):
+            raise ValueError("recorded cancellation phase and operation must be strings")
+        if terminal_records[0].payload.get("phase") != cancelled_phase:
+            raise ValueError("terminal Trial phase does not match cancellation")
+        if terminal_records[0].payload.get("operation") != cancelled_operation:
+            raise ValueError("terminal Trial operation does not match cancellation")
+
+    return TrialResult(
+        trial_id=trajectory.trial_id,
+        status=status,
+        final_output=final_output,
+        evaluation=evaluation,
+        trajectory=trajectory,
+        failure=failure,
+    )

--- a/python/iamai/harness/_trial.py
+++ b/python/iamai/harness/_trial.py
@@ -1,0 +1,422 @@
+"""Headless Trial execution for the provisional general-agent harness."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Mapping
+from typing import Protocol, TypeVar
+
+from ._model import (
+    HARNESS_CONFIGURATION_VERSION,
+    TRAJECTORY_FORMAT_VERSION,
+    Action,
+    Evaluation,
+    FrozenJsonValue,
+    Observation,
+    Task,
+    Trajectory,
+    TrajectoryRecord,
+    Transition,
+    TrialConfig,
+    TrialFailure,
+    TrialResult,
+    TrialStatus,
+    _action_payload,
+    _configuration_hash,
+    _evaluation_payload,
+    _frozen_object,
+    _transition_payload,
+)
+
+_AwaitedT = TypeVar("_AwaitedT")
+
+
+def _safe_exception_message(error: Exception) -> str:
+    try:
+        return str(error)
+    except Exception:
+        return f"<{type(error).__name__} message unavailable>"
+
+
+class _Agent(Protocol):
+    name: str
+    version: str
+    configuration: Mapping[str, FrozenJsonValue]
+
+    async def decide(
+        self,
+        task: Task,
+        observation: Observation,
+        trajectory: Trajectory,
+        *,
+        seed: int,
+        action_index: int,
+    ) -> Action: ...
+
+
+class _Environment(Protocol):
+    name: str
+    version: str
+    configuration: Mapping[str, FrozenJsonValue]
+
+    async def reset(self, task: Task, *, seed: int) -> Observation: ...
+
+    async def step(self, action: Action, *, seed: int, action_index: int) -> Transition: ...
+
+
+class _Evaluator(Protocol):
+    name: str
+    version: str
+    configuration: Mapping[str, FrozenJsonValue]
+
+    async def evaluate(
+        self,
+        task: Task,
+        trajectory: Trajectory,
+        output: FrozenJsonValue,
+    ) -> Evaluation: ...
+
+
+def _declared_adapter(
+    value: _Agent | _Environment | _Evaluator,
+) -> Mapping[str, FrozenJsonValue]:
+    if not isinstance(value.name, str) or not value.name.strip():
+        raise ValueError("Harness component name cannot be empty")
+    if not isinstance(value.version, str) or not value.version.strip():
+        raise ValueError("Harness component version cannot be empty")
+    if not isinstance(value.configuration, Mapping):
+        raise TypeError("Harness component configuration must be an object")
+    return _frozen_object(
+        name=value.name,
+        version=value.version,
+        config=value.configuration,
+    )
+
+
+def _configuration_snapshot(
+    *,
+    agent: _Agent,
+    environment: _Environment,
+    evaluator: _Evaluator,
+    max_actions: int,
+) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        harness_configuration_version=HARNESS_CONFIGURATION_VERSION,
+        agent=_declared_adapter(agent),
+        environment=_declared_adapter(environment),
+        evaluator=_declared_adapter(evaluator),
+        max_actions=max_actions,
+    )
+
+
+class _TrajectoryBuilder:
+    def __init__(
+        self,
+        *,
+        config: TrialConfig,
+        task: Task,
+        configuration: Mapping[str, FrozenJsonValue],
+    ) -> None:
+        self._config = config
+        self._task = task
+        self._configuration = configuration
+        self._config_hash = _configuration_hash(configuration)
+        self._records: list[TrajectoryRecord] = []
+
+    def append(self, kind: str, payload: Mapping[str, object] | None = None) -> None:
+        self._records.append(
+            TrajectoryRecord(
+                sequence=len(self._records),
+                kind=kind,
+                payload=_frozen_object(**dict(payload or {})),
+            )
+        )
+
+    def snapshot(self) -> Trajectory:
+        return Trajectory(
+            format_version=TRAJECTORY_FORMAT_VERSION,
+            trial_id=self._config.trial_id,
+            task=self._task,
+            seed=self._config.seed,
+            configuration=self._configuration,
+            config_hash=self._config_hash,
+            records=tuple(self._records),
+        )
+
+
+class Trial:
+    """Run one bounded Agent attempt in one Environment."""
+
+    def __init__(
+        self,
+        *,
+        task: Task,
+        agent: _Agent,
+        environment: _Environment,
+        evaluator: _Evaluator,
+        config: TrialConfig,
+    ) -> None:
+        self._task = task
+        self._agent = agent
+        self._environment = environment
+        self._evaluator = evaluator
+        self._config = config
+        self._started = False
+        configuration = _configuration_snapshot(
+            agent=agent,
+            environment=environment,
+            evaluator=evaluator,
+            max_actions=config.max_actions,
+        )
+        declared_evaluator = configuration["evaluator"]
+        if not isinstance(declared_evaluator, Mapping):
+            raise AssertionError("Evaluator declaration did not produce an object")
+        evaluator_name = declared_evaluator["name"]
+        evaluator_version = declared_evaluator["version"]
+        if not isinstance(evaluator_name, str) or not isinstance(evaluator_version, str):
+            raise AssertionError("Evaluator identity did not produce strings")
+        self._declared_evaluator_identity = (evaluator_name, evaluator_version)
+        self._trajectory = _TrajectoryBuilder(
+            config=config,
+            task=task,
+            configuration=configuration,
+        )
+
+    @property
+    def task(self) -> Task:
+        """Return the Task bound into this Trial's Trajectory header."""
+        return self._task
+
+    @property
+    def agent(self) -> _Agent:
+        """Return the Agent bound into this Trial's configuration snapshot."""
+        return self._agent
+
+    @property
+    def environment(self) -> _Environment:
+        """Return the Environment bound into this Trial's configuration snapshot."""
+        return self._environment
+
+    @property
+    def evaluator(self) -> _Evaluator:
+        """Return the Evaluator bound into this Trial's configuration snapshot."""
+        return self._evaluator
+
+    @property
+    def config(self) -> TrialConfig:
+        """Return the immutable configuration bound into this Trial."""
+        return self._config
+
+    @property
+    def trajectory(self) -> Trajectory:
+        """Return the committed Trajectory prefix."""
+        return self._trajectory.snapshot()
+
+    def _fail(self, *, phase: str, code: str, error: Exception) -> TrialResult:
+        failure = TrialFailure(
+            phase=phase,
+            code=code,
+            exception_type=type(error).__name__,
+            message=_safe_exception_message(error),
+        )
+        self._trajectory.append(
+            "trial.failure",
+            {
+                "phase": failure.phase,
+                "code": failure.code,
+                "exception_type": failure.exception_type,
+                "message": failure.message,
+            },
+        )
+        self._trajectory.append(
+            "trial.terminated",
+            {"status": TrialStatus.FAILED.value, "phase": failure.phase},
+        )
+        return TrialResult(
+            trial_id=self.config.trial_id,
+            status=TrialStatus.FAILED,
+            final_output=None,
+            evaluation=None,
+            trajectory=self.trajectory,
+            failure=failure,
+        )
+
+    def _cancel(self, *, phase: str, operation: str) -> None:
+        self._trajectory.append(
+            "trial.cancelled",
+            {"phase": phase, "operation": operation},
+        )
+        self._trajectory.append(
+            "trial.terminated",
+            {
+                "status": TrialStatus.CANCELLED.value,
+                "phase": phase,
+                "operation": operation,
+            },
+        )
+
+    async def _await_phase(
+        self,
+        awaitable: Awaitable[_AwaitedT],
+        *,
+        phase: str,
+        operation: str,
+    ) -> _AwaitedT:
+        try:
+            return await awaitable
+        except asyncio.CancelledError:
+            self._cancel(phase=phase, operation=operation)
+            raise
+
+    def _validate_evaluation_identity(self, evaluation: Evaluation) -> None:
+        if (
+            evaluation.evaluator,
+            evaluation.evaluator_version,
+        ) != self._declared_evaluator_identity:
+            raise ValueError(
+                "Evaluation identity must match the declared Evaluator name and version"
+            )
+
+    async def run(self) -> TrialResult:
+        """Run the Trial to a terminating Transition and Evaluation."""
+        if self._started:
+            raise RuntimeError("a Trial can only be run once")
+        self._started = True
+        self._trajectory.append("trial.started")
+        try:
+            observation = await self._await_phase(
+                self.environment.reset(self.task, seed=self.config.seed),
+                phase="environment",
+                operation="environment.reset",
+            )
+            if not isinstance(observation, Observation):
+                raise TypeError("Environment.reset() must return Observation")
+            self._trajectory.append(
+                "environment.reset",
+                {"observation": observation.value},
+            )
+        except Exception as error:
+            return self._fail(
+                phase="environment",
+                code="environment_reset_error",
+                error=error,
+            )
+        for action_index in range(self.config.max_actions):
+            try:
+                action = await self._await_phase(
+                    self.agent.decide(
+                        self.task,
+                        observation,
+                        self.trajectory,
+                        seed=self.config.seed,
+                        action_index=action_index,
+                    ),
+                    phase="agent",
+                    operation="agent.decide",
+                )
+                if not isinstance(action, Action):
+                    raise TypeError("Agent.decide() must return Action")
+                self._trajectory.append("agent.action", _action_payload(action))
+            except Exception as error:
+                return self._fail(
+                    phase="agent",
+                    code="agent_decide_error",
+                    error=error,
+                )
+            try:
+                transition = await self._await_phase(
+                    self.environment.step(
+                        action,
+                        seed=self.config.seed,
+                        action_index=action_index,
+                    ),
+                    phase="environment",
+                    operation="environment.step",
+                )
+                if not isinstance(transition, Transition):
+                    raise TypeError("Environment.step() must return Transition")
+                self._trajectory.append(
+                    "environment.transition",
+                    _transition_payload(transition),
+                )
+            except Exception as error:
+                return self._fail(
+                    phase="environment",
+                    code="environment_step_error",
+                    error=error,
+                )
+            observation = transition.observation
+            if not transition.terminated:
+                continue
+            try:
+                evaluation = await self._await_phase(
+                    self.evaluator.evaluate(
+                        self.task,
+                        self.trajectory,
+                        transition.output,
+                    ),
+                    phase="evaluator",
+                    operation="evaluator.evaluate",
+                )
+                if not isinstance(evaluation, Evaluation):
+                    raise TypeError("Evaluator.evaluate() must return Evaluation")
+                self._validate_evaluation_identity(evaluation)
+                self._trajectory.append(
+                    "evaluation.recorded",
+                    _evaluation_payload(evaluation),
+                )
+            except Exception as error:
+                return self._fail(
+                    phase="evaluator",
+                    code="evaluator_evaluate_error",
+                    error=error,
+                )
+            self._trajectory.append(
+                "trial.terminated",
+                {"status": TrialStatus.COMPLETED.value},
+            )
+            return TrialResult(
+                trial_id=self.config.trial_id,
+                status=TrialStatus.COMPLETED,
+                final_output=transition.output,
+                evaluation=evaluation,
+                trajectory=self.trajectory,
+            )
+        self._trajectory.append(
+            "budget.exhausted",
+            {"max_actions": self.config.max_actions},
+        )
+        try:
+            evaluation = await self._await_phase(
+                self.evaluator.evaluate(
+                    self.task,
+                    self.trajectory,
+                    None,
+                ),
+                phase="evaluator",
+                operation="evaluator.evaluate",
+            )
+            if not isinstance(evaluation, Evaluation):
+                raise TypeError("Evaluator.evaluate() must return Evaluation")
+            self._validate_evaluation_identity(evaluation)
+            self._trajectory.append(
+                "evaluation.recorded",
+                _evaluation_payload(evaluation),
+            )
+        except Exception as error:
+            return self._fail(
+                phase="evaluator",
+                code="evaluator_evaluate_error",
+                error=error,
+            )
+        self._trajectory.append(
+            "trial.terminated",
+            {"status": TrialStatus.BUDGET_EXHAUSTED.value},
+        )
+        return TrialResult(
+            trial_id=self.config.trial_id,
+            status=TrialStatus.BUDGET_EXHAUSTED,
+            final_output=None,
+            evaluation=evaluation,
+            trajectory=self.trajectory,
+        )

--- a/python/iamai/harness/_trial.py
+++ b/python/iamai/harness/_trial.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Mapping
-from typing import Protocol, TypeVar
+from typing import Protocol, TypeVar, cast
 
 from ._model import (
     HARNESS_CONFIGURATION_VERSION,
@@ -33,9 +33,11 @@ _AwaitedT = TypeVar("_AwaitedT")
 
 def _safe_exception_message(error: Exception) -> str:
     try:
-        return str(error)
+        message = str(error)
+        message.encode("utf-8")
     except Exception:
         return f"<{type(error).__name__} message unavailable>"
+    return message
 
 
 class _Agent(Protocol):
@@ -62,6 +64,21 @@ class _Environment(Protocol):
     async def reset(self, task: Task, *, seed: int) -> Observation: ...
 
     async def step(self, action: Action, *, seed: int, action_index: int) -> Transition: ...
+
+
+class _ControlledEnvironment(_Environment, Protocol):
+    async def _step_with_audit(
+        self,
+        action: Action,
+        *,
+        trial_id: str,
+        seed: int,
+        action_index: int,
+    ) -> Transition: ...
+
+    def _drain_trajectory_records(
+        self,
+    ) -> tuple[tuple[str, Mapping[str, FrozenJsonValue]], ...]: ...
 
 
 class _Evaluator(Protocol):
@@ -181,6 +198,9 @@ class Trial:
             task=task,
             configuration=configuration,
         )
+        bind_trial = getattr(environment, "_bind_trial", None)
+        if callable(bind_trial):
+            bind_trial(config.trial_id)
 
     @property
     def task(self) -> Task:
@@ -262,11 +282,28 @@ class Trial:
         phase: str,
         operation: str,
     ) -> _AwaitedT:
+        operation_task = asyncio.ensure_future(awaitable)
         try:
-            return await awaitable
+            result = await operation_task
         except asyncio.CancelledError:
-            self._cancel(phase=phase, operation=operation)
+            current = asyncio.current_task()
+            if current is not None and current.cancelling() > 0:
+                self._cancel(phase=phase, operation=operation)
+                raise
+            raise RuntimeError(
+                f"{operation} raised CancelledError without caller cancellation"
+            ) from None
+        except BaseException:
+            current = asyncio.current_task()
+            if current is not None and current.cancelling() > 0:
+                self._cancel(phase=phase, operation=operation)
+                raise asyncio.CancelledError from None
             raise
+        current = asyncio.current_task()
+        if current is not None and current.cancelling() > 0:
+            self._cancel(phase=phase, operation=operation)
+            raise asyncio.CancelledError
+        return result
 
     def _validate_evaluation_identity(self, evaluation: Evaluation) -> None:
         if (
@@ -276,6 +313,32 @@ class Trial:
             raise ValueError(
                 "Evaluation identity must match the declared Evaluator name and version"
             )
+
+    async def _step_environment(
+        self,
+        action: Action,
+        *,
+        action_index: int,
+    ) -> Transition:
+        step_with_audit = getattr(self.environment, "_step_with_audit", None)
+        drain = getattr(self.environment, "_drain_trajectory_records", None)
+        if not callable(step_with_audit) or not callable(drain):
+            return await self.environment.step(
+                action,
+                seed=self.config.seed,
+                action_index=action_index,
+            )
+        controlled = cast(_ControlledEnvironment, self.environment)
+        try:
+            return await controlled._step_with_audit(
+                action,
+                trial_id=self.config.trial_id,
+                seed=self.config.seed,
+                action_index=action_index,
+            )
+        finally:
+            for kind, payload in controlled._drain_trajectory_records():
+                self._trajectory.append(kind, payload)
 
     async def run(self) -> TrialResult:
         """Run the Trial to a terminating Transition and Evaluation."""
@@ -325,11 +388,7 @@ class Trial:
                 )
             try:
                 transition = await self._await_phase(
-                    self.environment.step(
-                        action,
-                        seed=self.config.seed,
-                        action_index=action_index,
-                    ),
+                    self._step_environment(action, action_index=action_index),
                     phase="environment",
                     operation="environment.step",
                 )

--- a/tests/test_controlled_execution.py
+++ b/tests/test_controlled_execution.py
@@ -1,0 +1,3108 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import cast
+
+import pytest
+
+from iamai.harness import (
+    Action,
+    ApprovalDecision,
+    ApprovalRequest,
+    ControlledToolEnvironment,
+    ExactEvaluator,
+    Experiment,
+    ExecutionBudget,
+    ExecutionPolicy,
+    JsonlTrajectoryStore,
+    ScriptedAgent,
+    Task,
+    Tool,
+    ToolResult,
+    ToolSpec,
+    Trial,
+    TrialConfig,
+    TrialResult,
+    TrialStatus,
+    Trajectory,
+    TrajectoryRecord,
+    replay,
+)
+from iamai.harness._model import (
+    FrozenJsonValue,
+    JsonValue,
+    _configuration_hash,
+    _freeze_json,
+    _thaw_json,
+)
+
+
+def _with_configuration(
+    trajectory: Trajectory,
+    configuration: dict[str, JsonValue],
+) -> Trajectory:
+    frozen = _freeze_json(configuration)
+    assert isinstance(frozen, Mapping)
+    typed = cast(Mapping[str, FrozenJsonValue], frozen)
+    return replace(
+        trajectory,
+        configuration=typed,
+        config_hash=_configuration_hash(typed),
+    )
+
+
+def _hash_json_object(value: dict[str, JsonValue]) -> str:
+    frozen = _freeze_json(value)
+    assert isinstance(frozen, Mapping)
+    return _configuration_hash(cast(Mapping[str, FrozenJsonValue], frozen))
+
+
+def _with_records(
+    trajectory: Trajectory,
+    records: list[TrajectoryRecord],
+) -> Trajectory:
+    return replace(
+        trajectory,
+        records=tuple(
+            replace(record, sequence=index)
+            for index, record in enumerate(records)
+        ),
+    )
+
+
+def _with_self_consistent_tool_outcome(
+    trajectory: Trajectory,
+    *,
+    outcome_number: int = 0,
+    **updates: JsonValue,
+) -> Trajectory:
+    records = list(trajectory.records)
+    outcome_indexes = [
+        index for index, record in enumerate(records) if record.kind == "tool.call.outcome"
+    ]
+    outcome_index = outcome_indexes[outcome_number]
+    transition_index = next(
+        index
+        for index, record in enumerate(records[outcome_index + 1 :], outcome_index + 1)
+        if record.kind == "environment.transition"
+    )
+    outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(records[outcome_index].payload),
+    )
+    outcome.update(updates)
+    transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(records[transition_index].payload),
+    )
+    observation = cast(dict[str, JsonValue], transition["observation"])
+    tool_call = cast(dict[str, JsonValue], observation["tool_call"])
+    for field_name in (
+        "call_id",
+        "tool_name",
+        "status",
+        "usage",
+        "error_code",
+        "message",
+    ):
+        tool_call[field_name] = outcome[field_name]
+    outcome["observation_hash"] = _hash_json_object({"observation": observation})
+    records[outcome_index] = replace(records[outcome_index], payload=outcome)
+    records[transition_index] = replace(records[transition_index], payload=transition)
+    return _with_records(trajectory, records)
+
+
+def test_controlled_tool_success_is_recorded_and_replay_has_no_effects() -> None:
+    calls = 0
+
+    async def add(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        assert arguments == {"left": 1, "right": 2}
+        return ToolResult(output=3, tokens=2, cost_microunits=5)
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="add",
+                        version="1",
+                        description="Add two integers.",
+                        input_schema={
+                            "type": "object",
+                            "properties": {
+                                "left": {"type": "integer"},
+                                "right": {"type": "integer"},
+                            },
+                            "required": ["left", "right"],
+                            "additionalProperties": False,
+                        },
+                        permission_name="math.read",
+                        reserved_tokens=4,
+                        reserved_cost_microunits=10,
+                    ),
+                    lambda arguments: add(arguments),
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="policy-1",
+                allowed_tools=("add",),
+                allowed_permissions=("math.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=2,
+                max_tokens=4,
+                max_cost_microunits=10,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="controlled-math",
+            version="1",
+        )
+        result = await Trial(
+            task=Task(id="controlled-add", input={"question": "1 + 2"}),
+            agent=ScriptedAgent(
+                [Action.invoke("add", {"left": 1, "right": 2}), Action.finish(3)],
+                name="controlled-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator(3, version="1"),
+            config=TrialConfig(trial_id="controlled-add-1", max_actions=2),
+        ).run()
+
+        assert result.status is TrialStatus.COMPLETED
+        assert calls == 1
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "agent.action",
+            "tool.call.outcome",
+            "environment.transition",
+            "agent.action",
+            "environment.transition",
+            "evaluation.recorded",
+            "trial.terminated",
+        ]
+        outcome = result.trajectory.records[3].payload
+        assert outcome["call_id"] == "tool-0"
+        assert outcome["tool_name"] == "add"
+        assert outcome["status"] == "succeeded"
+        assert outcome["usage"] == {"tokens": 2, "cost_microunits": 5}
+        assert result.trajectory.configuration["environment"]["config"]["kind"] == (
+            "controlled_tool"
+        )
+
+        assert replay(result.trajectory) == result
+        assert calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_schema_is_checked_without_coercion_before_approval_or_tool_effects() -> None:
+    approvals = 0
+    calls = 0
+
+    class Approver:
+        name = "fixture-approver"
+        version = "1"
+        configuration: dict[str, object] = {"mode": "approve"}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            nonlocal approvals
+            approvals += 1
+            return ApprovalDecision.approve(
+                request,
+            )
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments["value"])
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="strict-int",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {"value": {"type": "integer"}},
+                            "required": ["value"],
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                        requires_approval=True,
+                    ),
+                    effect,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("strict-int",),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=1,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            approver=Approver(),
+            name="strict-schema",
+            version="1",
+        )
+        result = await Trial(
+            task=Task(id="strict-schema", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("strict-int", {"value": True}), Action.finish("recovered")],
+                name="strict-schema-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id="strict-schema-1", max_actions=2),
+        ).run()
+
+        assert result.status is TrialStatus.COMPLETED
+        assert approvals == 0
+        assert calls == 0
+        outcomes = [
+            record for record in result.trajectory.records if record.kind == "tool.call.outcome"
+        ]
+        assert len(outcomes) == 1
+        assert outcomes[0].payload["status"] == "invalid"
+        assert outcomes[0].payload["error_code"] == "invalid_arguments"
+        transitions = [
+            record
+            for record in result.trajectory.records
+            if record.kind == "environment.transition"
+        ]
+        assert transitions[0].payload["observation"]["tool_call"]["status"] == "invalid"
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_tool_schema_rejects_unsupported_or_remote_reference_keywords() -> None:
+    try:
+        ToolSpec(
+            name="remote-schema",
+            version="1",
+            input_schema={"type": "object", "$ref": "https://example.com/schema.json"},
+            permission_name="fixture.read",
+        )
+    except ValueError as error:
+        assert "unsupported: $ref" in str(error)
+    else:
+        raise AssertionError("unsupported schema was accepted")
+
+
+def test_policy_is_default_deny_and_runs_before_approval() -> None:
+    approvals = 0
+    calls = 0
+
+    class Approver:
+        name = "should-not-run"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            nonlocal approvals
+            approvals += 1
+            return ApprovalDecision.approve(
+                request,
+            )
+
+    async def network_tool(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="fetch",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="network.read",
+                        runtime_capabilities=("network",),
+                        requires_approval=True,
+                    ),
+                    network_tool,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="deny-network-1",
+                allowed_tools=("fetch",),
+                allowed_permissions=("network.read",),
+                # The required runtime capability is deliberately not granted.
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=1,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            approver=Approver(),
+            name="default-deny",
+            version="1",
+        )
+        result = await Trial(
+            task=Task(id="deny-network", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("fetch"), Action.finish("recovered")],
+                name="deny-network-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id="deny-network-1", max_actions=2),
+        ).run()
+
+        outcome = next(
+            record for record in result.trajectory.records if record.kind == "tool.call.outcome"
+        )
+        assert outcome.payload["status"] == "denied"
+        assert outcome.payload["error_code"] == "policy_denied"
+        assert approvals == 0
+        assert calls == 0
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_approval_is_bound_to_the_exact_trial_action_tool_and_policy() -> None:
+    requests: list[ApprovalRequest] = []
+    calls = 0
+
+    class Approver:
+        name = "human-gate"
+        version = "2026-08"
+        configuration: dict[str, object] = {"queue": "fixture"}
+
+        def __init__(self, *, stale: bool) -> None:
+            self.stale = stale
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            requests.append(request)
+            approved_request = (
+                replace(request, trial_id="another-trial") if self.stale else request
+            )
+            return ApprovalDecision.approve(
+                approved_request,
+                reason="fixture approval",
+            )
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments["value"])
+
+    def trial(*, stale: bool, trial_id: str) -> Trial:
+        return Trial(
+            task=Task(id="bound-approval", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write", {"value": "ok"}), Action.finish("done")],
+                name="bound-approval-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="write",
+                            version="2",
+                            input_schema={
+                                "type": "object",
+                                "properties": {"value": {"type": "string"}},
+                                "required": ["value"],
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                            requires_approval=True,
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="write-policy-3",
+                    allowed_tools=("write",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=Approver(stale=stale),
+                name="bound-approval",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=2),
+        )
+
+    async def scenario() -> None:
+        accepted = await trial(stale=False, trial_id="approval-current").run()
+        rejected = await trial(stale=True, trial_id="approval-stale").run()
+
+        assert calls == 1
+        assert len(requests) == 2
+        assert requests[0].trial_id == "approval-current"
+        assert requests[0].call_id == "tool-0"
+        assert requests[0].tool_name == "write"
+        assert requests[0].tool_version == "2"
+        assert requests[0].arguments == {"value": "ok"}
+        assert requests[0].policy_hash != requests[0].tool_spec_hash
+        accepted_outcome = next(
+            record
+            for record in accepted.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        rejected_outcome = next(
+            record
+            for record in rejected.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        assert accepted_outcome.payload["status"] == "succeeded"
+        assert accepted_outcome.payload["request_hash"] == requests[0].request_hash
+        assert accepted_outcome.payload["approval"] == {
+            "status": "approved",
+            "approver": "human-gate",
+            "approver_version": "2026-08",
+            "reason": "fixture approval",
+        }
+        assert rejected_outcome.payload["status"] == "denied"
+        assert rejected_outcome.payload["error_code"] == "approval_mismatch"
+        assert rejected_outcome.payload["approval"]["status"] == "invalid"
+        assert replay(accepted.trajectory) == accepted
+        assert replay(rejected.trajectory) == rejected
+
+    asyncio.run(scenario())
+
+
+def test_approval_decision_cannot_be_reused_for_a_new_identical_invocation() -> None:
+    requests: list[ApprovalRequest] = []
+    cached: ApprovalDecision | None = None
+    calls = 0
+
+    class CachingApprover:
+        name = "caching-approver"
+        version = "1"
+        configuration: dict[str, object] = {"cache": True}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            nonlocal cached
+            requests.append(request)
+            if cached is None:
+                cached = ApprovalDecision.approve(request)
+            return cached
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    def trial(approver: CachingApprover) -> Trial:
+        return Trial(
+            task=Task(id="approval-reuse", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write"), Action.finish("done")],
+                name="approval-reuse-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="write",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                            requires_approval=True,
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("write",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=approver,
+                name="approval-reuse",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id="approval-reuse-1", max_actions=2),
+        )
+
+    async def scenario() -> None:
+        approver = CachingApprover()
+        accepted = await trial(approver).run()
+        rejected = await trial(approver).run()
+
+        assert calls == 1
+        assert len(requests) == 2
+        assert requests[0].request_hash != requests[1].request_hash
+        rejected_outcome = next(
+            record.payload
+            for record in rejected.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        assert rejected_outcome["status"] == "denied"
+        assert rejected_outcome["error_code"] == "approval_mismatch"
+        assert replay(accepted.trajectory) == accepted
+        assert replay(rejected.trajectory) == rejected
+
+    asyncio.run(scenario())
+
+
+def test_approver_identity_or_configuration_drift_fails_before_tool_effects() -> None:
+    calls = 0
+
+    class DriftingApprover:
+        name = "declared-approver"
+        version = "1"
+
+        def __init__(self) -> None:
+            self.configuration: dict[str, object] = {"gate": 1}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            self.configuration["gate"] = True
+            return ApprovalDecision.approve(
+                request,
+            )
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def scenario() -> None:
+        result = await Trial(
+            task=Task(id="approver-drift", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write"), Action.finish("recovered")],
+                name="approver-drift-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="write",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                            requires_approval=True,
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("write",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=DriftingApprover(),
+                name="approver-drift",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id="approver-drift-1", max_actions=2),
+        ).run()
+
+        assert calls == 0
+        outcome = next(
+            record.payload
+            for record in result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        assert outcome["status"] == "denied"
+        assert outcome["error_code"] == "approval_drift"
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_non_json_approver_identity_drift_is_an_audited_denial() -> None:
+    calls = 0
+
+    class MutableApprover:
+        name = "declared-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            raise AssertionError(f"drifted Approver was called: {request.request_hash}")
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def scenario() -> None:
+        approver = MutableApprover()
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="write",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.write",
+                        requires_approval=True,
+                    ),
+                    effect,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("write",),
+                allowed_permissions=("fixture.write",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=1,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            approver=approver,
+            name="malformed-approver-drift",
+            version="1",
+        )
+        trial = Trial(
+            task=Task(id="malformed-approver-drift", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write"), Action.finish("recovered")],
+                name="malformed-approver-drift-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id="malformed-approver-drift-1", max_actions=2),
+        )
+        approver.name = cast(str, object())
+        result = await trial.run()
+
+        assert result.status is TrialStatus.COMPLETED
+        assert calls == 0
+        outcome = next(
+            record.payload
+            for record in result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        assert outcome["status"] == "denied"
+        assert outcome["error_code"] == "approval_drift"
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_call_and_reservation_budgets_fail_before_additional_effects() -> None:
+    calls = 0
+
+    async def metered(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(
+            output=arguments["value"],
+            tokens=2,
+            cost_microunits=3,
+        )
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="metered",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                            "required": ["value"],
+                            "additionalProperties": False,
+                        },
+                        permission_name="metered.read",
+                        reserved_tokens=4,
+                        reserved_cost_microunits=5,
+                    ),
+                    metered,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("metered",),
+                allowed_permissions=("metered.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=2,
+                max_tokens=4,
+                max_cost_microunits=5,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="metered",
+            version="1",
+        )
+        result = await Trial(
+            task=Task(id="metered", input=None),
+            agent=ScriptedAgent(
+                [
+                    Action.invoke("metered", {"value": "first"}),
+                    Action.invoke("metered", {"value": "second"}),
+                    Action.finish("recovered"),
+                ],
+                name="metered-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id="metered-1", max_actions=3),
+        ).run()
+
+        assert calls == 1
+        outcomes = [
+            record.payload
+            for record in result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert [outcome["status"] for outcome in outcomes] == [
+            "succeeded",
+            "budget_exhausted",
+        ]
+        assert outcomes[0]["budget_charged"] == {
+            "tokens": 2,
+            "cost_microunits": 3,
+        }
+        assert outcomes[1]["error_code"] == "usage_budget_exhausted"
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_every_nonfinal_attempt_consumes_the_call_budget() -> None:
+    calls = 0
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="declared",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                    ),
+                    effect,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("declared",),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=1,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="attempt-budget",
+            version="1",
+        )
+        result = await Trial(
+            task=Task(id="attempt-budget", input=None),
+            agent=ScriptedAgent(
+                [
+                    Action.invoke("unknown"),
+                    Action.invoke("declared"),
+                    Action.finish("done"),
+                ],
+                name="attempt-budget-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id="attempt-budget-1", max_actions=3),
+        ).run()
+
+        assert calls == 0
+        outcomes = [
+            record.payload
+            for record in result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert [outcome["error_code"] for outcome in outcomes] == [
+            "unknown_tool",
+            "call_budget_exhausted",
+        ]
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_usage_beyond_a_reservation_is_an_audited_adapter_failure() -> None:
+    calls = 0
+
+    async def underdeclared(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments, tokens=2, cost_microunits=2)
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="underdeclared",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                        reserved_tokens=1,
+                        reserved_cost_microunits=1,
+                    ),
+                    underdeclared,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("underdeclared",),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=2,
+                max_tokens=1,
+                max_cost_microunits=1,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="underdeclared",
+            version="1",
+        )
+        result = await Trial(
+            task=Task(id="underdeclared", input=None),
+            agent=ScriptedAgent(
+                [
+                    Action.invoke("underdeclared"),
+                    Action.invoke("underdeclared"),
+                    Action.finish("recovered"),
+                ],
+                name="underdeclared-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id="underdeclared-1", max_actions=3),
+        ).run()
+
+        assert calls == 1
+        outcomes = [
+            record.payload
+            for record in result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert [outcome["status"] for outcome in outcomes] == [
+            "failed",
+            "budget_exhausted",
+        ]
+        assert outcomes[0]["error_code"] == "usage_exceeded_reservation"
+        assert outcomes[0]["usage"] == {"tokens": 2, "cost_microunits": 2}
+        assert outcomes[0]["budget_charged"] == {
+            "tokens": 2,
+            "cost_microunits": 2,
+        }
+        assert outcomes[1]["error_code"] == "usage_budget_exhausted"
+        assert replay(result.trajectory) == result
+
+    asyncio.run(scenario())
+
+
+def test_timeout_and_callback_failure_are_recoverable_environment_outcomes() -> None:
+    invalid_output_effects = 0
+    deeply_nested_output_effects = 0
+    invalid_usage_effects = 0
+
+    class CallbackBaseError(BaseException):
+        pass
+
+    async def slow(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def broken(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        raise RuntimeError("secret provider detail")
+
+    async def broken_base(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        raise CallbackBaseError("base callback failure")
+
+    async def provider_timeout(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        raise TimeoutError("provider timeout, not Harness timeout")
+
+    async def callback_cancel(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        raise asyncio.CancelledError
+
+    async def invalid_output(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal invalid_output_effects
+        del arguments
+        invalid_output_effects += 1
+        return ToolResult(output="\ud800")
+
+    async def deeply_nested_output(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal deeply_nested_output_effects
+        del arguments
+        deeply_nested_output_effects += 1
+        nested: object = "leaf"
+        for _ in range(126):
+            nested = [nested]
+        return ToolResult(output=nested)
+
+    async def invalid_usage(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal invalid_usage_effects
+        del arguments
+        invalid_usage_effects += 1
+        return ToolResult(output=None, tokens=10**5000)
+
+    def environment(name: str, handler: object) -> ControlledToolEnvironment:
+        return ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name=name,
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                    ),
+                    handler,  # type: ignore[arg-type]
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=(name,),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=1,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=0.01,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name=f"{name}-environment",
+            version="1",
+        )
+
+    async def run(name: str, handler: object, trial_id: str) -> object:
+        return await Trial(
+            task=Task(id=trial_id, input=None),
+            agent=ScriptedAgent(
+                [Action.invoke(name), Action.finish("recovered")],
+                name=f"{name}-agent",
+                version="1",
+            ),
+            environment=environment(name, handler),
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=2),
+        ).run()
+
+    async def scenario() -> None:
+        timed_out = await run("slow", slow, "timeout-1")
+        failed = await run("broken", broken, "failure-1")
+        base_failed = await run("broken-base", broken_base, "base-failure-1")
+        provider_failed = await run(
+            "provider-timeout",
+            provider_timeout,
+            "provider-timeout-1",
+        )
+        callback_cancelled = await run(
+            "callback-cancel",
+            callback_cancel,
+            "callback-cancel-1",
+        )
+        invalid = await run("invalid-output", invalid_output, "invalid-output-1")
+        too_deep = await run(
+            "deeply-nested-output",
+            deeply_nested_output,
+            "deeply-nested-output-1",
+        )
+        invalid_usage_result = await run(
+            "invalid-usage",
+            invalid_usage,
+            "invalid-usage-1",
+        )
+
+        assert timed_out.status is TrialStatus.COMPLETED
+        assert failed.status is TrialStatus.COMPLETED
+        assert base_failed.status is TrialStatus.COMPLETED
+        assert provider_failed.status is TrialStatus.COMPLETED
+        assert callback_cancelled.status is TrialStatus.COMPLETED
+        assert invalid.status is TrialStatus.COMPLETED
+        assert too_deep.status is TrialStatus.COMPLETED
+        assert invalid_usage_result.status is TrialStatus.COMPLETED
+        timeout_outcome = next(
+            record.payload
+            for record in timed_out.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        failure_outcome = next(
+            record.payload
+            for record in failed.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        base_failure_outcome = next(
+            record.payload
+            for record in base_failed.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        provider_failure_outcome = next(
+            record.payload
+            for record in provider_failed.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        callback_cancel_outcome = next(
+            record.payload
+            for record in callback_cancelled.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        invalid_outcome = next(
+            record.payload
+            for record in invalid.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        too_deep_outcome = next(
+            record.payload
+            for record in too_deep.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        invalid_usage_outcome = next(
+            record.payload
+            for record in invalid_usage_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        assert timeout_outcome["status"] == "timed_out"
+        assert timeout_outcome["error_code"] == "tool_timed_out"
+        assert failure_outcome["status"] == "failed"
+        assert failure_outcome["error_code"] == "tool_failed"
+        assert base_failure_outcome["status"] == "failed"
+        assert base_failure_outcome["error_code"] == "tool_failed"
+        assert provider_failure_outcome["status"] == "failed"
+        assert provider_failure_outcome["error_code"] == "tool_failed"
+        assert callback_cancel_outcome["status"] == "failed"
+        assert callback_cancel_outcome["error_code"] == "tool_failed"
+        assert invalid_outcome["status"] == "failed"
+        assert invalid_outcome["error_code"] == "tool_failed"
+        assert too_deep_outcome["status"] == "failed"
+        assert too_deep_outcome["error_code"] == "tool_failed"
+        assert invalid_usage_outcome["status"] == "failed"
+        assert invalid_usage_outcome["error_code"] == "tool_failed"
+        assert invalid_output_effects == 1
+        assert deeply_nested_output_effects == 1
+        assert invalid_usage_effects == 1
+        assert "secret provider detail" not in failure_outcome["message"]
+        assert replay(timed_out.trajectory) == timed_out
+        assert replay(failed.trajectory) == failed
+        assert replay(base_failed.trajectory) == base_failed
+        assert replay(provider_failed.trajectory) == provider_failed
+        assert replay(callback_cancelled.trajectory) == callback_cancelled
+        assert replay(invalid.trajectory) == invalid
+        assert replay(too_deep.trajectory) == too_deep
+        assert replay(invalid_usage_result.trajectory) == invalid_usage_result
+
+    asyncio.run(scenario())
+
+
+def test_approver_callback_errors_are_denials_not_harness_timeouts() -> None:
+    calls = 0
+
+    class CallbackBaseError(BaseException):
+        pass
+
+    class ProviderTimeoutApprover:
+        name = "provider-timeout-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            raise TimeoutError("provider timeout, not Harness timeout")
+
+    class InvalidReasonApprover:
+        name = "invalid-reason-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            return ApprovalDecision.approve(request, reason="\ud800")
+
+    class CallbackCancelApprover:
+        name = "callback-cancel-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            raise asyncio.CancelledError
+
+    class CallbackBaseErrorApprover:
+        name = "callback-base-error-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            raise CallbackBaseError("base callback failure")
+
+    class BlockingPostcheckApprover:
+        name = "blocking-postcheck-approver"
+        version = "1"
+
+        def __init__(self) -> None:
+            self.reads = 0
+
+        @property
+        def configuration(self) -> dict[str, object]:
+            self.reads += 1
+            if self.reads == 3:
+                time.sleep(0.02)
+            return {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            return ApprovalDecision.approve(request)
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def run(
+        approver: object,
+        trial_id: str,
+        *,
+        timeout: float = 1,
+    ) -> TrialResult:
+        return await Trial(
+            task=Task(id=trial_id, input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write"), Action.finish("recovered")],
+                name=f"{trial_id}-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="write",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                            requires_approval=True,
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("write",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=timeout,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=approver,  # type: ignore[arg-type]
+                name=f"{trial_id}-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=2),
+        ).run()
+
+    async def scenario() -> None:
+        provider_failure = await run(
+            ProviderTimeoutApprover(),
+            "approval-provider-timeout",
+        )
+        invalid_reason = await run(
+            InvalidReasonApprover(),
+            "approval-invalid-reason",
+        )
+        callback_cancel = await run(
+            CallbackCancelApprover(),
+            "approval-callback-cancel",
+        )
+        callback_base_error = await run(
+            CallbackBaseErrorApprover(),
+            "approval-callback-base-error",
+        )
+        postcheck_timeout = await run(
+            BlockingPostcheckApprover(),
+            "approval-blocking-postcheck",
+            timeout=0.005,
+        )
+
+        assert calls == 0
+        for result in (
+            provider_failure,
+            invalid_reason,
+            callback_cancel,
+            callback_base_error,
+        ):
+            assert result.status is TrialStatus.COMPLETED
+            outcome = next(
+                record.payload
+                for record in result.trajectory.records
+                if record.kind == "tool.call.outcome"
+            )
+            assert outcome["status"] == "denied"
+            assert outcome["error_code"] == "approval_failed"
+            assert outcome["approval"]["status"] == "failed"
+            assert replay(result.trajectory) == result
+
+        postcheck_outcome = next(
+            record.payload
+            for record in postcheck_timeout.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        assert postcheck_timeout.status is TrialStatus.COMPLETED
+        assert postcheck_outcome["status"] == "timed_out"
+        assert postcheck_outcome["error_code"] == "approval_timed_out"
+        assert postcheck_outcome["approval"]["status"] == "timed_out"
+        assert postcheck_outcome["budget_charged"] == {
+            "tokens": 0,
+            "cost_microunits": 0,
+        }
+        assert replay(postcheck_timeout.trajectory) == postcheck_timeout
+
+    asyncio.run(scenario())
+
+
+def test_late_tool_or_approval_return_cannot_turn_a_timeout_into_success() -> None:
+    tool_calls = 0
+
+    async def late_tool(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal tool_calls
+        tool_calls += 1
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.02)
+            return ToolResult(output=arguments)
+        raise AssertionError("unreachable")
+
+    async def late_tool_error(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal tool_calls
+        del arguments
+        tool_calls += 1
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.02)
+            raise RuntimeError("late Tool failure")
+        raise AssertionError("unreachable")
+
+    async def late_tool_over_reservation(
+        arguments: Mapping[str, object],
+    ) -> ToolResult:
+        nonlocal tool_calls
+        del arguments
+        tool_calls += 1
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.02)
+            return ToolResult(output=None, tokens=1, cost_microunits=1)
+        raise AssertionError("unreachable")
+
+    async def blocking_late_tool_over_reservation(
+        arguments: Mapping[str, object],
+    ) -> ToolResult:
+        nonlocal tool_calls
+        del arguments
+        tool_calls += 1
+        time.sleep(0.02)
+        return ToolResult(output=None, tokens=1, cost_microunits=1)
+
+    class LateApprover:
+        name = "late-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        def __init__(self, *, fail_late: bool = False) -> None:
+            self.fail_late = fail_late
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await asyncio.sleep(0.02)
+                if self.fail_late:
+                    raise RuntimeError("late Approver failure")
+                return ApprovalDecision.approve(
+                    request,
+                )
+            raise AssertionError("unreachable")
+
+    def trial(
+        *,
+        approval: bool,
+        trial_id: str,
+        handler: object = late_tool,
+        approver_fails_late: bool = False,
+        repeat: bool = False,
+    ) -> Trial:
+        return Trial(
+            task=Task(id=trial_id, input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("late")]
+                + ([Action.invoke("late")] if repeat else [])
+                + [Action.finish("recovered")],
+                name="late-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="late",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.read",
+                            requires_approval=approval,
+                        ),
+                        handler,  # type: ignore[arg-type]
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("late",),
+                    allowed_permissions=("fixture.read",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=2 if repeat else 1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=0.005,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=(
+                    LateApprover(fail_late=approver_fails_late)
+                    if approval
+                    else None
+                ),
+                name="late-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("recovered", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=3 if repeat else 2),
+        )
+
+    async def scenario() -> None:
+        late_result = await trial(approval=False, trial_id="late-tool-1").run()
+        approval_result = await trial(approval=True, trial_id="late-approval-1").run()
+        late_error_result = await trial(
+            approval=False,
+            trial_id="late-tool-error-1",
+            handler=late_tool_error,
+        ).run()
+        approval_error_result = await trial(
+            approval=True,
+            trial_id="late-approval-error-1",
+            approver_fails_late=True,
+        ).run()
+        late_over_reservation_result = await trial(
+            approval=False,
+            trial_id="late-tool-over-reservation-1",
+            handler=late_tool_over_reservation,
+            repeat=True,
+        ).run()
+        blocking_late_over_reservation_result = await trial(
+            approval=False,
+            trial_id="blocking-late-tool-over-reservation-1",
+            handler=blocking_late_tool_over_reservation,
+            repeat=True,
+        ).run()
+
+        late_outcome = next(
+            record.payload
+            for record in late_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        approval_outcome = next(
+            record.payload
+            for record in approval_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        late_error_outcome = next(
+            record.payload
+            for record in late_error_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        approval_error_outcome = next(
+            record.payload
+            for record in approval_error_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        )
+        late_over_reservation_outcomes = [
+            record.payload
+            for record in late_over_reservation_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        blocking_late_over_reservation_outcomes = [
+            record.payload
+            for record in blocking_late_over_reservation_result.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert late_outcome["status"] == "timed_out"
+        assert late_outcome["error_code"] == "tool_timed_out"
+        assert approval_outcome["status"] == "timed_out"
+        assert approval_outcome["error_code"] == "approval_timed_out"
+        assert late_error_outcome["status"] == "timed_out"
+        assert late_error_outcome["error_code"] == "tool_timed_out"
+        assert approval_error_outcome["status"] == "timed_out"
+        assert approval_error_outcome["error_code"] == "approval_timed_out"
+        assert [outcome["status"] for outcome in late_over_reservation_outcomes] == [
+            "failed",
+            "budget_exhausted",
+        ]
+        assert late_over_reservation_outcomes[0]["error_code"] == (
+            "usage_exceeded_reservation"
+        )
+        assert late_over_reservation_outcomes[0]["usage"] == {
+            "tokens": 1,
+            "cost_microunits": 1,
+        }
+        assert late_over_reservation_outcomes[0]["budget_charged"] == {
+            "tokens": 1,
+            "cost_microunits": 1,
+        }
+        assert late_over_reservation_outcomes[1]["error_code"] == (
+            "usage_budget_exhausted"
+        )
+        assert [
+            outcome["status"] for outcome in blocking_late_over_reservation_outcomes
+        ] == ["failed", "budget_exhausted"]
+        assert blocking_late_over_reservation_outcomes[0]["error_code"] == (
+            "usage_exceeded_reservation"
+        )
+        assert blocking_late_over_reservation_outcomes[1]["error_code"] == (
+            "usage_budget_exhausted"
+        )
+        assert tool_calls == 4
+        assert replay(late_result.trajectory) == late_result
+        assert replay(approval_result.trajectory) == approval_result
+        assert replay(late_error_result.trajectory) == late_error_result
+        assert replay(approval_error_result.trajectory) == approval_error_result
+        assert replay(late_over_reservation_result.trajectory) == (
+            late_over_reservation_result
+        )
+        assert replay(blocking_late_over_reservation_result.trajectory) == (
+            blocking_late_over_reservation_result
+        )
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_during_tool_records_one_outcome_before_trial_cancellation() -> None:
+    started: asyncio.Event
+
+    async def blocking(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        nonlocal started
+        started = asyncio.Event()
+        trial = Trial(
+            task=Task(id="cancel-tool", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("blocking")],
+                name="cancel-tool-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="blocking",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.read",
+                        ),
+                        blocking,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("blocking",),
+                    allowed_permissions=("fixture.read",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=30,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                name="cancel-tool",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="cancel-tool-1", max_actions=1),
+        )
+        running = asyncio.create_task(trial.run())
+        await started.wait()
+        running.cancel()
+        try:
+            await running
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError("Trial cancellation did not propagate")
+
+        assert [record.kind for record in trial.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "agent.action",
+            "tool.call.outcome",
+            "trial.cancelled",
+            "trial.terminated",
+        ]
+        assert trial.trajectory.records[3].payload["status"] == "cancelled"
+        assert replay(trial.trajectory).status is TrialStatus.CANCELLED
+
+        forged_records = list(trial.trajectory.records)
+        forged_records[-2] = replace(
+            forged_records[-2],
+            kind="trial.failure",
+            payload={
+                "phase": "environment",
+                "code": "environment_step_error",
+                "exception_type": "RuntimeError",
+                "message": "forged failure",
+            },
+        )
+        forged_records[-1] = replace(
+            forged_records[-1],
+            payload={"status": "failed", "phase": "environment"},
+        )
+        forged = _with_records(trial.trajectory, forged_records)
+        with pytest.raises(ValueError, match="invalid Trajectory causal order"):
+            replay(forged)
+
+    asyncio.run(scenario())
+
+
+def test_agent_cannot_swallow_caller_cancellation_and_start_a_tool() -> None:
+    started: asyncio.Event
+    effects = 0
+
+    class CallbackBaseError(BaseException):
+        pass
+
+    class SwallowingAgent:
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        def __init__(self, mode: str) -> None:
+            self.mode = mode
+            self.name = f"swallow-cancel-{mode}"
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                if self.mode == "return":
+                    return Action.invoke("effect")
+                if self.mode == "uncancel-return":
+                    current = asyncio.current_task()
+                    if current is None:
+                        raise AssertionError("Agent callback has no current Task")
+                    current.uncancel()
+                    return Action.invoke("effect")
+                if self.mode == "error":
+                    raise RuntimeError("callback replaced cancellation")
+                raise CallbackBaseError("callback replaced cancellation")
+            raise AssertionError("unreachable")
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal effects
+        effects += 1
+        return ToolResult(output=arguments)
+
+    def trial(mode: str) -> Trial:
+        return Trial(
+            task=Task(id=f"swallow-cancel-{mode}", input=None),
+            agent=SwallowingAgent(mode),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="effect",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("effect",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                name=f"swallow-cancel-{mode}",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id=f"swallow-cancel-{mode}-1", max_actions=1),
+        )
+
+    async def scenario() -> None:
+        nonlocal started
+        for mode in ("return", "uncancel-return", "error", "base-error"):
+            started = asyncio.Event()
+            current = trial(mode)
+            running = asyncio.create_task(current.run())
+            await started.wait()
+            running.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await running
+            assert [record.kind for record in current.trajectory.records][-2:] == [
+                "trial.cancelled",
+                "trial.terminated",
+            ]
+            assert replay(current.trajectory).status is TrialStatus.CANCELLED
+        assert effects == 0
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_during_timeout_cleanup_remains_caller_cancellation() -> None:
+    cleanup_started: asyncio.Event
+    approval_cleanup_started: asyncio.Event
+    calls = 0
+    fail_tool_cleanup = False
+    fail_approval_cleanup = False
+
+    async def slow_cleanup(arguments: Mapping[str, object]) -> ToolResult:
+        del arguments
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                if fail_tool_cleanup:
+                    raise RuntimeError("late Tool cleanup failed")
+                return ToolResult(output="ignored late result")
+        raise AssertionError("unreachable")
+
+    class SlowCleanupApprover:
+        name = "slow-cleanup-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                approval_cleanup_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    if fail_approval_cleanup:
+                        raise RuntimeError("late Approval cleanup failed")
+                    return ApprovalDecision.approve(request)
+            raise AssertionError("unreachable")
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    def tool_cleanup_trial(trial_id: str) -> Trial:
+        return Trial(
+            task=Task(id=trial_id, input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("slow-cleanup")],
+                name="cancel-timeout-cleanup-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="slow-cleanup",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.read",
+                        ),
+                        slow_cleanup,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("slow-cleanup",),
+                    allowed_permissions=("fixture.read",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=0.005,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                name="cancel-timeout-cleanup",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=1),
+        )
+
+    async def scenario() -> None:
+        nonlocal cleanup_started, approval_cleanup_started, fail_tool_cleanup
+        cleanup_started = asyncio.Event()
+        approval_cleanup_started = asyncio.Event()
+        trial = tool_cleanup_trial("cancel-timeout-cleanup-1")
+        running = asyncio.create_task(trial.run())
+        await cleanup_started.wait()
+        running.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+        outcomes = [
+            record.payload
+            for record in trial.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert len(outcomes) == 1
+        assert outcomes[0]["status"] == "cancelled"
+        assert replay(trial.trajectory).status is TrialStatus.CANCELLED
+
+        fail_tool_cleanup = True
+        cleanup_started = asyncio.Event()
+        failing_cleanup_trial = tool_cleanup_trial(
+            "cancel-failing-timeout-cleanup-1"
+        )
+        failing_cleanup_running = asyncio.create_task(failing_cleanup_trial.run())
+        await cleanup_started.wait()
+        failing_cleanup_running.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await failing_cleanup_running
+        failing_cleanup_outcomes = [
+            record.payload
+            for record in failing_cleanup_trial.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert len(failing_cleanup_outcomes) == 1
+        assert failing_cleanup_outcomes[0]["status"] == "cancelled"
+        assert replay(failing_cleanup_trial.trajectory).status is TrialStatus.CANCELLED
+
+        approval_trial = Trial(
+            task=Task(id="cancel-approval-timeout-cleanup", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write")],
+                name="cancel-approval-timeout-cleanup-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="write",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                            requires_approval=True,
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("write",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=0.005,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=SlowCleanupApprover(),
+                name="cancel-approval-timeout-cleanup",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(
+                trial_id="cancel-approval-timeout-cleanup-1",
+                max_actions=1,
+            ),
+        )
+        approval_running = asyncio.create_task(approval_trial.run())
+        await approval_cleanup_started.wait()
+        approval_running.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await approval_running
+
+        approval_outcomes = [
+            record.payload
+            for record in approval_trial.trajectory.records
+            if record.kind == "tool.call.outcome"
+        ]
+        assert calls == 0
+        assert len(approval_outcomes) == 1
+        assert approval_outcomes[0]["status"] == "cancelled"
+        assert replay(approval_trial.trajectory).status is TrialStatus.CANCELLED
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_during_approval_never_starts_the_tool() -> None:
+    approval_started: asyncio.Event
+    calls = 0
+
+    class BlockingApprover:
+        name = "blocking-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            approval_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def scenario() -> None:
+        nonlocal approval_started
+        approval_started = asyncio.Event()
+        trial = Trial(
+            task=Task(id="cancel-approval", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("write")],
+                name="cancel-approval-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="write",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.write",
+                            requires_approval=True,
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("write",),
+                    allowed_permissions=("fixture.write",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=30,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=BlockingApprover(),
+                name="cancel-approval",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="cancel-approval-1", max_actions=1),
+        )
+        running = asyncio.create_task(trial.run())
+        await approval_started.wait()
+        running.cancel()
+        try:
+            await running
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError("Trial cancellation did not propagate")
+
+        assert calls == 0
+        outcomes = [
+            record for record in trial.trajectory.records if record.kind == "tool.call.outcome"
+        ]
+        assert len(outcomes) == 1
+        assert outcomes[0].payload["status"] == "cancelled"
+        assert outcomes[0].payload["budget_charged"] == {
+            "tokens": 0,
+            "cost_microunits": 0,
+        }
+        assert replay(trial.trajectory).status is TrialStatus.CANCELLED
+
+    asyncio.run(scenario())
+
+
+def test_replay_rejects_missing_duplicate_or_mismatched_tool_outcomes() -> None:
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        return ToolResult(output=arguments)
+
+    async def original() -> Trajectory:
+        result = await Trial(
+            task=Task(id="tamper-tool", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("effect"), Action.finish("done")],
+                name="tamper-tool-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="effect",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.read",
+                        ),
+                        effect,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("effect",),
+                    allowed_permissions=("fixture.read",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                name="tamper-tool",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id="tamper-tool-1", max_actions=2),
+        ).run()
+        return result.trajectory
+
+    def with_records(
+        trajectory: Trajectory,
+        records: list[object],
+    ) -> Trajectory:
+        return replace(
+            trajectory,
+            records=tuple(
+                replace(record, sequence=index)
+                for index, record in enumerate(records)
+            ),
+        )
+
+    trajectory = asyncio.run(original())
+    records = list(trajectory.records)
+    outcome_index = next(
+        index for index, record in enumerate(records) if record.kind == "tool.call.outcome"
+    )
+
+    missing = with_records(trajectory, records[:outcome_index] + records[outcome_index + 1 :])
+    duplicate = with_records(
+        trajectory,
+        records[: outcome_index + 1] + [records[outcome_index]] + records[outcome_index + 1 :],
+    )
+    wrong_name_record = replace(
+        records[outcome_index],
+        payload={**records[outcome_index].payload, "tool_name": "another-tool"},
+    )
+    wrong_name = with_records(
+        trajectory,
+        records[:outcome_index] + [wrong_name_record] + records[outcome_index + 1 :],
+    )
+    wrong_spec_record = replace(
+        records[outcome_index],
+        payload={
+            **records[outcome_index].payload,
+            "tool_spec_hash": "sha256:wrong",
+        },
+    )
+    wrong_spec = with_records(
+        trajectory,
+        records[:outcome_index] + [wrong_spec_record] + records[outcome_index + 1 :],
+    )
+    wrong_approval_record = replace(
+        records[outcome_index],
+        payload={
+            **records[outcome_index].payload,
+            "approval": {
+                "status": "approved",
+                "approver": "forged",
+                "approver_version": "1",
+                "reason": "",
+            },
+        },
+    )
+    wrong_approval = with_records(
+        trajectory,
+        records[:outcome_index]
+        + [wrong_approval_record]
+        + records[outcome_index + 1 :],
+    )
+    wrong_approval_reason_record = replace(
+        records[outcome_index],
+        payload={
+            **records[outcome_index].payload,
+            "approval": {
+                **records[outcome_index].payload["approval"],
+                "reason": "forged",
+            },
+        },
+    )
+    wrong_approval_reason = with_records(
+        trajectory,
+        records[:outcome_index]
+        + [wrong_approval_reason_record]
+        + records[outcome_index + 1 :],
+    )
+    transition_index = next(
+        index
+        for index, record in enumerate(records[outcome_index + 1 :], outcome_index + 1)
+        if record.kind == "environment.transition"
+    )
+    original_observation = records[transition_index].payload["observation"]
+    original_tool_call = original_observation["tool_call"]
+    wrong_observation_record = replace(
+        records[transition_index],
+        payload={
+            **records[transition_index].payload,
+            "observation": {
+                "tool_call": {**original_tool_call, "output": "forged-output"}
+            },
+        },
+    )
+    wrong_observation = with_records(
+        trajectory,
+        records[:transition_index]
+        + [wrong_observation_record]
+        + records[transition_index + 1 :],
+    )
+    reset_index = next(
+        index for index, record in enumerate(records) if record.kind == "environment.reset"
+    )
+    wrong_reset_record = replace(
+        records[reset_index],
+        payload={**records[reset_index].payload, "observation": {"forged": True}},
+    )
+    wrong_reset = with_records(
+        trajectory,
+        records[:reset_index] + [wrong_reset_record] + records[reset_index + 1 :],
+    )
+
+    for tampered in (
+        missing,
+        duplicate,
+        wrong_name,
+        wrong_spec,
+        wrong_approval,
+        wrong_approval_reason,
+        wrong_observation,
+        wrong_reset,
+    ):
+        with pytest.raises(ValueError, match="invalid Trajectory causal order"):
+            replay(tampered)
+
+
+def test_replay_rejects_noncanonical_or_orphan_control_declarations() -> None:
+    async def unused(arguments: Mapping[str, object]) -> ToolResult:
+        raise AssertionError(f"final-only Trial invoked a Tool: {arguments}")
+
+    async def original() -> Trajectory:
+        result = await Trial(
+            task=Task(id="tamper-control-config", input=None),
+            agent=ScriptedAgent(
+                [Action.finish("done")],
+                name="tamper-control-config-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="unused",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                            permission_name="fixture.read",
+                            runtime_capabilities=("cap.a", "cap.z"),
+                        ),
+                        unused,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("unused",),
+                    allowed_permissions=("fixture.read",),
+                    allowed_runtime_capabilities=("cap.a", "cap.z"),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=0,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                name="tamper-control-config",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id="tamper-control-config-1", max_actions=1),
+        ).run()
+        return result.trajectory
+
+    trajectory = asyncio.run(original())
+
+    def forge_policy(**updates: JsonValue) -> Trajectory:
+        configuration = cast(
+            dict[str, JsonValue],
+            _thaw_json(trajectory.configuration),
+        )
+        environment = cast(dict[str, JsonValue], configuration["environment"])
+        controlled = cast(dict[str, JsonValue], environment["config"])
+        policy = cast(dict[str, JsonValue], controlled["policy"])
+        policy.update(updates)
+        controlled["policy_hash"] = _hash_json_object(policy)
+        return _with_configuration(trajectory, configuration)
+
+    forged = [
+        forge_policy(allowed_tools=["ghost"]),
+        forge_policy(approval_required_tools=["ghost"]),
+        forge_policy(approval_required_permissions=["fixture.write"]),
+        forge_policy(allowed_permissions=["fixture.read", "fixture.read"]),
+        forge_policy(allowed_runtime_capabilities=["cap.z", "cap.a"]),
+    ]
+
+    configuration = cast(dict[str, JsonValue], _thaw_json(trajectory.configuration))
+    environment = cast(dict[str, JsonValue], configuration["environment"])
+    controlled = cast(dict[str, JsonValue], environment["config"])
+    tools = cast(list[JsonValue], controlled["tools"])
+    tool = cast(dict[str, JsonValue], tools[0])
+    tool["runtime_capabilities"] = ["cap.z", "cap.a"]
+    forged.append(_with_configuration(trajectory, configuration))
+
+    configuration = cast(dict[str, JsonValue], _thaw_json(trajectory.configuration))
+    environment = cast(dict[str, JsonValue], configuration["environment"])
+    controlled = cast(dict[str, JsonValue], environment["config"])
+    budget = cast(dict[str, JsonValue], controlled["budget"])
+    budget["tool_timeout_seconds"] = 1
+    controlled["budget_hash"] = _hash_json_object(budget)
+    forged.append(_with_configuration(trajectory, configuration))
+
+    for tampered in forged:
+        with pytest.raises(ValueError, match="invalid Trajectory causal order"):
+            replay(tampered)
+
+
+def test_replay_rejects_self_consistent_control_state_forgery() -> None:
+    async def metered(arguments: Mapping[str, object]) -> ToolResult:
+        return ToolResult(output=arguments.get("value"), tokens=1)
+
+    class AlwaysApprover:
+        name = "forge-approver"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, request: ApprovalRequest) -> ApprovalDecision:
+            return ApprovalDecision.approve(request)
+
+    async def run_case(
+        *,
+        trial_id: str,
+        actions: list[Action],
+        spec: ToolSpec,
+        policy: ExecutionPolicy,
+        max_tokens: int,
+        approver: object | None = None,
+    ) -> Trajectory:
+        result = await Trial(
+            task=Task(id=trial_id, input={"case": trial_id}),
+            agent=ScriptedAgent(
+                actions,
+                name=f"{trial_id}-agent",
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(Tool(spec, metered),),
+                policy=policy,
+                budget=ExecutionBudget(
+                    max_tool_calls=max(1, len(actions) - 1),
+                    max_tokens=max_tokens,
+                    max_cost_microunits=0,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="fixture-1",
+                ),
+                approver=approver,  # type: ignore[arg-type]
+                name=f"{trial_id}-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=len(actions)),
+        ).run()
+        assert replay(result.trajectory) == result
+        return result.trajectory
+
+    plain_spec = ToolSpec(
+        name="metered",
+        version="1",
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        permission_name="fixture.read",
+        reserved_tokens=1,
+    )
+    plain_policy = ExecutionPolicy(
+        version="1",
+        allowed_tools=("metered",),
+        allowed_permissions=("fixture.read",),
+    )
+    capability_spec = ToolSpec(
+        name="metered",
+        version="1",
+        input_schema=plain_spec.input_schema,
+        permission_name="fixture.read",
+        runtime_capabilities=("network",),
+        reserved_tokens=1,
+    )
+    approval_spec = ToolSpec(
+        name="metered",
+        version="1",
+        input_schema=plain_spec.input_schema,
+        permission_name="fixture.read",
+        requires_approval=True,
+        reserved_tokens=1,
+    )
+
+    async def originals() -> tuple[Trajectory, ...]:
+        unknown = await run_case(
+            trial_id="forge-unknown",
+            actions=[Action.invoke("ghost"), Action.finish("done")],
+            spec=plain_spec,
+            policy=plain_policy,
+            max_tokens=1,
+        )
+        invalid = await run_case(
+            trial_id="forge-invalid",
+            actions=[Action.invoke("metered", {"value": "1"}), Action.finish("done")],
+            spec=plain_spec,
+            policy=plain_policy,
+            max_tokens=1,
+        )
+        denied = await run_case(
+            trial_id="forge-policy",
+            actions=[Action.invoke("metered", {"value": 1}), Action.finish("done")],
+            spec=capability_spec,
+            policy=plain_policy,
+            max_tokens=1,
+        )
+        succeeded = await run_case(
+            trial_id="forge-success",
+            actions=[Action.invoke("metered", {"value": 1}), Action.finish("done")],
+            spec=plain_spec,
+            policy=plain_policy,
+            max_tokens=1,
+        )
+        cumulative = await run_case(
+            trial_id="forge-cumulative",
+            actions=[
+                Action.invoke("metered", {"value": 1}),
+                Action.invoke("metered", {"value": 2}),
+                Action.finish("done"),
+            ],
+            spec=plain_spec,
+            policy=plain_policy,
+            max_tokens=1,
+        )
+        approval_missing = await run_case(
+            trial_id="forge-approval",
+            actions=[Action.invoke("metered", {"value": 1}), Action.finish("done")],
+            spec=approval_spec,
+            policy=plain_policy,
+            max_tokens=1,
+        )
+        approval_approved = await run_case(
+            trial_id="forge-approval-declared",
+            actions=[Action.invoke("metered", {"value": 1}), Action.finish("done")],
+            spec=approval_spec,
+            policy=plain_policy,
+            max_tokens=1,
+            approver=AlwaysApprover(),
+        )
+        return (
+            unknown,
+            invalid,
+            denied,
+            succeeded,
+            cumulative,
+            approval_missing,
+            approval_approved,
+        )
+
+    (
+        unknown,
+        invalid,
+        denied,
+        succeeded,
+        cumulative,
+        approval_missing,
+        approval_approved,
+    ) = asyncio.run(originals())
+    forged_success = {
+        "status": "succeeded",
+        "usage": {"tokens": 0, "cost_microunits": 0},
+        "budget_charged": {"tokens": 0, "cost_microunits": 0},
+        "error_code": None,
+        "message": None,
+    }
+    forged = [
+        _with_self_consistent_tool_outcome(unknown, **forged_success),
+        _with_self_consistent_tool_outcome(invalid, **forged_success),
+        _with_self_consistent_tool_outcome(denied, **forged_success),
+        _with_self_consistent_tool_outcome(succeeded, request_hash=None),
+        _with_self_consistent_tool_outcome(
+            cumulative,
+            outcome_number=1,
+            **forged_success,
+        ),
+        _with_self_consistent_tool_outcome(
+            approval_missing,
+            status="denied",
+            approval={
+                "status": "failed",
+                "approver": None,
+                "approver_version": None,
+                "reason": "",
+            },
+            error_code="approval_failed",
+            message="Approver failed: RuntimeError",
+        ),
+        _with_self_consistent_tool_outcome(
+            approval_approved,
+            status="denied",
+            approval={
+                "status": "missing",
+                "approver": None,
+                "approver_version": None,
+                "reason": "",
+            },
+            usage={"tokens": 0, "cost_microunits": 0},
+            budget_charged={"tokens": 0, "cost_microunits": 0},
+            error_code="approval_missing",
+            message="Tool requires an Approver",
+        ),
+    ]
+
+    split_records = list(denied.records)
+    split_outcome_index = next(
+        index
+        for index, record in enumerate(split_records)
+        if record.kind == "tool.call.outcome"
+    )
+    split_transition_index = next(
+        index
+        for index, record in enumerate(split_records[split_outcome_index + 1 :])
+        if record.kind == "environment.transition"
+    ) + split_outcome_index + 1
+    split_transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(split_records[split_transition_index].payload),
+    )
+    split_observation = cast(
+        dict[str, JsonValue],
+        split_transition["observation"],
+    )
+    split_tool_call = cast(dict[str, JsonValue], split_observation["tool_call"])
+    split_tool_call["message"] = "forged observation detail"
+    split_outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(split_records[split_outcome_index].payload),
+    )
+    split_outcome["observation_hash"] = _hash_json_object(
+        {"observation": split_observation}
+    )
+    split_records[split_outcome_index] = replace(
+        split_records[split_outcome_index],
+        payload=split_outcome,
+    )
+    split_records[split_transition_index] = replace(
+        split_records[split_transition_index],
+        payload=split_transition,
+    )
+    forged.append(_with_records(denied, split_records))
+
+    error_split_records = list(denied.records)
+    error_split_transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(error_split_records[split_transition_index].payload),
+    )
+    error_split_observation = cast(
+        dict[str, JsonValue],
+        error_split_transition["observation"],
+    )
+    error_split_tool_call = cast(
+        dict[str, JsonValue],
+        error_split_observation["tool_call"],
+    )
+    error_split_tool_call["error_code"] = "forged_error"
+    error_split_outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(error_split_records[split_outcome_index].payload),
+    )
+    error_split_outcome["observation_hash"] = _hash_json_object(
+        {"observation": error_split_observation}
+    )
+    error_split_records[split_outcome_index] = replace(
+        error_split_records[split_outcome_index],
+        payload=error_split_outcome,
+    )
+    error_split_records[split_transition_index] = replace(
+        error_split_records[split_transition_index],
+        payload=error_split_transition,
+    )
+    forged.append(_with_records(denied, error_split_records))
+
+    denied_output_records = list(denied.records)
+    denied_output_transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(denied_output_records[split_transition_index].payload),
+    )
+    denied_output_observation = cast(
+        dict[str, JsonValue],
+        denied_output_transition["observation"],
+    )
+    denied_output_tool_call = cast(
+        dict[str, JsonValue],
+        denied_output_observation["tool_call"],
+    )
+    denied_output_tool_call["output"] = {"forged": "secret-from-denied-tool"}
+    denied_output_outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(denied_output_records[split_outcome_index].payload),
+    )
+    denied_output_outcome["observation_hash"] = _hash_json_object(
+        {"observation": denied_output_observation}
+    )
+    denied_output_records[split_outcome_index] = replace(
+        denied_output_records[split_outcome_index],
+        payload=denied_output_outcome,
+    )
+    denied_output_records[split_transition_index] = replace(
+        denied_output_records[split_transition_index],
+        payload=denied_output_transition,
+    )
+    forged.append(_with_records(denied, denied_output_records))
+
+    failed_after_outcome_records = denied.records[:split_transition_index] + (
+        replace(
+            denied.records[split_transition_index],
+            kind="trial.failure",
+            payload={
+                "phase": "environment",
+                "code": "environment_step_error",
+                "exception_type": "RuntimeError",
+                "message": "forged failure after a committed outcome",
+            },
+        ),
+        replace(
+            denied.records[-1],
+            payload={"status": "failed", "phase": "environment"},
+        ),
+    )
+    forged.append(
+        _with_records(denied, list(failed_after_outcome_records))
+    )
+
+    missing_field_records = list(succeeded.records)
+    succeeded_outcome_index = next(
+        index
+        for index, record in enumerate(missing_field_records)
+        if record.kind == "tool.call.outcome"
+    )
+    succeeded_transition_index = next(
+        index
+        for index, record in enumerate(
+            missing_field_records[succeeded_outcome_index + 1 :]
+        )
+        if record.kind == "environment.transition"
+    ) + succeeded_outcome_index + 1
+    missing_field_outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(missing_field_records[succeeded_outcome_index].payload),
+    )
+    missing_field_transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(missing_field_records[succeeded_transition_index].payload),
+    )
+    missing_field_observation = cast(
+        dict[str, JsonValue],
+        missing_field_transition["observation"],
+    )
+    missing_field_tool_call = cast(
+        dict[str, JsonValue],
+        missing_field_observation["tool_call"],
+    )
+    missing_field_outcome.pop("error_code")
+    missing_field_outcome.pop("message")
+    missing_field_tool_call.pop("error_code")
+    missing_field_tool_call.pop("message")
+    missing_field_tool_call.pop("output")
+    missing_field_outcome["observation_hash"] = _hash_json_object(
+        {"observation": missing_field_observation}
+    )
+    missing_field_records[succeeded_outcome_index] = replace(
+        missing_field_records[succeeded_outcome_index],
+        payload=missing_field_outcome,
+    )
+    missing_field_records[succeeded_transition_index] = replace(
+        missing_field_records[succeeded_transition_index],
+        payload=missing_field_transition,
+    )
+    forged.append(_with_records(succeeded, missing_field_records))
+
+    extra_field_records = list(succeeded.records)
+    extra_field_outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(extra_field_records[succeeded_outcome_index].payload),
+    )
+    extra_field_outcome["undeclared"] = "forged"
+    extra_field_records[succeeded_outcome_index] = replace(
+        extra_field_records[succeeded_outcome_index],
+        payload=extra_field_outcome,
+    )
+    forged.append(_with_records(succeeded, extra_field_records))
+
+    typed_split_records = list(succeeded.records)
+    typed_split_transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(typed_split_records[succeeded_transition_index].payload),
+    )
+    typed_split_observation = cast(
+        dict[str, JsonValue],
+        typed_split_transition["observation"],
+    )
+    typed_split_tool_call = cast(
+        dict[str, JsonValue],
+        typed_split_observation["tool_call"],
+    )
+    typed_split_usage = cast(
+        dict[str, JsonValue],
+        typed_split_tool_call["usage"],
+    )
+    typed_split_usage["tokens"] = True
+    typed_split_outcome = cast(
+        dict[str, JsonValue],
+        _thaw_json(typed_split_records[succeeded_outcome_index].payload),
+    )
+    typed_split_outcome["observation_hash"] = _hash_json_object(
+        {"observation": typed_split_observation}
+    )
+    typed_split_records[succeeded_outcome_index] = replace(
+        typed_split_records[succeeded_outcome_index],
+        payload=typed_split_outcome,
+    )
+    typed_split_records[succeeded_transition_index] = replace(
+        typed_split_records[succeeded_transition_index],
+        payload=typed_split_transition,
+    )
+    forged.append(_with_records(succeeded, typed_split_records))
+
+    final_records = list(succeeded.records)
+    final_action_index = max(
+        index
+        for index, record in enumerate(final_records)
+        if record.kind == "agent.action"
+    )
+    final_transition_index = next(
+        index
+        for index, record in enumerate(final_records[final_action_index + 1 :])
+        if record.kind == "environment.transition"
+    ) + final_action_index + 1
+    final_transition = cast(
+        dict[str, JsonValue],
+        _thaw_json(final_records[final_transition_index].payload),
+    )
+    final_transition["observation"] = "forged"
+    final_transition["output"] = "forged"
+    final_records[final_transition_index] = replace(
+        final_records[final_transition_index],
+        payload=final_transition,
+    )
+    forged.append(_with_records(succeeded, final_records))
+
+    for tampered in forged:
+        with pytest.raises(ValueError, match="invalid Trajectory causal order"):
+            replay(tampered)
+
+
+def test_persisted_experiment_resume_never_reexecutes_a_controlled_tool(tmp_path) -> None:
+    first_calls = 0
+    resumed_calls = 0
+
+    async def first_handler(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal first_calls
+        first_calls += 1
+        return ToolResult(output=arguments["value"])
+
+    async def bomb_handler(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal resumed_calls
+        resumed_calls += 1
+        raise AssertionError(f"re-executed persisted Tool: {arguments}")
+
+    def experiment(handler: object) -> Experiment:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="persisted",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                            "required": ["value"],
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                    ),
+                    handler,  # type: ignore[arg-type]
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("persisted",),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=1,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="persisted-environment",
+            version="1",
+        )
+        trial = Trial(
+            task=Task(id="persisted-tool", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("persisted", {"value": "ok"}), Action.finish("done")],
+                name="persisted-tool-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id="persisted-tool-1", max_actions=2),
+        )
+        return Experiment(
+            experiment_id="persisted-controlled-tool",
+            version="1",
+            baseline="baseline",
+            trials={"baseline": (trial,)},
+        )
+
+    async def scenario() -> None:
+        path = tmp_path / "controlled.jsonl"
+        first = await experiment(first_handler).run(JsonlTrajectoryStore(path))
+        resumed = await experiment(bomb_handler).run(JsonlTrajectoryStore(path))
+
+        assert first.complete is True
+        assert resumed == first
+        assert first_calls == 1
+        assert resumed_calls == 0
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored == first
+        assert replay(stored.results["baseline"][0].trajectory).status is TrialStatus.COMPLETED
+
+    asyncio.run(scenario())
+
+
+def test_controlled_environment_is_single_use_and_rejects_duplicate_action_indexes() -> None:
+    calls = 0
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        calls += 1
+        return ToolResult(output=arguments)
+
+    async def scenario() -> None:
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="effect",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                    ),
+                    effect,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("effect",),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=2,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="single-use",
+            version="1",
+        )
+        task = Task(id="single-use", input=None)
+        await environment.reset(task, seed=0)
+        await environment.step(Action.invoke("effect"), seed=0, action_index=0)
+        assert environment._drain_trajectory_records() == ()
+        assert environment._request_nonces == {}
+
+        with pytest.raises(RuntimeError, match="action_index must be contiguous"):
+            await environment.step(Action.invoke("effect"), seed=0, action_index=0)
+        with pytest.raises(RuntimeError, match="single-use"):
+            await environment.reset(task, seed=0)
+        assert calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_concurrent_steps_cannot_execute_after_a_final_action() -> None:
+    started: asyncio.Event
+    release: asyncio.Event
+    calls = 0
+
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        nonlocal calls
+        del arguments
+        calls += 1
+        if calls == 1:
+            started.set()
+            await release.wait()
+        return ToolResult(output="effect")
+
+    async def scenario() -> None:
+        nonlocal started, release
+        started = asyncio.Event()
+        release = asyncio.Event()
+        environment = ControlledToolEnvironment(
+            tools=(
+                Tool(
+                    ToolSpec(
+                        name="effect",
+                        version="1",
+                        input_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                        permission_name="fixture.read",
+                    ),
+                    effect,
+                ),
+            ),
+            policy=ExecutionPolicy(
+                version="1",
+                allowed_tools=("effect",),
+                allowed_permissions=("fixture.read",),
+            ),
+            budget=ExecutionBudget(
+                max_tool_calls=2,
+                max_tokens=0,
+                max_cost_microunits=0,
+                tool_timeout_seconds=1,
+                currency="USD",
+                pricing_version="fixture-1",
+            ),
+            name="concurrent-final",
+            version="1",
+        )
+        await environment.reset(Task(id="concurrent-final", input=None), seed=0)
+        first = asyncio.create_task(
+            environment.step(Action.invoke("effect"), seed=0, action_index=0)
+        )
+        await started.wait()
+        final = asyncio.create_task(
+            environment.step(Action.finish("done"), seed=0, action_index=1)
+        )
+        await asyncio.sleep(0)
+        after_final = asyncio.create_task(
+            environment.step(Action.invoke("effect"), seed=0, action_index=2)
+        )
+        await asyncio.sleep(0)
+        release.set()
+
+        await first
+        final_transition = await final
+        assert final_transition.terminated is True
+        with pytest.raises(RuntimeError, match="already terminated"):
+            await after_final
+        assert calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_one_controlled_environment_cannot_be_bound_to_two_trials() -> None:
+    async def effect(arguments: Mapping[str, object]) -> ToolResult:
+        return ToolResult(output=arguments)
+
+    environment = ControlledToolEnvironment(
+        tools=(
+            Tool(
+                ToolSpec(
+                    name="effect",
+                    version="1",
+                    input_schema={
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": False,
+                    },
+                    permission_name="fixture.read",
+                ),
+                effect,
+            ),
+        ),
+        policy=ExecutionPolicy(
+            version="1",
+            allowed_tools=("effect",),
+            allowed_permissions=("fixture.read",),
+        ),
+        budget=ExecutionBudget(
+            max_tool_calls=1,
+            max_tokens=0,
+            max_cost_microunits=0,
+            tool_timeout_seconds=1,
+            currency="USD",
+            pricing_version="fixture-1",
+        ),
+        name="one-binding",
+        version="1",
+    )
+
+    def bind(trial_id: str) -> Trial:
+        return Trial(
+            task=Task(id="one-binding", input=None),
+            agent=ScriptedAgent(
+                [Action.finish("done")],
+                name="one-binding-agent",
+                version="1",
+            ),
+            environment=environment,
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=1),
+        )
+
+    first = bind("one-binding-1")
+    with pytest.raises(RuntimeError, match="only one Trial"):
+        bind("one-binding-2")
+    assert first.trajectory.records == ()
+
+
+def test_schema_enum_comparison_is_deep_and_preserves_large_integer_precision() -> None:
+    huge = 10**400
+    spec = ToolSpec(
+        name="enum",
+        version="1",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "large": {"type": "integer", "enum": [huge]},
+                "nested": {
+                    "type": "object",
+                    "enum": [{"flag": 1}],
+                    "properties": {"flag": {"type": "integer"}},
+                    "required": ["flag"],
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["large", "nested"],
+            "additionalProperties": False,
+        },
+        permission_name="fixture.read",
+    )
+
+    spec.validate(Action.invoke("enum", {"large": huge, "nested": {"flag": 1}}).payload)
+    with pytest.raises(ValueError, match="enum values"):
+        spec.validate(
+            Action.invoke(
+                "enum",
+                {"large": huge + 1, "nested": {"flag": 1}},
+            ).payload
+        )
+    with pytest.raises(ValueError, match="enum values"):
+        spec.validate(
+            Action.invoke(
+                "enum",
+                {"large": huge, "nested": {"flag": True}},
+            ).payload
+        )
+
+
+def test_action_rejects_integers_that_cannot_be_canonical_json() -> None:
+    with pytest.raises(ValueError, match="JSON integer that is too large"):
+        Action.invoke("huge", {"value": 10**5000})
+
+
+def test_controlled_public_values_reject_noncanonical_json_scalars() -> None:
+    with pytest.raises(ValueError, match="JSON integer that is too large"):
+        ToolResult(output=None, tokens=10**5000)
+    with pytest.raises(ValueError, match="not valid Unicode"):
+        ApprovalDecision("sha256:fixture", True, "\ud800")

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -256,6 +256,7 @@ def test_roadmap_contains_versioned_design_decisions() -> None:
     assert "``1.0``\n   |shipped|" in content
     assert "能力里程碑（非版本承诺）" in content
     assert "Headless Trial" in content
+    assert "受控执行\n   |implemented|" in content
     assert "持久化 Experiment" in content
     assert "持久化 Experiment\n   |implemented|" in content
     assert "消息桥接" in content
@@ -294,6 +295,60 @@ def test_research_harness_docs_define_the_provisional_trial_boundary() -> None:
     assert "JSONL" in readme
     assert "通用 Agent 研究 Harness" in readme_zh
     assert "JSONL" in readme_zh
+
+
+def test_controlled_execution_docs_define_scope_and_non_guarantees() -> None:
+    content = _read("docs/guides/research-harness.rst")
+    roadmap = _read("docs/guides/roadmap.rst")
+    api_index = _read("docs/api/index.rst")
+    context = _read("CONTEXT.md")
+    adr = _read("docs/adr/0002-controlled-tool-environment.md")
+    readme = _read("README.md")
+    readme_zh = _read("README.zh.md")
+
+    public_names = (
+        "ToolSpec",
+        "ToolResult",
+        "ExecutionPolicy",
+        "ExecutionBudget",
+        "ApprovalRequest",
+        "ApprovalDecision",
+        "Approver",
+        "ToolCallStatus",
+        "ControlledToolEnvironment",
+    )
+    for name in public_names:
+        assert name in content
+        assert name in api_index
+
+    for status in (
+        "succeeded",
+        "invalid",
+        "denied",
+        "budget_exhausted",
+        "timed_out",
+        "failed",
+        "cancelled",
+    ):
+        assert f"``{status}``" in content
+
+    assert "iamai-json-schema-subset-1" in content
+    assert "tool.call.outcome" in content
+    assert "request nonce" in content
+    assert "tool_timeout_seconds" in content
+    assert "它不是 Trial 总时限" in content
+    assert "usage_exceeded_reservation" in content
+    assert "不是 OS、进程、文件系统、网络或凭据沙箱" in content
+    assert "exactly-once" in content
+    assert "受控执行\n   |implemented|" in roadmap
+    assert "OS/进程/网络沙箱" in roadmap
+    assert "Execution Policy" in context
+    assert "It is not the stable Runtime Permission" in context
+    assert adr.startswith("---\nstatus: accepted\n---")
+    assert "one Trial" in adr
+    assert "external exactly-once" in adr
+    assert "not an OS, process, or network sandbox" in readme
+    assert "不提供 OS、进程或网络沙箱" in readme_zh
 
 
 def test_community_page_contains_blog_and_store_sections() -> None:

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -21,6 +21,8 @@ def test_ecosystem_comparison_contains_matrix_and_roadmap_link() -> None:
     assert "iamai-table-scroll" in content
     assert "差距到实现" in content
     assert ":doc:`roadmap`" in content
+    assert ":doc:`research-harness`" in content
+    assert "AGI 只是研究北极星" in content
 
 
 def test_extensions_reference_contains_public_extension_specs() -> None:
@@ -74,6 +76,8 @@ def test_serialization_reference_contains_v1_contract_rules() -> None:
     assert "``Event.from_payload()``" in content
     assert "同一 major" in content
     assert "legacy normalization" in content
+    assert "Harness JSONL" in content
+    assert "不属于本契约" in content
 
 
 def test_public_api_lifecycle_reference_contains_v1_normative_rules() -> None:
@@ -249,10 +253,47 @@ def test_roadmap_contains_versioned_design_decisions() -> None:
 
     assert "``0.1``" in content
     assert "``0.2``" in content
-    assert "``0.3``\n   |latest-stable|" in content
-    assert "``0.4``\n   |implemented|" in content
-    assert "``1.0``\n   |release-candidate|" in content
+    assert "``1.0``\n   |shipped|" in content
+    assert "能力里程碑（非版本承诺）" in content
+    assert "Headless Trial" in content
+    assert "持久化 Experiment" in content
+    assert "持久化 Experiment\n   |implemented|" in content
+    assert "消息桥接" in content
     assert "WebUI 不进入核心" in content
+
+
+def test_research_harness_docs_define_the_provisional_trial_boundary() -> None:
+    content = _read("docs/guides/research-harness.rst")
+    guides_index = _read("docs/guides/index.rst")
+    api_index = _read("docs/api/index.rst")
+    concepts = _read("docs/concepts.rst")
+    readme = _read("README.md")
+    readme_zh = _read("README.zh.md")
+
+    assert "Task → Agent → Environment → Trajectory → Evaluation" in content
+    assert "iamai.harness" in content
+    assert "provisional" in content
+    assert "completed" in content
+    assert "budget_exhausted" in content
+    assert "failed" in content
+    assert "cancelled" in content
+    assert "Replay" in content
+    assert "Re-execution" in content
+    assert "Experiment(" in content
+    assert "JsonlTrajectoryStore" in content
+    assert "repair_tail" in content
+    assert "single writer" in content
+    assert "独立的 provisional 格式版本" in content
+    assert "interrupted" in content
+    assert "research-harness" in guides_index
+    assert "持久化 Experiment" in guides_index
+    assert "iamai.harness" in api_index
+    assert "provisional" in api_index
+    assert "Trajectory Store" in concepts
+    assert "General-agent research harness" in readme
+    assert "JSONL" in readme
+    assert "通用 Agent 研究 Harness" in readme_zh
+    assert "JSONL" in readme_zh
 
 
 def test_community_page_contains_blog_and_store_sections() -> None:

--- a/tests/test_headless_trial.py
+++ b/tests/test_headless_trial.py
@@ -272,6 +272,33 @@ def test_public_trajectory_constructors_freeze_nested_mappings() -> None:
         record.payload["new"] = "value"  # type: ignore[index]
 
 
+def test_public_json_values_reject_excessive_nesting() -> None:
+    nested: object = "leaf"
+    for _ in range(129):
+        nested = [nested]
+
+    with pytest.raises(ValueError, match="maximum JSON nesting depth"):
+        Task(id="too-deep", input=nested)
+    with pytest.raises(ValueError, match="not valid Unicode"):
+        TrialConfig(trial_id="\ud800")
+    with pytest.raises(ValueError, match="JSON integer that is too large"):
+        TrajectoryRecord(
+            sequence=10**5000,
+            kind="trial.started",
+            payload={},
+        )
+    with pytest.raises(ValueError, match="JSON integer that is too large"):
+        Trajectory(
+            format_version="1",
+            trial_id="huge-seed",
+            task=Task(id="huge-seed", input=None),
+            seed=10**5000,
+            configuration={},
+            config_hash="sha256:fixture",
+            records=(),
+        )
+
+
 def test_public_trial_result_freezes_direct_final_output() -> None:
     async def scenario() -> None:
         original = await _capital_trial().run()
@@ -289,6 +316,13 @@ def test_public_trial_result_freezes_direct_final_output() -> None:
         assert direct.final_output["parts"] == ("Paris",)
 
     asyncio.run(scenario())
+
+
+def test_harness_json_rejects_lone_unicode_surrogates() -> None:
+    with pytest.raises(ValueError, match="valid Unicode"):
+        Action.finish("\ud800")
+    with pytest.raises(ValueError, match="valid Unicode"):
+        Task(id="invalid-unicode-key", input={"\udfff": "value"})
 
 
 def test_cancellation_records_terminal_state_and_propagates() -> None:
@@ -343,6 +377,39 @@ def test_cancellation_records_terminal_state_and_propagates() -> None:
         assert replayed.status is TrialStatus.CANCELLED
         assert replayed.evaluation is None
         assert replayed.failure is None
+
+    asyncio.run(scenario())
+
+
+def test_phase_callback_self_cancellation_is_an_attributed_failure() -> None:
+    class SelfCancellingAgent:
+        name = "self-cancelling-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise asyncio.CancelledError
+
+    async def scenario() -> None:
+        result = await Trial(
+            task=Task(id="self-cancelling-agent", input=None),
+            agent=SelfCancellingAgent(),
+            environment=LookupEnvironment(
+                {},
+                name="self-cancelling-agent-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="self-cancelling-agent-1", max_actions=1),
+        ).run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "agent"
+        assert result.failure.code == "agent_decide_error"
+        assert result.failure.exception_type == "RuntimeError"
+        assert replay(result.trajectory) == result
 
     asyncio.run(scenario())
 
@@ -436,6 +503,20 @@ def test_trial_records_budget_exhaustion_as_an_evaluated_result() -> None:
             "trial.terminated",
         ]
         assert result.trajectory.records[-1].payload["status"] == "budget_exhausted"
+
+        records = list(result.trajectory.records)
+        budget_index = next(
+            index
+            for index, record in enumerate(records)
+            if record.kind == "budget.exhausted"
+        )
+        records[budget_index] = replace(
+            records[budget_index],
+            payload={"max_actions": True},
+        )
+        tampered = replace(result.trajectory, records=tuple(records))
+        with pytest.raises(ValueError, match="invalid Trajectory causal order"):
+            replay(tampered)
 
     asyncio.run(scenario())
 
@@ -768,6 +849,37 @@ def test_unprintable_exception_still_produces_one_terminal_failure() -> None:
             "trial.failure",
             "trial.terminated",
         ]
+
+    asyncio.run(scenario())
+
+
+def test_noncanonical_exception_message_still_produces_terminal_failure() -> None:
+    class FailingAgent:
+        name = "noncanonical-failure-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise ValueError("\ud800")
+
+    async def scenario() -> None:
+        result = await Trial(
+            task=Task(id="noncanonical-failure", input=None),
+            agent=FailingAgent(),
+            environment=LookupEnvironment(
+                {},
+                name="noncanonical-failure-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-noncanonical-failure", max_actions=1),
+        ).run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.message == "<ValueError message unavailable>"
+        assert replay(result.trajectory) == result
 
     asyncio.run(scenario())
 

--- a/tests/test_headless_trial.py
+++ b/tests/test_headless_trial.py
@@ -1,0 +1,979 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import replace
+
+import pytest
+
+import iamai
+import iamai.harness as harness
+from iamai.harness import (
+    Action,
+    Evaluation,
+    ExactEvaluator,
+    LookupEnvironment,
+    Observation,
+    ScriptedAgent,
+    Task,
+    Trial,
+    TrialConfig,
+    TrialResult,
+    TrialStatus,
+    Trajectory,
+    TrajectoryRecord,
+    replay,
+)
+
+
+def test_provisional_harness_is_not_reexported_from_stable_top_level_api() -> None:
+    harness_names = set(harness.__all__)
+
+    assert harness_names.isdisjoint(iamai.__all__)
+    for name in harness_names:
+        assert not hasattr(iamai, name)
+
+
+def _capital_trial(*, final_output: str = "Paris", max_actions: int = 2) -> Trial:
+    return Trial(
+        task=Task(
+            id="capital-of-france",
+            input={"question": "What is the capital of France?"},
+        ),
+        agent=ScriptedAgent(
+            [
+                Action.invoke("lookup", {"key": "france"}),
+                Action.finish(final_output),
+            ],
+            name="scripted-capital-agent",
+            version="1",
+        ),
+        environment=LookupEnvironment(
+            {"france": "Paris"},
+            name="country-capitals",
+            version="1",
+        ),
+        evaluator=ExactEvaluator("Paris", version="1"),
+        config=TrialConfig(
+            trial_id="trial-capital-france",
+            seed=7,
+            max_actions=max_actions,
+        ),
+    )
+
+
+def test_scripted_agent_completes_headless_lookup_trial() -> None:
+    async def scenario() -> None:
+        result = await _capital_trial().run()
+
+        assert result.status is TrialStatus.COMPLETED
+        assert result.final_output == "Paris"
+        assert result.evaluation is not None
+        assert result.evaluation.passed is True
+        assert result.evaluation.score == 1.0
+
+    asyncio.run(scenario())
+
+
+def test_wrong_final_answer_is_completed_but_does_not_pass_evaluation() -> None:
+    async def scenario() -> None:
+        result = await _capital_trial(final_output="Lyon").run()
+
+        assert result.status is TrialStatus.COMPLETED
+        assert result.final_output == "Lyon"
+        assert result.evaluation is not None
+        assert result.evaluation.passed is False
+        assert result.evaluation.score == 0.0
+
+    asyncio.run(scenario())
+
+
+def test_configuration_hash_tracks_declared_harness_configuration_only() -> None:
+    def configured_trial(*, trial_id: str, task_id: str, seed: int) -> Trial:
+        return Trial(
+            task=Task(id=task_id, input={"seed-specific": seed}),
+            agent=ScriptedAgent(
+                [Action.finish("done")],
+                name="configuration-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="configuration-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(
+                trial_id=trial_id,
+                seed=seed,
+                max_actions=1,
+            ),
+        )
+
+    first = configured_trial(trial_id="first", task_id="task-a", seed=1)
+    second = configured_trial(trial_id="second", task_id="task-b", seed=2)
+
+    assert first.trajectory.config_hash == second.trajectory.config_hash
+    assert first.trajectory.trial_id != second.trajectory.trial_id
+    assert first.trajectory.seed != second.trajectory.seed
+
+
+@pytest.mark.parametrize("max_actions", [True, 1.5, "1"])
+def test_trial_config_rejects_non_integer_action_budgets(max_actions: object) -> None:
+    with pytest.raises(TypeError, match="max_actions must be an integer"):
+        TrialConfig(trial_id="invalid-budget", max_actions=max_actions)  # type: ignore[arg-type]
+
+
+def test_scripted_agent_has_no_hidden_cross_trial_cursor() -> None:
+    async def scenario() -> None:
+        agent = ScriptedAgent(
+            [Action.finish("done")],
+            name="reusable-script",
+            version="1",
+        )
+
+        def trial(trial_id: str) -> Trial:
+            return Trial(
+                task=Task(id="reusable-script-task", input=None),
+                agent=agent,
+                environment=LookupEnvironment(
+                    {},
+                    name="reusable-script-environment",
+                    version="1",
+                ),
+                evaluator=ExactEvaluator("done", version="1"),
+                config=TrialConfig(trial_id=trial_id, max_actions=1),
+            )
+
+        first = await trial("reusable-script-first").run()
+        second = await trial("reusable-script-second").run()
+
+        assert first.status is TrialStatus.COMPLETED
+        assert second.status is TrialStatus.COMPLETED
+        assert first.trajectory.config_hash == second.trajectory.config_hash
+
+    asyncio.run(scenario())
+
+
+def test_trial_execution_bindings_cannot_drift_from_trajectory_header() -> None:
+    async def scenario() -> None:
+        trial = _capital_trial()
+
+        with pytest.raises(AttributeError):
+            setattr(
+                trial,
+                "config",
+                TrialConfig(trial_id="replacement", max_actions=1),
+            )
+        with pytest.raises(AttributeError):
+            setattr(
+                trial,
+                "agent",
+                ScriptedAgent(
+                    [Action.finish("replacement")],
+                    name="replacement-agent",
+                    version="1",
+                ),
+            )
+
+        result = await trial.run()
+
+        assert result.trial_id == result.trajectory.trial_id
+        assert replay(result.trajectory).status is TrialStatus.COMPLETED
+
+    asyncio.run(scenario())
+
+
+def test_builtin_evaluator_cannot_drift_from_declared_configuration() -> None:
+    async def scenario() -> None:
+        evaluator = ExactEvaluator("Paris", version="1")
+        trial = Trial(
+            task=Task(id="stable-evaluator", input=None),
+            agent=ScriptedAgent(
+                [Action.finish("Paris")],
+                name="stable-evaluator-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="stable-evaluator-environment",
+                version="1",
+            ),
+            evaluator=evaluator,
+            config=TrialConfig(trial_id="trial-stable-evaluator", max_actions=1),
+        )
+
+        with pytest.raises(AttributeError):
+            setattr(evaluator, "expected", "changed")
+        with pytest.raises(AttributeError):
+            setattr(evaluator, "version", "changed")
+        with pytest.raises(AttributeError):
+            setattr(evaluator, "configuration", {})
+
+        result = await trial.run()
+        assert result.evaluation is not None
+        assert result.evaluation.passed is True
+
+    asyncio.run(scenario())
+
+
+def test_committed_trajectory_does_not_alias_mutable_task_input() -> None:
+    async def scenario() -> None:
+        source = {"question": {"parts": ["capital", "france"]}}
+        task = Task(id="immutable-task", input=source)
+        source["question"]["parts"].append("mutated")
+        result = await Trial(
+            task=task,
+            agent=ScriptedAgent(
+                [Action.finish("Paris")],
+                name="immutable-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="immutable-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="trial-immutable", max_actions=1),
+        ).run()
+
+        question = result.trajectory.task.input
+        assert isinstance(question, Mapping)
+        assert question["question"]["parts"] == ("capital", "france")
+        with pytest.raises(TypeError):
+            result.trajectory.records[-1].payload["status"] = "changed"  # type: ignore[index]
+
+    asyncio.run(scenario())
+
+
+def test_public_trajectory_constructors_freeze_nested_mappings() -> None:
+    payload = {"nested": {"values": [1]}}
+    configuration = {"adapter": {"name": "original"}}
+    record = TrajectoryRecord(sequence=0, kind="trial.started", payload=payload)
+    trajectory = Trajectory(
+        format_version="1",
+        trial_id="public-constructor",
+        task=Task(id="public-constructor-task", input=None),
+        seed=0,
+        configuration=configuration,
+        config_hash="not-used-by-this-test",
+        records=(record,),
+    )
+
+    payload["nested"]["values"].append(2)
+    configuration["adapter"]["name"] = "mutated"
+
+    assert record.payload["nested"]["values"] == (1,)
+    assert trajectory.configuration["adapter"]["name"] == "original"
+    with pytest.raises(TypeError):
+        record.payload["new"] = "value"  # type: ignore[index]
+
+
+def test_public_trial_result_freezes_direct_final_output() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial().run()
+        output = {"parts": ["Paris"]}
+        direct = TrialResult(
+            trial_id=original.trial_id,
+            status=original.status,
+            final_output=output,
+            evaluation=original.evaluation,
+            trajectory=original.trajectory,
+        )
+
+        output["parts"].append("mutated")
+
+        assert direct.final_output["parts"] == ("Paris",)
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_records_terminal_state_and_propagates() -> None:
+    class BlockingAgent:
+        name = "blocking-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        def __init__(self, started: asyncio.Event) -> None:
+            self.started = started
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        started = asyncio.Event()
+        trial = Trial(
+            task=Task(id="cancelled-task", input={"question": "wait"}),
+            agent=BlockingAgent(started),
+            environment=LookupEnvironment(
+                {"unused": "unused"},
+                name="cancel-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-cancelled", max_actions=1),
+        )
+
+        running = asyncio.create_task(trial.run())
+        await started.wait()
+        running.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+        assert [record.kind for record in trial.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "trial.cancelled",
+            "trial.terminated",
+        ]
+        assert trial.trajectory.records[-1].payload == {
+            "status": "cancelled",
+            "phase": "agent",
+            "operation": "agent.decide",
+        }
+
+        replayed = replay(trial.trajectory)
+        assert replayed.status is TrialStatus.CANCELLED
+        assert replayed.evaluation is None
+        assert replayed.failure is None
+
+    asyncio.run(scenario())
+
+
+def test_environment_failure_preserves_the_committed_action() -> None:
+    class FailingEnvironment:
+        name = "failing-environment"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def reset(self, task: Task, *, seed: int) -> Observation:
+            del seed
+            return Observation(task.input)
+
+        async def step(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise OSError("world unavailable")
+
+    async def scenario() -> None:
+        trial = Trial(
+            task=Task(id="failing-world", input={"question": "act"}),
+            agent=ScriptedAgent(
+                [Action.invoke("act")],
+                name="one-action-agent",
+                version="1",
+            ),
+            environment=FailingEnvironment(),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-environment-failure", max_actions=1),
+        )
+
+        result = await trial.run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "environment"
+        assert result.failure.exception_type == "OSError"
+        assert result.failure.message == "world unavailable"
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "agent.action",
+            "trial.failure",
+            "trial.terminated",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_trial_records_a_replayable_causal_trajectory() -> None:
+    async def scenario() -> None:
+        result = await _capital_trial().run()
+
+        trajectory = result.trajectory
+        assert trajectory.trial_id == "trial-capital-france"
+        assert trajectory.task.id == "capital-of-france"
+        assert trajectory.seed == 7
+        assert trajectory.config_hash.startswith("sha256:")
+        assert [record.sequence for record in trajectory.records] == list(range(8))
+        assert [record.kind for record in trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "agent.action",
+            "environment.transition",
+            "agent.action",
+            "environment.transition",
+            "evaluation.recorded",
+            "trial.terminated",
+        ]
+        assert trajectory.records[4].payload["name"] == "final"
+        assert trajectory.records[5].payload["terminated"] is True
+
+    asyncio.run(scenario())
+
+
+def test_trial_records_budget_exhaustion_as_an_evaluated_result() -> None:
+    async def scenario() -> None:
+        result = await _capital_trial(max_actions=1).run()
+
+        assert result.status is TrialStatus.BUDGET_EXHAUSTED
+        assert result.final_output is None
+        assert result.evaluation is not None
+        assert result.evaluation.passed is False
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "agent.action",
+            "environment.transition",
+            "budget.exhausted",
+            "evaluation.recorded",
+            "trial.terminated",
+        ]
+        assert result.trajectory.records[-1].payload["status"] == "budget_exhausted"
+
+    asyncio.run(scenario())
+
+
+def test_budget_exhaustion_cannot_exact_match_an_expected_null_output() -> None:
+    async def scenario() -> None:
+        result = await Trial(
+            task=Task(id="null-output", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("lookup", {"key": "unused"})],
+                name="null-output-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {"unused": None},
+                name="null-output-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-null-output", max_actions=1),
+        ).run()
+
+        assert result.status is TrialStatus.BUDGET_EXHAUSTED
+        assert result.evaluation is not None
+        assert result.evaluation.passed is False
+        assert result.evaluation.score == 0.0
+
+    asyncio.run(scenario())
+
+
+def test_replay_reconstructs_result_without_agent_or_environment() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial().run()
+
+        replayed = replay(original.trajectory)
+
+        assert replayed.status is original.status
+        assert replayed.final_output == original.final_output
+        assert replayed.evaluation == original.evaluation
+        assert replayed.trajectory == original.trajectory
+
+    asyncio.run(scenario())
+
+
+def test_replay_rejects_evaluation_before_the_terminating_transition() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial().run()
+        records = list(original.trajectory.records)
+        records[5], records[6] = records[6], records[5]
+        resequenced = tuple(
+            replace(record, sequence=sequence)
+            for sequence, record in enumerate(records)
+        )
+        tampered = replace(original.trajectory, records=resequenced)
+
+        with pytest.raises(ValueError, match="causal order"):
+            replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_replay_requires_declared_harness_component_configuration() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial().run()
+        configuration = {"max_actions": 2}
+        canonical = json.dumps(
+            configuration,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        tampered = replace(
+            original.trajectory,
+            configuration=configuration,
+            config_hash=f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+        )
+
+        with pytest.raises(ValueError, match="configuration"):
+            replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_replay_rejects_reset_without_a_committed_observation() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial().run()
+        records = list(original.trajectory.records)
+        records[1] = replace(records[1], payload={})
+        tampered = replace(original.trajectory, records=tuple(records))
+
+        with pytest.raises(ValueError, match="reset observation"):
+            replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_replay_rejects_budget_failure_before_the_declared_action_count() -> None:
+    class FailingEvaluator:
+        name = "budget-failing-evaluator"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def evaluate(self, *args: object, **kwargs: object) -> Evaluation:
+            del args, kwargs
+            raise RuntimeError("evaluation failed")
+
+    async def scenario() -> None:
+        original = await Trial(
+            task=Task(id="tampered-budget-failure", input=None),
+            agent=ScriptedAgent(
+                [Action.invoke("lookup", {"key": "value"})],
+                name="tampered-budget-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {"value": "observation"},
+                name="tampered-budget-environment",
+                version="1",
+            ),
+            evaluator=FailingEvaluator(),
+            config=TrialConfig(trial_id="trial-tampered-budget", max_actions=1),
+        ).run()
+        records = [
+            record
+            for record in original.trajectory.records
+            if record.kind not in {"agent.action", "environment.transition"}
+        ]
+        records = [
+            replace(record, sequence=sequence)
+            for sequence, record in enumerate(records)
+        ]
+        tampered = replace(original.trajectory, records=tuple(records))
+
+        with pytest.raises(ValueError, match="bounded Action loop"):
+            replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_replay_binds_failure_phase_to_failure_code() -> None:
+    class FailingAgent:
+        name = "phase-failing-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise RuntimeError("phase failure")
+
+    async def scenario() -> None:
+        original = await Trial(
+            task=Task(id="phase-failure", input=None),
+            agent=FailingAgent(),
+            environment=LookupEnvironment(
+                {},
+                name="phase-failure-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-phase-failure", max_actions=1),
+        ).run()
+        records = list(original.trajectory.records)
+        failure_index = next(
+            index for index, record in enumerate(records) if record.kind == "trial.failure"
+        )
+        records[failure_index] = replace(
+            records[failure_index],
+            payload={**records[failure_index].payload, "phase": "environment"},
+        )
+        records[-1] = replace(
+            records[-1],
+            payload={**records[-1].payload, "phase": "environment"},
+        )
+        tampered = replace(original.trajectory, records=tuple(records))
+
+        with pytest.raises(ValueError, match="failure code"):
+            replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_replay_binds_evaluation_identity_to_configuration() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial().run()
+        records = list(original.trajectory.records)
+        evaluation_index = next(
+            index
+            for index, record in enumerate(records)
+            if record.kind == "evaluation.recorded"
+        )
+        records[evaluation_index] = replace(
+            records[evaluation_index],
+            payload={
+                **records[evaluation_index].payload,
+                "evaluator": "other-evaluator",
+                "evaluator_version": "999",
+            },
+        )
+        tampered = replace(original.trajectory, records=tuple(records))
+
+        with pytest.raises(ValueError, match="Evaluation identity"):
+            replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_replay_rejects_agent_outcomes_after_action_budget_is_spent() -> None:
+    async def scenario() -> None:
+        original = await _capital_trial(max_actions=1).run()
+        committed_prefix = original.trajectory.records[:4]
+        forged_outcomes = (
+            (
+                TrajectoryRecord(
+                    sequence=4,
+                    kind="trial.failure",
+                    payload={
+                        "phase": "agent",
+                        "code": "agent_decide_error",
+                        "exception_type": "RuntimeError",
+                        "message": "impossible extra decision",
+                    },
+                ),
+                TrajectoryRecord(
+                    sequence=5,
+                    kind="trial.terminated",
+                    payload={"status": "failed", "phase": "agent"},
+                ),
+            ),
+            (
+                TrajectoryRecord(
+                    sequence=4,
+                    kind="trial.cancelled",
+                    payload={"phase": "agent", "operation": "agent.decide"},
+                ),
+                TrajectoryRecord(
+                    sequence=5,
+                    kind="trial.terminated",
+                    payload={
+                        "status": "cancelled",
+                        "phase": "agent",
+                        "operation": "agent.decide",
+                    },
+                ),
+            ),
+        )
+
+        for marker, terminal in forged_outcomes:
+            tampered = replace(
+                original.trajectory,
+                records=(*committed_prefix, marker, terminal),
+            )
+            with pytest.raises(ValueError, match="execution prefix"):
+                replay(tampered)
+
+    asyncio.run(scenario())
+
+
+def test_agent_failure_becomes_an_attributed_terminal_result() -> None:
+    class FailingAgent:
+        name = "failing-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise RuntimeError("decision failed")
+
+    async def scenario() -> None:
+        trial = Trial(
+            task=Task(id="failing-task", input={"question": "fail"}),
+            agent=FailingAgent(),
+            environment=LookupEnvironment(
+                {"unused": "unused"},
+                name="failure-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("unused", version="1"),
+            config=TrialConfig(trial_id="trial-agent-failure", max_actions=1),
+        )
+
+        result = await trial.run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "agent"
+        assert result.failure.exception_type == "RuntimeError"
+        assert result.failure.message == "decision failed"
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "trial.failure",
+            "trial.terminated",
+        ]
+        assert result.trajectory.records[-1].payload["status"] == "failed"
+
+    asyncio.run(scenario())
+
+
+def test_unprintable_exception_still_produces_one_terminal_failure() -> None:
+    class UnprintableError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("formatting failed")
+
+    class FailingAgent:
+        name = "unprintable-failure-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise UnprintableError()
+
+    async def scenario() -> None:
+        result = await Trial(
+            task=Task(id="unprintable-failure", input=None),
+            agent=FailingAgent(),
+            environment=LookupEnvironment(
+                {},
+                name="unprintable-failure-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-unprintable-failure", max_actions=1),
+        ).run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.exception_type == "UnprintableError"
+        assert result.failure.message == "<UnprintableError message unavailable>"
+        assert [record.kind for record in result.trajectory.records][-2:] == [
+            "trial.failure",
+            "trial.terminated",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_replay_reconstructs_an_attributed_failure() -> None:
+    class FailingAgent:
+        name = "replay-failing-agent"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise RuntimeError("replay this failure")
+
+    async def scenario() -> None:
+        original = await Trial(
+            task=Task(id="replay-failure", input=None),
+            agent=FailingAgent(),
+            environment=LookupEnvironment(
+                {},
+                name="replay-failure-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-replay-failure", max_actions=1),
+        ).run()
+
+        replayed = replay(original.trajectory)
+
+        assert replayed.status is TrialStatus.FAILED
+        assert replayed.final_output is None
+        assert replayed.evaluation is None
+        assert replayed.failure == original.failure
+        assert replayed.trajectory is original.trajectory
+
+    asyncio.run(scenario())
+
+
+def test_environment_reset_failure_is_attributed_before_observation() -> None:
+    class ResetFailingEnvironment:
+        name = "reset-failing-environment"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def reset(self, *args: object, **kwargs: object) -> Observation:
+            del args, kwargs
+            raise ConnectionError("reset unavailable")
+
+        async def step(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        trial = Trial(
+            task=Task(id="reset-failure", input=None),
+            agent=ScriptedAgent(
+                [Action.finish(None)],
+                name="unused-agent",
+                version="1",
+            ),
+            environment=ResetFailingEnvironment(),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-reset-failure", max_actions=1),
+        )
+
+        result = await trial.run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "environment"
+        assert result.failure.exception_type == "ConnectionError"
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "trial.failure",
+            "trial.terminated",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_evaluator_failure_keeps_the_terminating_transition() -> None:
+    class FailingEvaluator:
+        name = "failing-evaluator"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def evaluate(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise ValueError("evaluation unavailable")
+
+    async def scenario() -> None:
+        trial = Trial(
+            task=Task(id="evaluation-failure", input=None),
+            agent=ScriptedAgent(
+                [Action.finish("answer")],
+                name="answering-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="answer-environment",
+                version="1",
+            ),
+            evaluator=FailingEvaluator(),
+            config=TrialConfig(trial_id="trial-evaluation-failure", max_actions=1),
+        )
+
+        result = await trial.run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "evaluator"
+        assert result.failure.exception_type == "ValueError"
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "environment.reset",
+            "agent.action",
+            "environment.transition",
+            "trial.failure",
+            "trial.terminated",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_evaluation_identity_must_match_the_declared_evaluator() -> None:
+    class MisidentifiedEvaluator:
+        name = "declared-evaluator"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def evaluate(self, *args: object, **kwargs: object) -> Evaluation:
+            del args, kwargs
+            self.name = "other-evaluator"
+            self.version = "999"
+            return Evaluation(
+                passed=True,
+                score=1.0,
+                evaluator="other-evaluator",
+                evaluator_version="999",
+            )
+
+    async def scenario() -> None:
+        result = await Trial(
+            task=Task(id="misidentified-evaluation", input=None),
+            agent=ScriptedAgent(
+                [Action.finish("answer")],
+                name="misidentified-evaluation-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="misidentified-evaluation-environment",
+                version="1",
+            ),
+            evaluator=MisidentifiedEvaluator(),
+            config=TrialConfig(trial_id="trial-misidentified-evaluation", max_actions=1),
+        ).run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "evaluator"
+        assert result.failure.code == "evaluator_evaluate_error"
+        assert result.evaluation is None
+
+    asyncio.run(scenario())
+
+
+def test_invalid_environment_reset_result_becomes_a_terminal_failure() -> None:
+    class InvalidResetEnvironment:
+        name = "invalid-reset-environment"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        async def reset(self, *args: object, **kwargs: object) -> object:
+            del args, kwargs
+            return object()
+
+        async def step(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        trial = Trial(
+            task=Task(id="invalid-reset", input=None),
+            agent=ScriptedAgent(
+                [Action.finish(None)],
+                name="unused-invalid-reset-agent",
+                version="1",
+            ),
+            environment=InvalidResetEnvironment(),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="trial-invalid-reset", max_actions=1),
+        )
+
+        result = await trial.run()
+
+        assert result.status is TrialStatus.FAILED
+        assert result.failure is not None
+        assert result.failure.phase == "environment"
+        assert result.failure.code == "environment_reset_error"
+        assert result.failure.exception_type == "TypeError"
+        assert [record.kind for record in result.trajectory.records] == [
+            "trial.started",
+            "trial.failure",
+            "trial.terminated",
+        ]
+
+    asyncio.run(scenario())

--- a/tests/test_installed_extensions.py
+++ b/tests/test_installed_extensions.py
@@ -146,12 +146,17 @@ import sys
 from iamai import Context, Message, Runtime
 from iamai.harness import (
     Action,
+    ControlledToolEnvironment,
     ExactEvaluator,
     Experiment,
+    ExecutionBudget,
+    ExecutionPolicy,
     JsonlTrajectoryStore,
-    LookupEnvironment,
     ScriptedAgent,
     Task,
+    Tool,
+    ToolResult,
+    ToolSpec,
     Trial,
     TrialConfig,
 )
@@ -266,6 +271,13 @@ async def run_conformance(runtime, plugin, adapter):
 
 
 async def run_harness():
+    async def installed_tool(arguments):
+        return ToolResult(
+            output=arguments["value"],
+            tokens=1,
+            cost_microunits=2,
+        )
+
     path = Path("installed-harness.jsonl")
     result = await Experiment(
         experiment_id="installed-harness",
@@ -277,26 +289,64 @@ async def run_harness():
                 Trial(
                     task=Task(id="installed-task", input=None),
                     agent=ScriptedAgent(
-                        [Action.finish("done")],
+                        [
+                            Action.invoke("installed-tool", {"value": "observed"}),
+                            Action.finish("done"),
+                        ],
                         name="installed-agent",
                         version="1",
                     ),
-                    environment=LookupEnvironment(
-                        {},
+                    environment=ControlledToolEnvironment(
+                        tools=(
+                            Tool(
+                                ToolSpec(
+                                    name="installed-tool",
+                                    version="1",
+                                    input_schema={
+                                        "type": "object",
+                                        "properties": {"value": {"type": "string"}},
+                                        "required": ["value"],
+                                        "additionalProperties": False,
+                                    },
+                                    permission_name="installed.read",
+                                    reserved_tokens=1,
+                                    reserved_cost_microunits=2,
+                                ),
+                                installed_tool,
+                            ),
+                        ),
+                        policy=ExecutionPolicy(
+                            version="1",
+                            allowed_tools=("installed-tool",),
+                            allowed_permissions=("installed.read",),
+                        ),
+                        budget=ExecutionBudget(
+                            max_tool_calls=1,
+                            max_tokens=1,
+                            max_cost_microunits=2,
+                            tool_timeout_seconds=1,
+                            currency="USD",
+                            pricing_version="installed-fixture-1",
+                        ),
                         name="installed-environment",
                         version="1",
                     ),
                     evaluator=ExactEvaluator("done", version="1"),
-                    config=TrialConfig(trial_id="installed-trial", max_actions=1),
+                    config=TrialConfig(trial_id="installed-trial", max_actions=2),
                 ),
             )
         },
     ).run(JsonlTrajectoryStore(path))
     loaded = JsonlTrajectoryStore(path).load()
+    trajectory = result.results["baseline"][0].trajectory
+    tool_outcome = next(
+        record for record in trajectory.records if record.kind == "tool.call.outcome"
+    )
     return {
         "complete": result.complete,
         "round_trip": loaded == result,
         "status": result.results["baseline"][0].status.value,
+        "tool_status": tool_outcome.payload["status"],
     }
 
 
@@ -381,6 +431,7 @@ print(
         "complete": True,
         "round_trip": True,
         "status": "completed",
+        "tool_status": "succeeded",
     }
     for run in payload["runs"]:
         assert run["plugins"] == ["reference_plugin"]

--- a/tests/test_installed_extensions.py
+++ b/tests/test_installed_extensions.py
@@ -144,6 +144,17 @@ from pathlib import Path
 import sys
 
 from iamai import Context, Message, Runtime
+from iamai.harness import (
+    Action,
+    ExactEvaluator,
+    Experiment,
+    JsonlTrajectoryStore,
+    LookupEnvironment,
+    ScriptedAgent,
+    Task,
+    Trial,
+    TrialConfig,
+)
 from iamai.testing import (
     assert_adapter_api_result,
     assert_adapter_can_close,
@@ -254,6 +265,41 @@ async def run_conformance(runtime, plugin, adapter):
     return {"adapter": True, "plugin": True}
 
 
+async def run_harness():
+    path = Path("installed-harness.jsonl")
+    result = await Experiment(
+        experiment_id="installed-harness",
+        version="1",
+        baseline="baseline",
+        provenance={"distribution": "installed"},
+        trials={
+            "baseline": (
+                Trial(
+                    task=Task(id="installed-task", input=None),
+                    agent=ScriptedAgent(
+                        [Action.finish("done")],
+                        name="installed-agent",
+                        version="1",
+                    ),
+                    environment=LookupEnvironment(
+                        {},
+                        name="installed-environment",
+                        version="1",
+                    ),
+                    evaluator=ExactEvaluator("done", version="1"),
+                    config=TrialConfig(trial_id="installed-trial", max_actions=1),
+                ),
+            )
+        },
+    ).run(JsonlTrajectoryStore(path))
+    loaded = JsonlTrajectoryStore(path).load()
+    return {
+        "complete": result.complete,
+        "round_trip": loaded == result,
+        "status": result.results["baseline"][0].status.value,
+    }
+
+
 def load(mode: str) -> dict[str, object]:
     explicit = mode == "explicit"
     config = {
@@ -297,6 +343,7 @@ print(
             ],
             "iamai_module": str(Path(iamai.__file__).resolve()),
             "runs": [load("explicit"), load("auto")],
+            "harness": asyncio.run(run_harness()),
         }
     )
 )
@@ -330,6 +377,11 @@ print(
     iamai_module = Path(payload["iamai_module"])
     assert any(iamai_module.is_relative_to(path) for path in site_packages)
     assert not iamai_module.is_relative_to(PROJECT_SOURCE_ROOT)
+    assert payload["harness"] == {
+        "complete": True,
+        "round_trip": True,
+        "status": "completed",
+    }
     for run in payload["runs"]:
         assert run["plugins"] == ["reference_plugin"]
         assert run["adapters"] == ["reference_adapter"]

--- a/tests/test_persistent_experiment.py
+++ b/tests/test_persistent_experiment.py
@@ -1,0 +1,1583 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+import time
+from collections.abc import Mapping
+from dataclasses import replace
+
+import pytest
+
+from iamai.harness import _jsonl as jsonl_module
+from iamai.harness import (
+    Action,
+    ExactEvaluator,
+    Experiment,
+    ExperimentPlan,
+    ExperimentResult,
+    JsonlTrajectoryStore,
+    LookupEnvironment,
+    ScriptedAgent,
+    Task,
+    Trial,
+    TrialConfig,
+    TrialStatus,
+    replay,
+)
+
+
+def _capital_trial(*, trial_id: str, output: str) -> Trial:
+    return Trial(
+        task=Task(
+            id="capital-of-france",
+            input={"question": "What is the capital of France?"},
+        ),
+        agent=ScriptedAgent(
+            [Action.finish(output)],
+            name=f"{trial_id}-agent",
+            version="1",
+        ),
+        environment=LookupEnvironment(
+            {},
+            name="country-capitals",
+            version="1",
+        ),
+        evaluator=ExactEvaluator("Paris", version="1"),
+        config=TrialConfig(trial_id=trial_id, seed=7, max_actions=1),
+    )
+
+
+def test_experiment_persists_complete_trajectories_by_variant(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "capital-comparison.jsonl"
+        experiment = Experiment(
+            experiment_id="capital-comparison",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="baseline-7", output="Lyon"),),
+                "candidate": (_capital_trial(trial_id="candidate-7", output="Paris"),),
+            },
+        )
+
+        result = await experiment.run(JsonlTrajectoryStore(path))
+        loaded = JsonlTrajectoryStore(path).load()
+
+        assert result.complete is True
+        assert result.experiment_id == "capital-comparison"
+        assert result.version == "1"
+        assert result.baseline == "baseline"
+        assert result.planned_trial_ids == {
+            "baseline": ("baseline-7",),
+            "candidate": ("candidate-7",),
+        }
+        assert result.results["baseline"][0].status is TrialStatus.COMPLETED
+        assert result.results["baseline"][0].evaluation is not None
+        assert result.results["baseline"][0].evaluation.passed is False
+        assert result.results["candidate"][0].evaluation is not None
+        assert result.results["candidate"][0].evaluation.passed is True
+        assert loaded == result
+        assert all(
+            replay(trial_result.trajectory) == trial_result
+            for variant_results in result.results.values()
+            for trial_result in variant_results
+        )
+        assert len(path.read_text(encoding="utf-8").splitlines()) == 5
+
+    asyncio.run(scenario())
+
+
+def test_store_reports_and_explicitly_repairs_a_torn_final_record(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "torn-tail.jsonl"
+        store = JsonlTrajectoryStore(path)
+        original = await Experiment(
+            experiment_id="torn-tail",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="baseline-tail", output="Paris"),),
+            },
+        ).run(store)
+        with path.open("ab") as stream:
+            stream.write(b'{"record_type":"trajectory.committed"')
+
+        with pytest.raises(ValueError, match=r"torn-tail\.jsonl:4"):
+            store.load()
+
+        assert store.repair_tail() is True
+        assert store.load() == original
+        assert store.repair_tail() is False
+        assert path.read_bytes().endswith(b"\n")
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_reordered_complete_records(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "reordered-records.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="reordered-records",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="reordered-a", output="Lyon"),),
+                "candidate": (_capital_trial(trial_id="reordered-b", output="Paris"),),
+            },
+        ).run(store)
+        lines = path.read_bytes().splitlines(keepends=True)
+        path.write_bytes(b"".join((lines[0], lines[2], lines[1])))
+
+        with pytest.raises(ValueError, match="entry chain"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_experiment_resume_replays_committed_trials_without_effects(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "resume.jsonl"
+        first = Experiment(
+            experiment_id="resume",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="resume-a", output="Lyon"),),
+                "candidate": (_capital_trial(trial_id="resume-b", output="Paris"),),
+            },
+        )
+        original = await first.run(JsonlTrajectoryStore(path))
+        line_count = len(path.read_bytes().splitlines())
+
+        resumed_baseline = _capital_trial(trial_id="resume-a", output="Lyon")
+        resumed_candidate = _capital_trial(trial_id="resume-b", output="Paris")
+        resumed = await Experiment(
+            experiment_id="resume",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (resumed_baseline,),
+                "candidate": (resumed_candidate,),
+            },
+        ).run(JsonlTrajectoryStore(path))
+
+        assert resumed == original
+        assert resumed_baseline.trajectory.records == ()
+        assert resumed_candidate.trajectory.records == ()
+        assert len(path.read_bytes().splitlines()) == line_count
+
+    asyncio.run(scenario())
+
+
+def test_store_does_not_commit_a_complete_json_object_without_final_lf(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "missing-commit-marker.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="missing-commit-marker",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="missing-lf", output="Paris"),),
+            },
+        ).run(store)
+        path.write_bytes(path.read_bytes()[:-1])
+
+        with pytest.raises(ValueError, match="torn JSONL Store record"):
+            store.load()
+
+        assert store.repair_tail() is True
+        recovered = store.load()
+        assert recovered is not None
+        assert recovered.complete is False
+        assert recovered.results == {"baseline": ()}
+
+    asyncio.run(scenario())
+
+
+def test_interrupted_trial_is_not_reexecuted_while_pending_trials_continue(
+    tmp_path,
+) -> None:
+    class SimulatedProcessCrash(BaseException):
+        pass
+
+    class CrashingAgent:
+        name = "interruptible-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {"policy": "fixture"}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise SimulatedProcessCrash
+
+    class ReplacementAgent:
+        name = "interruptible-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {"policy": "fixture"}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    def trial(agent: object) -> Trial:
+        return Trial(
+            task=Task(id="interrupted-task", input=None),
+            agent=agent,  # type: ignore[arg-type]
+            environment=LookupEnvironment(
+                {},
+                name="interrupted-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="interrupted-trial", max_actions=1),
+        )
+
+    async def scenario() -> None:
+        path = tmp_path / "interrupted.jsonl"
+        store = JsonlTrajectoryStore(path)
+        never_started = _capital_trial(
+            trial_id="never-started-trial",
+            output="Paris",
+        )
+        with pytest.raises(SimulatedProcessCrash):
+            await Experiment(
+                experiment_id="interrupted",
+                version="1",
+                baseline="baseline",
+                trials={
+                    "baseline": (trial(CrashingAgent()),),
+                    "candidate": (never_started,),
+                },
+            ).run(store)
+
+        interrupted = store.load()
+        assert interrupted is not None
+        assert interrupted.complete is False
+        assert interrupted.started_trial_ids == {
+            "baseline": ("interrupted-trial",),
+            "candidate": (),
+        }
+        assert never_started.trajectory.records == ()
+
+        replacement = ReplacementAgent()
+        pending = _capital_trial(trial_id="never-started-trial", output="Paris")
+        resumed = await Experiment(
+            experiment_id="interrupted",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (trial(replacement),),
+                "candidate": (pending,),
+            },
+        ).run(store)
+
+        assert replacement.calls == 0
+        assert pending.trajectory.records
+        assert resumed.complete is False
+        assert resumed.started_trial_ids == {
+            "baseline": ("interrupted-trial",),
+            "candidate": (),
+        }
+        assert [result.trial_id for result in resumed.results["candidate"]] == [
+            "never-started-trial"
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_experiment_plan_exposes_deeply_immutable_pending_provenance(tmp_path) -> None:
+    async def scenario() -> None:
+        provenance = {
+            "source_revision": "abc123",
+            "datasets": {"capitals": ["sha256:fixture"]},
+        }
+        experiment = Experiment(
+            experiment_id="inspectable-plan",
+            version="1",
+            baseline="baseline",
+            provenance=provenance,
+            trials={
+                "baseline": (_capital_trial(trial_id="inspectable", output="Paris"),),
+            },
+        )
+        provenance["datasets"]["capitals"].append("mutated")
+
+        assert isinstance(experiment.plan, ExperimentPlan)
+        assert experiment.plan.provenance == {
+            "source_revision": "abc123",
+            "datasets": {"capitals": ("sha256:fixture",)},
+        }
+        planned = experiment.plan.trial_specs["baseline"][0]
+        assert planned.task.id == "capital-of-france"
+        assert planned.seed == 7
+        assert planned.configuration["max_actions"] == 1
+        assert planned.records == ()
+        with pytest.raises(TypeError):
+            experiment.plan.provenance["changed"] = True  # type: ignore[index]
+
+        stored = await experiment.run(
+            JsonlTrajectoryStore(tmp_path / "inspectable-plan.jsonl")
+        )
+        assert stored.plan == experiment.plan
+
+    asyncio.run(scenario())
+
+
+def test_experiment_rejects_non_object_provenance_instead_of_dropping_it() -> None:
+    with pytest.raises(TypeError, match="provenance must be an object"):
+        Experiment(
+            experiment_id="invalid-provenance",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (
+                    _capital_trial(trial_id="invalid-provenance", output="Paris"),
+                ),
+            },
+            provenance=[],  # type: ignore[arg-type]
+        )
+
+
+def test_store_rejects_a_second_writer_before_trial_effects(tmp_path) -> None:
+    class BlockingAgent:
+        name = "single-writer-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self, started: asyncio.Event) -> None:
+            self.started = started
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    def trial(trial_id: str, agent: object) -> Trial:
+        return Trial(
+            task=Task(id="single-writer", input=None),
+            agent=agent,  # type: ignore[arg-type]
+            environment=LookupEnvironment(
+                {},
+                name="single-writer-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=1),
+        )
+
+    async def scenario() -> None:
+        path = tmp_path / "single-writer.jsonl"
+        first_started = asyncio.Event()
+        first = asyncio.create_task(
+            Experiment(
+                experiment_id="single-writer",
+                version="1",
+                baseline="baseline",
+                trials={
+                    "baseline": (
+                        trial("single-writer-trial", BlockingAgent(first_started)),
+                    )
+                },
+            ).run(JsonlTrajectoryStore(path))
+        )
+        await first_started.wait()
+
+        second_started = asyncio.Event()
+        second_trial = trial(
+            "single-writer-trial",
+            BlockingAgent(second_started),
+        )
+        with pytest.raises(RuntimeError, match="active writer"):
+            await Experiment(
+                experiment_id="single-writer",
+                version="1",
+                baseline="baseline",
+                trials={"baseline": (second_trial,)},
+            ).run(JsonlTrajectoryStore(path))
+        assert second_started.is_set() is False
+        assert second_trial.trajectory.records == ()
+        with pytest.raises(RuntimeError, match="active writer"):
+            JsonlTrajectoryStore(path).repair_tail()
+        with pytest.raises(RuntimeError, match="active writer"):
+            JsonlTrajectoryStore(path).load()
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.skipif(os.name == "nt", reason="this probe targets POSIX flock")
+def test_store_lock_blocks_cross_process_load_and_repair_then_recovers(tmp_path) -> None:
+    async def prepare() -> ExperimentResult:
+        return await Experiment(
+            experiment_id="cross-process-lock",
+            version="1",
+            trials={
+                "candidate": (
+                    _capital_trial(trial_id="cross-process-lock", output="Paris"),
+                ),
+            },
+        ).run(JsonlTrajectoryStore(tmp_path / "cross-process-lock.jsonl"))
+
+    original = asyncio.run(prepare())
+    path = tmp_path / "cross-process-lock.jsonl"
+    ready = tmp_path / "writer-ready"
+    release = tmp_path / "writer-release"
+    program = (
+        "import sys, time\n"
+        "from pathlib import Path\n"
+        "from iamai.harness import JsonlTrajectoryStore\n"
+        "path, ready, release = map(Path, sys.argv[1:])\n"
+        "with JsonlTrajectoryStore(path)._writer():\n"
+        "    ready.touch()\n"
+        "    deadline = time.monotonic() + 10\n"
+        "    while not release.exists():\n"
+        "        if time.monotonic() >= deadline:\n"
+        "            raise TimeoutError('release signal was not received')\n"
+        "        time.sleep(0.01)\n"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", program, str(path), str(ready), str(release)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists():
+            if process.poll() is not None:
+                stdout, stderr = process.communicate()
+                pytest.fail(f"lock process exited early: {stdout}\n{stderr}")
+            if time.monotonic() >= deadline:
+                pytest.fail("lock process did not become ready")
+            time.sleep(0.01)
+
+        store = JsonlTrajectoryStore(path)
+        with pytest.raises(RuntimeError, match="active writer"):
+            store.load()
+        with pytest.raises(RuntimeError, match="active writer"):
+            store.repair_tail()
+
+        release.touch()
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, f"{stdout}\n{stderr}"
+        assert store.load() == original
+        assert store.repair_tail() is False
+    finally:
+        if process.poll() is None:
+            release.touch()
+            process.terminate()
+            process.wait(timeout=10)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not portable")
+def test_store_fails_closed_when_an_existing_lock_is_unreadable(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "unreadable-lock.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="unreadable-lock",
+            version="1",
+            trials={
+                "candidate": (
+                    _capital_trial(trial_id="unreadable-lock", output="Paris"),
+                ),
+            },
+        ).run(store)
+        lock_path = path.with_name(f"{path.name}.lock")
+        lock_path.chmod(0)
+        try:
+            with pytest.raises(PermissionError):
+                store.load()
+        finally:
+            lock_path.chmod(0o600)
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_duplicate_json_object_keys(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "duplicate-key.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="duplicate-key",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="duplicate-key", output="Paris"),),
+            },
+        ).run(store)
+        lines = path.read_bytes().splitlines(keepends=True)
+        lines[0] = b'{"record_type":"experiment.plan",' + lines[0][1:]
+        path.write_bytes(b"".join(lines))
+
+        with pytest.raises(ValueError, match="duplicate JSON object key"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_noncanonical_number_spelling_even_when_value_is_equal(
+    tmp_path,
+) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "noncanonical-number.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="noncanonical-number",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (
+                    _capital_trial(trial_id="noncanonical", output="Lyon"),
+                ),
+            },
+        ).run(store)
+        content = path.read_bytes()
+        assert b'"score":0.0' in content
+        path.write_bytes(content.replace(b'"score":0.0', b'"score":1e-999', 1))
+
+        with pytest.raises(ValueError, match="not canonical JSON"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_bool_entry_sequence_even_with_a_matching_digest(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "bool-sequence.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="bool-sequence",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="bool-sequence", output="Paris"),),
+            },
+        ).run(store)
+        manifest = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        manifest["entry_sequence"] = False
+        manifest.pop("entry_digest")
+        encoded_payload = json.dumps(
+            manifest,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        manifest["entry_digest"] = (
+            f"sha256:{hashlib.sha256(encoded_payload).hexdigest()}"
+        )
+        encoded_manifest = json.dumps(
+            manifest,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        path.write_bytes(encoded_manifest + b"\n")
+
+        with pytest.raises(ValueError, match="entry chain"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_experiment_persists_cancelled_trial_before_propagating_cancellation(
+    tmp_path,
+) -> None:
+    class BlockingAgent:
+        name = "cancelled-experiment-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self, started: asyncio.Event) -> None:
+            self.started = started
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        path = tmp_path / "cancelled-experiment.jsonl"
+        started = asyncio.Event()
+        trial = Trial(
+            task=Task(id="cancelled-experiment", input=None),
+            agent=BlockingAgent(started),
+            environment=LookupEnvironment(
+                {},
+                name="cancelled-experiment-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="cancelled-experiment-trial", max_actions=1),
+        )
+        running = asyncio.create_task(
+            Experiment(
+                experiment_id="cancelled-experiment",
+                version="1",
+                baseline=None,
+                trials={"candidate": (trial,)},
+            ).run(JsonlTrajectoryStore(path))
+        )
+        await started.wait()
+        running.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.complete is True
+        assert stored.started_trial_ids == {"candidate": ()}
+        assert stored.results["candidate"][0].status is TrialStatus.CANCELLED
+        assert replay(stored.results["candidate"][0].trajectory).status is TrialStatus.CANCELLED
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_remains_primary_when_terminal_commit_fails(tmp_path) -> None:
+    class FailCommitStore(JsonlTrajectoryStore):
+        fail_commits = True
+
+        def _append(self, payload: Mapping[str, object]) -> None:
+            if self.fail_commits and payload.get("record_type") == "trajectory.committed":
+                raise OSError("simulated cancellation commit failure")
+            super()._append(payload)
+
+    class BlockingAgent:
+        name = "cancel-commit-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self, started: asyncio.Event) -> None:
+            self.started = started
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            self.started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        path = tmp_path / "cancel-commit-failure.jsonl"
+        started = asyncio.Event()
+        agent = BlockingAgent(started)
+        trial = Trial(
+            task=Task(id="cancel-commit-failure", input=None),
+            agent=agent,
+            environment=LookupEnvironment(
+                {},
+                name="cancel-commit-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(None, version="1"),
+            config=TrialConfig(trial_id="cancel-commit-failure", max_actions=1),
+        )
+        experiment = Experiment(
+            experiment_id="cancel-commit-failure",
+            version="1",
+            trials={"candidate": (trial,)},
+        )
+        store = FailCommitStore(path)
+        running = asyncio.create_task(experiment.run(store))
+        await started.wait()
+        running.cancel()
+
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await running
+        assert any(
+            "simulated cancellation commit failure" in note
+            for note in getattr(cancelled.value, "__notes__", ())
+        )
+        assert agent.calls == 1
+        interrupted = store.load()
+        assert interrupted is not None
+        assert interrupted.started_trial_ids == {
+            "candidate": ("cancel-commit-failure",),
+        }
+
+        store.fail_commits = False
+        recovered = await experiment.run(store)
+        assert recovered.complete is True
+        assert recovered.results["candidate"][0].status is TrialStatus.CANCELLED
+        assert agent.calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_remains_primary_when_writer_unlock_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class BlockingAgent:
+        name = "cancel-unlock-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self, started: asyncio.Event) -> None:
+            self.started = started
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    async def scenario() -> None:
+        path = tmp_path / "cancel-unlock.jsonl"
+        started = asyncio.Event()
+        experiment = Experiment(
+            experiment_id="cancel-unlock",
+            version="1",
+            trials={
+                "candidate": (
+                    Trial(
+                        task=Task(id="cancel-unlock", input=None),
+                        agent=BlockingAgent(started),
+                        environment=LookupEnvironment(
+                            {},
+                            name="cancel-unlock-environment",
+                            version="1",
+                        ),
+                        evaluator=ExactEvaluator(None, version="1"),
+                        config=TrialConfig(trial_id="cancel-unlock", max_actions=1),
+                    ),
+                ),
+            },
+        )
+        running = asyncio.create_task(experiment.run(JsonlTrajectoryStore(path)))
+        await started.wait()
+        real_unlock = jsonl_module._unlock_stream
+
+        def fail_unlock(stream: object) -> None:
+            del stream
+            raise OSError("simulated unlock failure")
+
+        monkeypatch.setattr(jsonl_module, "_unlock_stream", fail_unlock)
+        running.cancel()
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await running
+        assert any(
+            "simulated unlock failure" in note
+            for note in getattr(cancelled.value, "__notes__", ())
+        )
+
+        monkeypatch.setattr(jsonl_module, "_unlock_stream", real_unlock)
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.complete is True
+        assert stored.results["candidate"][0].status is TrialStatus.CANCELLED
+
+    asyncio.run(scenario())
+
+
+def test_terminal_commit_failure_can_be_finalized_without_reexecuting(tmp_path) -> None:
+    class FailOnceCommitStore(JsonlTrajectoryStore):
+        fail_next_commit = True
+
+        def _append(self, payload: Mapping[str, object]) -> None:
+            if (
+                self.fail_next_commit
+                and payload.get("record_type") == "trajectory.committed"
+            ):
+                self.fail_next_commit = False
+                raise OSError("simulated terminal commit failure")
+            super()._append(payload)
+
+    class CountingAgent:
+        name = "retry-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "retry-terminal-commit.jsonl"
+        agent = CountingAgent()
+        experiment = Experiment(
+            experiment_id="retry-terminal-commit",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (
+                    Trial(
+                        task=Task(id="retry-terminal-commit", input=None),
+                        agent=agent,
+                        environment=LookupEnvironment(
+                            {},
+                            name="retry-environment",
+                            version="1",
+                        ),
+                        evaluator=ExactEvaluator("Paris", version="1"),
+                        config=TrialConfig(
+                            trial_id="retry-terminal-commit",
+                            max_actions=1,
+                        ),
+                    ),
+                ),
+            },
+        )
+        store = FailOnceCommitStore(path)
+
+        with pytest.raises(OSError, match="simulated terminal commit failure"):
+            await experiment.run(store)
+        assert agent.calls == 1
+        interrupted = store.load()
+        assert interrupted is not None
+        assert interrupted.complete is False
+
+        recovered = await experiment.run(store)
+        assert recovered.complete is True
+        assert agent.calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_store_never_grafts_a_different_execution_onto_an_interrupted_start(
+    tmp_path,
+) -> None:
+    class SimulatedProcessCrash(BaseException):
+        pass
+
+    class AttemptAgent:
+        name = "attempt-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self, *, crash: bool) -> None:
+            self.crash = crash
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            if self.crash:
+                raise SimulatedProcessCrash
+            return Action.finish("Paris")
+
+    def make_trial(agent: AttemptAgent) -> Trial:
+        return Trial(
+            task=Task(id="attempt-binding", input=None),
+            agent=agent,
+            environment=LookupEnvironment(
+                {},
+                name="attempt-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="attempt-slot", max_actions=1),
+        )
+
+    async def scenario() -> None:
+        path = tmp_path / "attempt-binding.jsonl"
+        with pytest.raises(SimulatedProcessCrash):
+            await Experiment(
+                experiment_id="attempt-binding",
+                version="1",
+                trials={"candidate": (make_trial(AttemptAgent(crash=True)),)},
+            ).run(JsonlTrajectoryStore(path))
+
+        external_agent = AttemptAgent(crash=False)
+        external_trial = make_trial(external_agent)
+        replacement = Experiment(
+            experiment_id="attempt-binding",
+            version="1",
+            trials={"candidate": (external_trial,)},
+        )
+        external_result = await external_trial.run()
+        assert external_result.status is TrialStatus.COMPLETED
+
+        stored = await replacement.run(JsonlTrajectoryStore(path))
+        assert stored.complete is False
+        assert stored.results == {"candidate": ()}
+        assert stored.started_trial_ids == {"candidate": ("attempt-slot",)}
+        assert external_agent.calls == 1
+        assert len(path.read_bytes().splitlines()) == 2
+
+    asyncio.run(scenario())
+
+
+def test_experiment_rejects_plan_drift_before_new_trial_effects(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "plan-conflict.jsonl"
+        await Experiment(
+            experiment_id="plan-conflict",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="same-id", output="Paris"),),
+            },
+        ).run(JsonlTrajectoryStore(path))
+        original_bytes = path.read_bytes()
+
+        changed = Trial(
+            task=Task(id="changed-task", input={"question": "changed"}),
+            agent=ScriptedAgent(
+                [Action.finish("Paris")],
+                name="same-id-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="country-capitals",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="same-id", seed=7, max_actions=1),
+        )
+        with pytest.raises(ValueError, match="different Experiment plan"):
+            await Experiment(
+                experiment_id="plan-conflict",
+                version="1",
+                baseline="baseline",
+                trials={"baseline": (changed,)},
+            ).run(JsonlTrajectoryStore(path))
+
+        assert changed.trajectory.records == ()
+        assert path.read_bytes() == original_bytes
+
+    asyncio.run(scenario())
+
+
+def test_store_binds_recomputed_trajectory_bytes_to_the_planned_provenance(
+    tmp_path,
+) -> None:
+    def digest(value: object) -> str:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+    async def scenario() -> None:
+        path = tmp_path / "tampered-provenance.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="tampered-provenance",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="tampered", output="Paris"),),
+            },
+        ).run(store)
+        lines = path.read_text(encoding="utf-8").splitlines()
+        committed = json.loads(lines[-1])
+        committed["trajectory"]["task"]["input"]["question"] = "tampered"
+        committed["trajectory_digest"] = digest(committed["trajectory"])
+        digest_payload = dict(committed)
+        digest_payload.pop("entry_digest")
+        committed["entry_digest"] = digest(digest_payload)
+        lines[-1] = json.dumps(
+            committed,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="provenance does not match"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_tail_repair_never_hides_a_malformed_complete_record(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "bad-prefix.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="bad-prefix",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="bad-prefix", output="Paris"),),
+            },
+        ).run(store)
+        lines = path.read_bytes().splitlines(keepends=True)
+        lines[1] = b"{malformed}\n"
+        corrupted = b"".join(lines) + b'{"torn":'
+        path.write_bytes(corrupted)
+
+        with pytest.raises(ValueError, match=r"bad-prefix\.jsonl:2"):
+            store.repair_tail()
+        assert path.read_bytes() == corrupted
+
+    asyncio.run(scenario())
+
+
+def test_fsync_failure_stops_before_trial_effects_and_leaves_a_valid_prefix(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class CountingAgent:
+        name = "fsync-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "fsync-failure.jsonl"
+        agent = CountingAgent()
+        real_fsync = os.fsync
+        fsync_calls = 0
+
+        failure_call = 3 if os.name != "nt" else 2
+
+        def fail_start_fsync(file_descriptor: int) -> None:
+            nonlocal fsync_calls
+            fsync_calls += 1
+            if fsync_calls == failure_call:
+                raise OSError("simulated fsync failure")
+            real_fsync(file_descriptor)
+
+        monkeypatch.setattr(os, "fsync", fail_start_fsync)
+        with pytest.raises(OSError, match="simulated fsync failure"):
+            await Experiment(
+                experiment_id="fsync-failure",
+                version="1",
+                baseline="baseline",
+                trials={
+                    "baseline": (
+                        Trial(
+                            task=Task(id="fsync-failure", input=None),
+                            agent=agent,
+                            environment=LookupEnvironment(
+                                {},
+                                name="fsync-environment",
+                                version="1",
+                            ),
+                            evaluator=ExactEvaluator("Paris", version="1"),
+                            config=TrialConfig(
+                                trial_id="fsync-failure-trial",
+                                max_actions=1,
+                            ),
+                        ),
+                    )
+                },
+            ).run(JsonlTrajectoryStore(path))
+
+        assert agent.calls == 0
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.complete is False
+        assert stored.started_trial_ids == {
+            "baseline": ("fsync-failure-trial",),
+        }
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory fsync is POSIX-specific")
+def test_retry_reconfirms_parent_directory_durability_before_effects(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    sync_state = {"directory_calls": 0}
+
+    class CountingAgent:
+        name = "directory-fsync-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            assert sync_state["directory_calls"] >= 1
+            self.calls += 1
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "directory-fsync-retry.jsonl"
+        agent = CountingAgent()
+        experiment = Experiment(
+            experiment_id="directory-fsync-retry",
+            version="1",
+            trials={
+                "candidate": (
+                    Trial(
+                        task=Task(id="directory-fsync-retry", input=None),
+                        agent=agent,
+                        environment=LookupEnvironment(
+                            {},
+                            name="directory-fsync-environment",
+                            version="1",
+                        ),
+                        evaluator=ExactEvaluator("Paris", version="1"),
+                        config=TrialConfig(
+                            trial_id="directory-fsync-retry",
+                            max_actions=1,
+                        ),
+                    ),
+                ),
+            },
+        )
+        real_fsync = os.fsync
+        failed = False
+
+        def fail_first_directory_fsync(file_descriptor: int) -> None:
+            nonlocal failed
+            if stat.S_ISDIR(os.fstat(file_descriptor).st_mode) and not failed:
+                failed = True
+                raise OSError("simulated directory fsync failure")
+            real_fsync(file_descriptor)
+
+        monkeypatch.setattr(os, "fsync", fail_first_directory_fsync)
+        with pytest.raises(OSError, match="simulated directory fsync failure"):
+            await experiment.run(JsonlTrajectoryStore(path))
+        assert agent.calls == 0
+        assert path.exists()
+
+        def track_directory_fsync(file_descriptor: int) -> None:
+            if stat.S_ISDIR(os.fstat(file_descriptor).st_mode):
+                sync_state["directory_calls"] += 1
+            real_fsync(file_descriptor)
+
+        monkeypatch.setattr(os, "fsync", track_directory_fsync)
+        recovered = await experiment.run(JsonlTrajectoryStore(path))
+        assert recovered.complete is True
+        assert agent.calls == 1
+        assert sync_state["directory_calls"] >= 2
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory fsync is POSIX-specific")
+def test_retry_flushes_a_visible_terminal_record_before_returning(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class CountingAgent:
+        name = "terminal-fsync-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "terminal-fsync-retry.jsonl"
+        agent = CountingAgent()
+        experiment = Experiment(
+            experiment_id="terminal-fsync-retry",
+            version="1",
+            trials={
+                "candidate": (
+                    Trial(
+                        task=Task(id="terminal-fsync-retry", input=None),
+                        agent=agent,
+                        environment=LookupEnvironment(
+                            {},
+                            name="terminal-fsync-environment",
+                            version="1",
+                        ),
+                        evaluator=ExactEvaluator("Paris", version="1"),
+                        config=TrialConfig(
+                            trial_id="terminal-fsync-retry",
+                            max_actions=1,
+                        ),
+                    ),
+                ),
+            },
+        )
+        real_fsync = os.fsync
+        fsync_calls = 0
+
+        def fail_terminal_file_fsync(file_descriptor: int) -> None:
+            nonlocal fsync_calls
+            fsync_calls += 1
+            if fsync_calls == 5:
+                raise OSError("simulated terminal fsync failure")
+            real_fsync(file_descriptor)
+
+        monkeypatch.setattr(os, "fsync", fail_terminal_file_fsync)
+        with pytest.raises(OSError, match="simulated terminal fsync failure"):
+            await experiment.run(JsonlTrajectoryStore(path))
+        assert agent.calls == 1
+        assert len(path.read_bytes().splitlines()) == 3
+
+        sync_state = {"file": 0, "directory": 0}
+
+        def track_retry_fsync(file_descriptor: int) -> None:
+            if stat.S_ISDIR(os.fstat(file_descriptor).st_mode):
+                sync_state["directory"] += 1
+            else:
+                sync_state["file"] += 1
+            real_fsync(file_descriptor)
+
+        monkeypatch.setattr(os, "fsync", track_retry_fsync)
+        recovered = await experiment.run(JsonlTrajectoryStore(path))
+        assert recovered.complete is True
+        assert agent.calls == 1
+        assert sync_state == {"file": 1, "directory": 1}
+
+    asyncio.run(scenario())
+
+
+def test_oversized_manifest_is_rejected_before_store_creation_or_trial_effects(
+    tmp_path,
+) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "oversized.jsonl"
+        trial = Trial(
+            task=Task(id="oversized", input={"value": "x" * (16 * 1024 * 1024)}),
+            agent=ScriptedAgent(
+                [Action.finish("done")],
+                name="oversized-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="oversized-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id="oversized-trial", max_actions=1),
+        )
+
+        with pytest.raises(ValueError, match="record is too large"):
+            await Experiment(
+                experiment_id="oversized",
+                version="1",
+                baseline=None,
+                trials={"candidate": (trial,)},
+            ).run(JsonlTrajectoryStore(path))
+
+        assert path.exists() is False
+        assert trial.trajectory.records == ()
+
+    asyncio.run(scenario())
+
+
+def test_experiment_plan_rejects_a_trial_spec_with_invalid_configuration_hash() -> None:
+    spec = _capital_trial(trial_id="invalid-spec", output="Paris").trajectory
+
+    with pytest.raises(ValueError, match="configuration hash"):
+        ExperimentPlan(
+            experiment_id="invalid-spec",
+            version="1",
+            baseline="baseline",
+            trial_specs={
+                "baseline": (replace(spec, config_hash="sha256:invalid"),),
+            },
+        )
+
+
+def test_experiment_result_rejects_a_result_outside_its_planned_provenance() -> None:
+    async def scenario() -> None:
+        trial = _capital_trial(trial_id="forged-result", output="Paris")
+        plan = Experiment(
+            experiment_id="forged-result",
+            version="1",
+            baseline="baseline",
+            trials={"baseline": (trial,)},
+        ).plan
+        result = await trial.run()
+        forged_trajectory = replace(
+            result.trajectory,
+            task=Task(id="different-task", input=None),
+        )
+        forged_result = replace(result, trajectory=forged_trajectory)
+
+        with pytest.raises(ValueError, match="planned provenance"):
+            ExperimentResult(
+                plan=plan,
+                results={"baseline": (forged_result,)},
+                started_trial_ids={"baseline": ()},
+            )
+
+    asyncio.run(scenario())
+
+
+def test_experiment_rejects_live_declaration_drift_before_starting_trial(
+    tmp_path,
+) -> None:
+    class MutableAgent:
+        name = "mutable-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {"policy": "fixed"}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "declaration-drift.jsonl"
+        agent = MutableAgent()
+        trial = Trial(
+            task=Task(id="declaration-drift", input=None),
+            agent=agent,
+            environment=LookupEnvironment(
+                {},
+                name="declaration-drift-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="declaration-drift-trial", max_actions=1),
+        )
+        experiment = Experiment(
+            experiment_id="declaration-drift",
+            version="1",
+            baseline="baseline",
+            trials={"baseline": (trial,)},
+        )
+        agent.version = "2"
+
+        with pytest.raises(ValueError, match="declarations drifted"):
+            await experiment.run(JsonlTrajectoryStore(path))
+
+        assert agent.calls == 0
+        assert trial.trajectory.records == ()
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.results == {"baseline": ()}
+        assert stored.started_trial_ids == {"baseline": ()}
+
+    asyncio.run(scenario())
+
+
+def test_experiment_rechecks_later_slot_after_earlier_trial_effects(tmp_path) -> None:
+    class LaterAgent:
+        name = "later-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    class MutatingAgent:
+        name = "mutating-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        def __init__(self, later: LaterAgent) -> None:
+            self.later = later
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.later.version = "2"
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "between-slot-drift.jsonl"
+        later_agent = LaterAgent()
+        first = Trial(
+            task=Task(id="mutate-later", input=None),
+            agent=MutatingAgent(later_agent),
+            environment=LookupEnvironment({}, name="first-environment", version="1"),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="mutate-later", max_actions=1),
+        )
+        later = Trial(
+            task=Task(id="later", input=None),
+            agent=later_agent,
+            environment=LookupEnvironment({}, name="later-environment", version="1"),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id="later", max_actions=1),
+        )
+
+        with pytest.raises(ValueError, match="declarations drifted"):
+            await Experiment(
+                experiment_id="between-slot-drift",
+                version="1",
+                baseline="baseline",
+                trials={"baseline": (first,), "candidate": (later,)},
+            ).run(JsonlTrajectoryStore(path))
+
+        assert later_agent.calls == 0
+        assert later.trajectory.records == ()
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.complete is False
+        assert len(stored.results["baseline"]) == 1
+        assert stored.results["candidate"] == ()
+        assert stored.started_trial_ids == {"baseline": (), "candidate": ()}
+
+    asyncio.run(scenario())
+
+
+def test_experiment_rechecks_declarations_before_terminal_commit(tmp_path) -> None:
+    class SelfMutatingAgent:
+        name = "self-mutating-agent"
+        version = "1"
+        configuration: Mapping[str, object] = {}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.version = "2"
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        path = tmp_path / "in-trial-drift.jsonl"
+        agent = SelfMutatingAgent()
+        experiment = Experiment(
+            experiment_id="in-trial-drift",
+            version="1",
+            trials={
+                "candidate": (
+                    Trial(
+                        task=Task(id="in-trial-drift", input=None),
+                        agent=agent,
+                        environment=LookupEnvironment(
+                            {},
+                            name="in-trial-environment",
+                            version="1",
+                        ),
+                        evaluator=ExactEvaluator("Paris", version="1"),
+                        config=TrialConfig(trial_id="in-trial-drift", max_actions=1),
+                    ),
+                ),
+            },
+        )
+
+        with pytest.raises(ValueError, match="declarations drifted"):
+            await experiment.run(JsonlTrajectoryStore(path))
+
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.complete is False
+        assert stored.results == {"candidate": ()}
+        assert stored.started_trial_ids == {"candidate": ("in-trial-drift",)}
+
+        agent.version = "1"
+        still_interrupted = await experiment.run(JsonlTrajectoryStore(path))
+        assert still_interrupted.complete is False
+        assert still_interrupted.results == {"candidate": ()}
+
+    asyncio.run(scenario())
+
+
+def test_experiment_preflights_every_pending_trial_before_any_start(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "batch-preflight.jsonl"
+        first = _capital_trial(trial_id="batch-first", output="Paris")
+        already_run = _capital_trial(trial_id="batch-second", output="Paris")
+        experiment = Experiment(
+            experiment_id="batch-preflight",
+            version="1",
+            baseline="baseline",
+            trials={"baseline": (first, already_run)},
+        )
+        await already_run.run()
+
+        with pytest.raises(RuntimeError, match="already started"):
+            await experiment.run(JsonlTrajectoryStore(path))
+
+        assert first.trajectory.records == ()
+        stored = JsonlTrajectoryStore(path).load()
+        assert stored is not None
+        assert stored.results == {"baseline": ()}
+        assert stored.started_trial_ids == {"baseline": ()}
+        assert len(path.read_bytes().splitlines()) == 1
+
+    asyncio.run(scenario())
+
+
+def test_completed_experiment_object_cannot_poison_a_new_store(tmp_path) -> None:
+    async def scenario() -> None:
+        trial = _capital_trial(trial_id="one-shot", output="Paris")
+        experiment = Experiment(
+            experiment_id="one-shot",
+            version="1",
+            baseline="baseline",
+            trials={"baseline": (trial,)},
+        )
+        await experiment.run(JsonlTrajectoryStore(tmp_path / "first.jsonl"))
+
+        second_path = tmp_path / "second.jsonl"
+        with pytest.raises(RuntimeError, match="already started"):
+            await experiment.run(JsonlTrajectoryStore(second_path))
+
+        stored = JsonlTrajectoryStore(second_path).load()
+        assert stored is not None
+        assert stored.results == {"baseline": ()}
+        assert stored.started_trial_ids == {"baseline": ()}
+        assert len(second_path.read_bytes().splitlines()) == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not portable")
+def test_store_creates_private_artifacts_and_loads_a_read_only_copy(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "private.jsonl"
+        original = await Experiment(
+            experiment_id="private-artifact",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="private", output="Paris"),),
+            },
+        ).run(JsonlTrajectoryStore(path))
+        assert stat.S_IMODE(path.stat().st_mode) & 0o077 == 0
+
+        archive = tmp_path / "archive"
+        archive.mkdir()
+        copy = archive / "private.jsonl"
+        copy.write_bytes(path.read_bytes())
+        copy.chmod(0o400)
+        archive.chmod(0o500)
+        try:
+            assert JsonlTrajectoryStore(copy).load() == original
+        finally:
+            archive.chmod(0o700)
+            copy.chmod(0o600)
+
+    asyncio.run(scenario())
+
+
+def test_loading_a_missing_store_has_no_filesystem_side_effect(tmp_path) -> None:
+    path = tmp_path / "missing-parent" / "missing.jsonl"
+
+    assert JsonlTrajectoryStore(path).load() is None
+    assert path.parent.exists() is False


### PR DESCRIPTION
## Summary

- add a provisional record-first research harness with persistent experiments
- add controlled Tool execution with strict schemas, default-deny policy, exact approvals, budgets, timeout and cancellation evidence, and effect-free replay
- document the architecture, limits, and roadmap

## Validation

- uv run pytest -q
- uv run ruff check .
- uv run python -m mypy
- cargo test --no-default-features
- bash scripts/check_example_configs.sh
- uv run sphinx-build -W --keep-going -b html docs docs/_build/html