### PR TITLE
feat(harness): add paired experiment evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,9 +24,21 @@ _Avoid_: Trial session, episode store
 The headless execution system that runs and records Experiments and Trials. It is independent from the stable messaging Runtime, which may host a messaging Environment.
 _Avoid_: Agent runtime, bot framework
 
+**Record-first**:
+The discipline of declaring comparison inputs before effects and treating persisted Trajectories as the source for later projections. A Trial first records an in-process causal sequence; an Experiment Store durably records the plan and Trial boundary markers; comparisons are pure projections from verified stored evidence. It does not imply per-Action durable write-ahead logging.
+_Avoid_: Event sourcing, exactly-once execution
+
 **Experiment**:
-A versioned comparison plan and its collected results over one or more Trials. Its task distribution, seeds, budgets, Agent versions, Environment versions, Evaluations, baselines, and caller-declared provenance are explicit.
+A versioned comparison plan and its collected results over one or more Trials. It freezes Trial seeds, budgets, Agent versions, Environment versions, Evaluators, an optional baseline, and caller-declared provenance. An Experiment using the paired evidence protocol additionally pre-registers a Task Distribution Manifest with exactly one baseline and one candidate.
 _Avoid_: Benchmark run, test batch
+
+**Task Distribution Manifest**:
+A versioned, hash-bound, caller-declared Task suite, split, ordered unique case IDs, and sampling rule. It fixes which cases form the denominator before a paired Experiment runs; it does not load a dataset, execute sampling, or prove that the suite is representative or uncontaminated.
+_Avoid_: Dataset, benchmark result
+
+**Paired Experiment Evidence Protocol**:
+The pre-registration, Agent-only pairing, complete-denominator, and pure-projection rules for comparing exactly one candidate with one baseline inside one persisted Experiment.
+_Avoid_: AGI evaluation, generality score
 
 **Trial**:
 One bounded attempt by an Agent to complete a Task in an Environment under a fixed seed, budget, and configuration.
@@ -81,12 +93,20 @@ The append-only, causally ordered evidence of a Trial. It records decision-relev
 _Avoid_: Trace, transcript, log
 
 **Trajectory Store**:
-Append-only persistence for versioned Experiment plans, Trial start markers, and immutable terminal Trajectories. It validates provenance and Replay before projecting results; it is not the messaging StateStore or SessionManager.
+Append-only persistence for versioned Experiment plans, Trial start markers, and immutable terminal Trajectories. It validates canonical schemas, hash chains, provenance, and Replay before projecting results; it is not the messaging StateStore or SessionManager, a signature authority, or a trusted timestamp service.
 _Avoid_: StateStore, SessionManager, log database
 
 **Evaluation**:
-A versioned judgment derived from a committed Trajectory under the selected Evaluator's declared criteria.
+A versioned judgment derived from a committed Trajectory under the selected Evaluator's declared criteria. Evaluation values are evidence for declared cases, not an AGI score or a generalization claim.
 _Avoid_: Reward, assertion, score only
+
+**Trial Comparison**:
+A read-only paired projection for one pre-registered case, binding the baseline and candidate Trajectory hashes, statuses, Evaluations, and score delta to their case projection hash.
+_Avoid_: Independent sample, winner
+
+**Experiment Comparison**:
+A read-only, hash-bound descriptive aggregate over every case in one Task Distribution Manifest. Its fixed denominator includes failed and budget-exhausted pairs; it does not establish uncertainty, statistical significance, causality, or cross-distribution generalization.
+_Avoid_: Benchmark score, proof of improvement
 
 **Replay**:
 Reconstruction of Trial projections and Evaluation from an existing Trajectory without repeating Agent decisions or external effects.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ terminal Trajectories as integrity-checked JSONL, then resumes already committed
 repeating their effects. A start-only interrupted Trial is never re-executed automatically; other
 never-started Trials in the same plan may continue and the result remains explicitly incomplete.
 
+For paired experiment evidence, a `TaskDistributionManifest` pre-registers the suite, split,
+ordered case IDs, and sampling rule together with exactly one baseline and one candidate.
+`compare_experiment` accepts only a complete, `JsonlTrajectoryStore`-verified result and returns
+read-only `TrialComparison` and `ExperimentComparison` values over the fixed denominator, including
+failed and budget-exhausted Trials. The resulting hashes are stable identifiers and integrity checks
+for descriptive evidence; they are not signatures, statistical significance tests, or proof of
+generalization beyond the declared distribution.
+
 For declared asynchronous Tools, `ControlledToolEnvironment` adds strict `ToolSpec` input
 validation, a static default-deny `ExecutionPolicy`, approvals bound to one exact request, and
 run-scoped reservation ledgers for Tool calls, tokens, and integer cost microunits. Each handled

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,6 +72,12 @@ Environment 副作用的情况下 Replay。内置的 `ScriptedAgent`、`LookupEn
 JSONL，并在恢复时跳过已经提交的 Trial，不重复其副作用。只有 start marker 的 interrupted Trial
 不会被自动重跑；同一 plan 中其它从未开始的 Trial 仍可继续，返回结果会明确保持 incomplete。
 
+配对实验评证由 `TaskDistributionManifest` 在执行前登记 suite、split、有序 case ID 与 sampling rule，
+并把 plan 限定为一个 baseline 和一个 candidate。`compare_experiment` 只接受完整且经过
+`JsonlTrajectoryStore` 校验的结果，按固定分母返回只读的 `TrialComparison` 与
+`ExperimentComparison`；failed 和 budget-exhausted Trial 也保留在分母中。comparison hash 是
+描述性证据的稳定标识与完整性检查，不是签名、显著性检验，也不能证明声明分布之外的泛化。
+
 对于声明后的异步 Tool，`ControlledToolEnvironment` 提供严格的 `ToolSpec` 输入校验、静态
 default-deny `ExecutionPolicy`、绑定单次精确请求的审批，以及按 run 计算的 Tool 调用、token 和
 整数费用微单位 reservation ledger。每个被处理的非 final Action 都会记录 `tool.call.outcome`；

--- a/docs/adr/0003-paired-experiment-evidence-protocol.md
+++ b/docs/adr/0003-paired-experiment-evidence-protocol.md
@@ -1,0 +1,19 @@
+---
+status: accepted
+---
+
+# Pre-register paired experiment evidence
+
+The Harness will use a Paired Experiment Evidence Protocol for its first supported comparison artifact. A `TaskDistributionManifest` binds a versioned suite, split, ordered unique case IDs, and sampling rule into the `ExperimentPlan`. A plan carrying that manifest must contain exactly one baseline and one candidate. At each case position, the two Trial specifications must have the same Task, seed, Environment, Evaluator, and budgets; only the Agent declaration may differ.
+
+This restriction is intentional. Allowing an operator to remove failed cases, change the denominator, or choose one of several candidates after observing outcomes would make the resulting aggregate a post-hoc claim. Broader multi-candidate studies require a future protocol that pre-registers contrasts and handles multiple comparisons.
+
+`JsonlTrajectoryStore` is the supported evidence boundary. It persists the plan before Trial effects, a start marker before each Trial, and the complete terminal Trajectory after the Trial. Loading verifies canonical JSON, exact owned schemas, the entry chain, plan and specification hashes, Trajectory provenance, and Replay. `compare_experiment` accepts only a complete result produced by that verified load path, exposed as `ExperimentResult.jsonl_verified`. Publicly constructed or `dataclasses.replace`-created `ExperimentResult` values do not inherit eligibility and do not compare equal to a verified result. `TrialComparison` and `ExperimentComparison` are read-only result types without supported public constructors.
+
+The comparison denominator is every case in the manifest. Failed, cancelled, and budget-exhausted pairs remain visible in status counts and rates instead of being dropped. Pass rates use the full denominator. A score delta exists only where both sides have an Evaluation, and the aggregate reports the paired score count separately. Each pair carries the baseline and candidate full-Trajectory hashes used by the JSONL artifact. The comparison hash binds those hashes together with the plan hash, manifest hash, case projections, an explicit `comparison_format_version`, and derived descriptive statistics, so metric-identical but evidentially different runs do not alias and future aggregate semantics can take a new version.
+
+The persistence levels remain explicit. Trial records establish in-process causal order but are not a per-Action durable write-ahead log. The Store durably establishes plan, Trial-start, and terminal-Trajectory boundaries. Comparison is a pure projection and performs neither execution nor persistence.
+
+These outputs are descriptive evidence for the declared distribution. The manifest fields are caller declarations: the Harness neither executes the sampling rule nor verifies split isolation. A positive score delta means improvement only when the Evaluator defines that direction, and averaging heterogeneous score scales may have only arithmetic meaning. The protocol does not establish statistical significance, uncertainty, causality, dataset representativeness, contamination freedom, or generalization to another Task or Environment distribution. Hashes detect inconsistent content; they are not signatures, trusted timestamps, anti-rollback protection, or proof that an artifact existed before an outcome was known. An actor able to fabricate the entire artifact can create a self-consistent history. External effects also remain outside any exactly-once guarantee.
+
+The consequence is a deliberately narrow but auditable comparison surface. Future uncertainty estimates, repeated-seed designs, generalization suites, signed artifact manifests, and multi-candidate contrasts must extend the protocol explicitly instead of changing the meaning of this first format.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -21,6 +21,15 @@ Provisional research Harness
 ``ControlledToolEnvironment``。Harness ``ExecutionPolicy`` 不复用稳定消息 Runtime 的
 ``Permission`` 或 ``ToolRegistry``，``ControlledToolEnvironment`` 也不是隔离沙箱。
 
+配对实验评证接口包括 ``TaskDistributionManifest``、``TrialComparison``、
+``ExperimentComparison`` 与 ``compare_experiment``。manifest 预登记 exactly one baseline and one
+candidate 的固定 case 分布；manifest 字段是调用方声明，Harness 不执行 sampling rule。
+``compare_experiment`` 只接受 complete、经 ``JsonlTrajectoryStore``
+校验且 ``jsonl_verified=True`` 的结果；``dataclasses.replace`` 或公开重建的结果不会继承该资格。两个 Comparison 类是
+返回值类型，没有受支持的公共构造器。它们提供描述性聚合与完整性
+hash；``ExperimentComparison.comparison_format_version`` 版本化其 hash 与聚合语义。它们不提供签名、
+可信时间、统计显著性或分布外泛化证明。
+
 .. automodule:: iamai.harness
    :members:
    :imported-members:

--- a/docs/guides/ecosystem-comparison.rst
+++ b/docs/guides/ecosystem-comparison.rst
@@ -245,6 +245,7 @@ record-first 的通用 Agent 研究 Harness。消息 Runtime 以后可以通过�
 --------
 
 稳定消息 Runtime 继续遵守 ``1.x`` 合同；新增研究能力进入 provisional 的 ``iamai.harness``。
-短期顺序是先完成可回放的 headless Trial，再扩展受控执行、持久化 Experiment 与消息桥接。
+当前已完成 headless Trial、受控执行、持久化 Experiment 与配对实验评证；下一步是 Policy-backed Agent
+和跨分布评测套件，消息桥接作为并行集成轨推进。
 AGI 只是研究北极星，能力结论必须明确 Task/Environment 分布、seed、预算、组件版本和基线；
 WebUI 仍作为独立插件或独立项目，不进入核心。具体里程碑见 :doc:`roadmap`。

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -19,7 +19,7 @@
 
    **运行研究 Trial**
       用 headless Harness 组合 Task、Agent、Environment、Trajectory 与 Evaluation，并把持久化 Experiment
-      保存为可校验的 JSONL。
+      保存为可校验的 JSONL，再从预登记分布生成固定分母的配对证据。
       :doc:`research-harness` · :doc:`roadmap`
 
    **接入与上线**

--- a/docs/guides/research-harness.rst
+++ b/docs/guides/research-harness.rst
@@ -267,6 +267,18 @@ request binding 与记录内 ledger 的一致性。它不会重新调用 Agent�
 Policy、clock 或价格系统，也不能证明原外部 effect 真实发生。Re-execution 则是使用同一规范开始一个
 新的 Trial；只有所有参与组件和依赖都确定时，Re-execution 才应产生相同结果。
 
+Record-first 的三个层级
+-----------------------
+
+``Trial`` 在进程内按因果顺序追加 Trajectory record；这是执行状态机的证据顺序，不是逐 Action 的 write-ahead log，
+也不保证进程崩溃前的中间 Action 已落盘。``Experiment`` 与
+``JsonlTrajectoryStore`` 会在任何 Trial effect 前持久化 plan，并在每个 Trial 运行前持久化
+``trial.started``；终态 Trajectory 则在整个 Trial 完成后一次提交。``compare_experiment`` 不执行任何
+Agent、Environment 或 Evaluator，也不写 artifact，只从 Store 校验后的完整结果构造纯投影。
+
+因此这里的 record-first 表示“先声明、再执行、从记录推导结论”，并不承诺外部 effect exactly-once、
+逐步 durable checkpoint 或 mid-Trial resume。
+
 持久化 Experiment
 ------------------
 
@@ -287,8 +299,10 @@ Trajectory；status、Evaluation 与 failure 都由 :func:`~iamai.harness.replay
        LookupEnvironment,
        ScriptedAgent,
        Task,
+       TaskDistributionManifest,
        Trial,
        TrialConfig,
+       compare_experiment,
    )
 
 
@@ -316,6 +330,13 @@ Trajectory；status、Evaluation 与 failure 都由 :func:`~iamai.harness.replay
            experiment_id="capitals",
            version="1",
            baseline="baseline",
+           task_distribution=TaskDistributionManifest(
+               suite_id="capital-suite",
+               version="1",
+               split="test",
+               case_ids=("capital-of-france/seed-7",),
+               sampling_rule="ordered-full-set-v1",
+           ),
            provenance={"source_revision": "abc123"},
            trials={
                "baseline": (candidate("baseline-7", "Lyon"),),
@@ -328,8 +349,44 @@ Trajectory；status、Evaluation 与 failure 都由 :func:`~iamai.harness.replay
        assert result.results["candidate"][0].evaluation.passed
        assert JsonlTrajectoryStore("runs/capitals.jsonl").load() == result
 
+       comparison = compare_experiment(result, candidate="candidate")
+       assert comparison.total_pairs == 1
+       assert comparison.pass_rate_delta == 1.0
+       assert comparison.mean_score_delta == 1.0
+
 
    asyncio.run(compare())
+
+Paired Experiment Evidence Protocol
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``TaskDistributionManifest`` 在 Trial 开始前把 suite ID、suite version、split、有序且唯一的 case ID，
+以及 sampling rule 纳入 plan hash。带 manifest 的 plan 必须预登记 exactly one baseline and one candidate；
+两侧 slot 数量、case 顺序、Task、seed、Environment、Evaluator 和预算必须一致，只允许 Agent 声明不同。
+这避免跑完后删掉失败 case、改变分母或从多个 candidate 中挑选最好结果。
+
+``compare_experiment(result, candidate=...)`` 只接受 complete、JsonlTrajectoryStore-verified 的
+``ExperimentResult``。这里的 verified 表示当前支持路径已经校验 canonical JSON、exact schema、行链、
+plan/spec/Trajectory hash、声明 provenance 和 Replay；公开重建的 ``ExperimentResult``、不完整结果或
+legacy manifest-less plan 都不能进入比较。``ExperimentResult.jsonl_verified`` 可读取这项资格；
+``dataclasses.replace`` 或公开构造得到的新对象不会继承它，并且不会与 verified result 相等。
+``TrialComparison`` 与 ``ExperimentComparison`` 是只读返回类型，不能由公共构造器拼装。
+
+比较的固定分母是 manifest 中的全部 case。``failed``、``budget_exhausted`` 与 ``cancelled`` 不会被
+静默丢弃；每种 ``TrialStatus`` 都有 count 与 rate，pass rate 也始终除以全部 pair。score delta 只在
+baseline 与 candidate 两侧都有 Evaluation 时形成，``paired_score_count`` 明确报告实际有多少 score pair，
+``mean_score_delta`` 在没有 score pair 时为 ``None``。comparison hash 绑定 plan hash、manifest hash、
+每个 case projection、两侧完整 Trajectory hash 和全部描述性统计；pair 中的
+``baseline_trajectory_hash`` / ``candidate_trajectory_hash`` 与 JSONL 的 ``trajectory_digest`` 一致，
+因此指标相同但运行证据不同的比较不会共享同一个 comparison hash。公开的
+``comparison_format_version`` 标识 hash preimage 与聚合语义版本，当前为 ``"1"``。
+
+这些结果是 declared distribution 上的 descriptive evidence。它不估计置信区间，不做显著性或多重比较
+校正，不证明因果改进、suite 代表性、数据无污染或跨分布泛化。``sampling_rule`` 与 ``split`` 都只是
+调用方声明，Harness 不执行抽样或验证 split 隔离。正 score delta 是否代表改进由 Evaluator 的方向语义
+决定；不同 case 使用异质 score scale 时，``mean_score_delta`` 可能只有算术意义。Store 的 verified 和 comparison hash
+不是签名、可信时间戳或真实性证明；能写 artifact 的恶意主体仍可从头伪造一条自洽记录。调用方需要保护
+artifact、固定源代码与依赖版本，并在更广的结论前增加独立评测设计。
 
 恢复与完整性语义
 ~~~~~~~~~~~~~~~~
@@ -377,7 +434,7 @@ variant 顺序、baseline、Task、seed、预算、组件声明和调用方 prov
 - 每个 Trial 必须创建独立的 ``ControlledToolEnvironment``。Tool 与 Approver 是受信任的进程内 Python；
   Harness 记录其声明但不自动指纹化实现，也不独立核验 ToolResult usage、provider 账单或外部 effect。
 - Tool schema 是固定的 JSON 子集；远程 ``$ref``、schema default/coercion 和完整 JSON Schema 尚未加入。
-- 当前 Store 是单文件本地 JSONL；跨 Experiment 查询、artifact manifest、统计汇总、schema migration、
+- 当前 Store 是单文件本地 JSONL；跨 Experiment 查询、artifact manifest、推断统计、schema migration、
   mid-Trial resume、远程持久审批、分布式预算、沙箱、模型 provider、学习器和消息桥接尚未加入。
 - 恢复合同面向预先存在父目录上的本地文件系统与进程中断/末行撕裂；不声明断电、NFS、共享挂载或
   多主机 writer 的持久性保证。

--- a/docs/guides/roadmap.rst
+++ b/docs/guides/roadmap.rst
@@ -2,7 +2,7 @@
 ================
 
 这页把 :doc:`ecosystem-comparison` 的定位落到工程顺序。``1.0`` 已经稳定消息 Runtime；
-后续工作在不改变这些语义的前提下，把 iamai 演进为可复现的通用 Agent 研究 Harness。
+后续工作在不改变这些语义的前提下，把 iamai 演进为可审计、可回放、可比较的通用 Agent 研究 Harness。
 
 版本路线图
 ----------
@@ -43,6 +43,16 @@
 ------------------------
 
 这些里程碑表达依赖顺序，不承诺版本号或日期。AGI 是研究方向，不是其中任意一项完成后的产品声明。
+依赖不是纯线性：受控执行和消息桥接都是独立 Environment 轨；离线学习必须同时建立在版本化 Agent policy 和可信评测
+分布之上。
+
+.. code-block:: text
+
+   Headless Trial
+   ├── Policy-backed Agent ─────────────────────────────────────┐
+   ├── Persistent Experiment → Paired evidence → Generalization suites ─┴── Offline learning
+   ├── Controlled execution (independent Environment track)
+   └── Messaging bridge (parallel Environment track)
 
 语义与兼容性基线
    保留 ``Runtime``、``Event``、``SessionManager`` 等 ``1.x`` 名称的既有含义；Harness 能力只进入
@@ -61,16 +71,33 @@ Headless Trial
 持久化 Experiment
    |implemented| 第一条 JSONL 垂直切片已保存不可变 Experiment plan、调用方 provenance、variant/baseline
    标签、Trial start marker 与完整终态 Trajectory；支持完整性链、显式尾修复、已提交 Trial 的幂等恢复、
-   start-only Trial 防重跑、计划冲突检测和 single-writer 纪律。聚合基线统计、artifact manifest、跨
-   Experiment 查询和 schema migration 仍属后续工作。
+   start-only Trial 防重跑、计划冲突检测和 single-writer 纪律。artifact manifest、跨 Experiment 查询和
+   schema migration 仍属后续工作。
+
+配对实验评证协议
+   |implemented| ``TaskDistributionManifest`` 把 suite、split、有序 case 和 sampling rule 预登记进 plan；
+   manifest plan 只允许一个 baseline 与一个 candidate，并在 slot 层校验除 Agent 外的可比性。
+   ``compare_experiment`` 只从完整、Store 校验后的结果产生固定分母的 ``TrialComparison`` 与
+   ``ExperimentComparison``，显式报告每种终态、pass rate 和有 Evaluation 的配对 score delta。
+   这是描述性证据，不是签名、显著性检验或跨分布泛化证明。
+
+Policy-backed Agent
+   从 Headless Trial 的 Agent interface 冻结 policy checkpoint：模型与 provider 声明、prompt/tool-use
+   policy、memory policy、context shaping 和版本化配置必须进入 Trial provenance。该层先建立可替换的
+   policy interface 与确定性 fixture，再接远程模型；它不依赖某一种 Environment，也不会把某个 provider
+   SDK 固化为 Harness 核心。
+
+泛化评测套件
+   在 paired evidence 之上定义多个独立 Task/Environment distribution、污染与迁移检查、重复 seed、
+   不确定性报告和回归门禁。任何“更通用”的结论必须跨预登记分布成立，不能从单一 comparison hash 推导。
 
 消息桥接
    通过独立桥接把稳定消息 Runtime 作为一种 Environment 接入；``Event`` 不改名为 Observation，
-   ``SessionManager`` 也不承担 Trial 存储职责。
+   ``SessionManager`` 也不承担 Trial 存储职责。该分支可以与 Policy-backed Agent 和评测套件并行推进。
 
 离线学习闭环
-   在可复现 Experiment 之上研究数据筛选、策略检查点、回归评测和离线改进。任何“更通用”的结论都必须
-   明确 Task/Environment 分布、种子、预算、版本和基线。
+   只有 Policy-backed Agent、泛化评测套件和可追踪 checkpoint 都落地后，才研究数据筛选、回归评测与
+   离线改进。任何“更通用”的结论都必须明确 Task/Environment 分布、种子、预算、版本和基线。
 
 设计决策
 --------

--- a/python/iamai/harness/__init__.py
+++ b/python/iamai/harness/__init__.py
@@ -13,7 +13,13 @@ from ._controlled import (
     ToolResult,
     ToolSpec,
 )
-from ._experiment import Experiment, ExperimentPlan, ExperimentResult
+from ._evidence import ExperimentComparison, TrialComparison, compare_experiment
+from ._experiment import (
+    Experiment,
+    ExperimentPlan,
+    ExperimentResult,
+    TaskDistributionManifest,
+)
 from ._jsonl import JsonlTrajectoryStore
 from ._model import (
     Action,
@@ -40,6 +46,7 @@ __all__ = [
     "Evaluation",
     "ExactEvaluator",
     "Experiment",
+    "ExperimentComparison",
     "ExperimentPlan",
     "ExperimentResult",
     "ExecutionBudget",
@@ -49,11 +56,13 @@ __all__ = [
     "Observation",
     "ScriptedAgent",
     "Task",
+    "TaskDistributionManifest",
     "Tool",
     "ToolCallStatus",
     "ToolResult",
     "ToolSpec",
     "Trial",
+    "TrialComparison",
     "TrialConfig",
     "TrialFailure",
     "TrialResult",
@@ -61,5 +70,6 @@ __all__ = [
     "Trajectory",
     "TrajectoryRecord",
     "Transition",
+    "compare_experiment",
     "replay",
 ]

--- a/python/iamai/harness/_evidence.py
+++ b/python/iamai/harness/_evidence.py
@@ -1,0 +1,447 @@
+"""Pure paired evidence projections for persisted Harness Experiments."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+from ._experiment import (
+    ExperimentResult,
+    TaskDistributionManifest,
+    _comparison_projection,
+    _is_registered_experiment_result,
+)
+from ._model import (
+    TrialResult,
+    TrialStatus,
+    _configuration_hash,
+    _frozen_object,
+    _trajectory_hash,
+)
+
+EXPERIMENT_COMPARISON_FORMAT_VERSION = "1"
+
+
+def _is_sha256_identifier(value: str) -> bool:
+    prefix = "sha256:"
+    digest = value.removeprefix(prefix)
+    return (
+        value.startswith(prefix)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    )
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class TrialComparison:
+    """One pre-registered baseline/candidate Trial pair."""
+
+    position: int
+    case_id: str
+    case_hash: str
+    task_id: str
+    seed: int
+    baseline_trial_id: str
+    candidate_trial_id: str
+    baseline_trajectory_hash: str
+    candidate_trajectory_hash: str
+    baseline_status: TrialStatus
+    candidate_status: TrialStatus
+    baseline_passed: bool | None
+    candidate_passed: bool | None
+    baseline_score: float | None
+    candidate_score: float | None
+    score_delta: float | None = field(init=False)
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TypeError("TrialComparison has no public constructor; use compare_experiment")
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.position, bool)
+            or not isinstance(self.position, int)
+            or self.position < 0
+        ):
+            raise ValueError("TrialComparison position must be a non-negative integer")
+        for field_name in (
+            "case_id",
+            "case_hash",
+            "task_id",
+            "baseline_trial_id",
+            "candidate_trial_id",
+            "baseline_trajectory_hash",
+            "candidate_trajectory_hash",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"TrialComparison {field_name} cannot be empty")
+        if not _is_sha256_identifier(self.case_hash):
+            raise ValueError("TrialComparison case_hash must be a sha256 identifier")
+        for field_name in (
+            "baseline_trajectory_hash",
+            "candidate_trajectory_hash",
+        ):
+            if not _is_sha256_identifier(getattr(self, field_name)):
+                raise ValueError(f"TrialComparison {field_name} must be a sha256 identifier")
+        if self.baseline_trial_id == self.candidate_trial_id:
+            raise ValueError("TrialComparison Trial ids must differ")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise TypeError("TrialComparison seed must be an integer")
+        if not isinstance(self.baseline_status, TrialStatus) or not isinstance(
+            self.candidate_status, TrialStatus
+        ):
+            raise TypeError("TrialComparison statuses must be TrialStatus values")
+        for field_name in ("baseline_passed", "candidate_passed"):
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, bool):
+                raise TypeError(f"TrialComparison {field_name} must be a bool or None")
+        scores: dict[str, float | None] = {}
+        for field_name in ("baseline_score", "candidate_score"):
+            value = getattr(self, field_name)
+            if value is None:
+                scores[field_name] = None
+                continue
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"TrialComparison {field_name} must be a number or None")
+            score = float(value)
+            if not math.isfinite(score):
+                raise ValueError(f"TrialComparison {field_name} must be finite")
+            scores[field_name] = score
+            object.__setattr__(self, field_name, score)
+        if (self.baseline_passed is None) != (self.baseline_score is None):
+            raise ValueError("TrialComparison baseline Evaluation fields are inconsistent")
+        if (self.candidate_passed is None) != (self.candidate_score is None):
+            raise ValueError("TrialComparison candidate Evaluation fields are inconsistent")
+        evaluated_statuses = {
+            TrialStatus.COMPLETED,
+            TrialStatus.BUDGET_EXHAUSTED,
+        }
+        for side in ("baseline", "candidate"):
+            status = getattr(self, f"{side}_status")
+            has_evaluation = getattr(self, f"{side}_passed") is not None
+            if (status in evaluated_statuses) != has_evaluation:
+                raise ValueError(f"TrialComparison {side} status and Evaluation are inconsistent")
+        score_delta = (
+            None
+            if scores["baseline_score"] is None or scores["candidate_score"] is None
+            else scores["candidate_score"] - scores["baseline_score"]
+        )
+        if score_delta is not None and not math.isfinite(score_delta):
+            raise ValueError("TrialComparison score_delta must be finite")
+        object.__setattr__(self, "score_delta", score_delta)
+
+
+def _trial_comparison(
+    *,
+    position: int,
+    case_id: str,
+    case_hash: str,
+    task_id: str,
+    seed: int,
+    baseline_trial_id: str,
+    candidate_trial_id: str,
+    baseline_trajectory_hash: str,
+    candidate_trajectory_hash: str,
+    baseline_status: TrialStatus,
+    candidate_status: TrialStatus,
+    baseline_passed: bool | None,
+    candidate_passed: bool | None,
+    baseline_score: float | None,
+    candidate_score: float | None,
+) -> TrialComparison:
+    comparison = object.__new__(TrialComparison)
+    values = {
+        "position": position,
+        "case_id": case_id,
+        "case_hash": case_hash,
+        "task_id": task_id,
+        "seed": seed,
+        "baseline_trial_id": baseline_trial_id,
+        "candidate_trial_id": candidate_trial_id,
+        "baseline_trajectory_hash": baseline_trajectory_hash,
+        "candidate_trajectory_hash": candidate_trajectory_hash,
+        "baseline_status": baseline_status,
+        "candidate_status": candidate_status,
+        "baseline_passed": baseline_passed,
+        "candidate_passed": candidate_passed,
+        "baseline_score": baseline_score,
+        "candidate_score": candidate_score,
+    }
+    for field_name, value in values.items():
+        object.__setattr__(comparison, field_name, value)
+    comparison.__post_init__()
+    return comparison
+
+
+def _trial_comparison_payload(comparison: TrialComparison) -> dict[str, object]:
+    return {
+        "position": comparison.position,
+        "case_id": comparison.case_id,
+        "case_hash": comparison.case_hash,
+        "task_id": comparison.task_id,
+        "seed": comparison.seed,
+        "baseline_trial_id": comparison.baseline_trial_id,
+        "candidate_trial_id": comparison.candidate_trial_id,
+        "baseline_trajectory_hash": comparison.baseline_trajectory_hash,
+        "candidate_trajectory_hash": comparison.candidate_trajectory_hash,
+        "baseline_status": comparison.baseline_status.value,
+        "candidate_status": comparison.candidate_status.value,
+        "baseline_passed": comparison.baseline_passed,
+        "candidate_passed": comparison.candidate_passed,
+        "baseline_score": comparison.baseline_score,
+        "candidate_score": comparison.candidate_score,
+        "score_delta": comparison.score_delta,
+    }
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class ExperimentComparison:
+    """Hash-bound aggregate over one baseline and one candidate variant."""
+
+    experiment_id: str
+    plan_hash: str
+    task_distribution: TaskDistributionManifest
+    baseline: str
+    candidate: str
+    trials: tuple[TrialComparison, ...]
+    comparison_format_version: str = field(init=False)
+    total_pairs: int = field(init=False)
+    baseline_passes: int = field(init=False)
+    candidate_passes: int = field(init=False)
+    baseline_pass_rate: float = field(init=False)
+    candidate_pass_rate: float = field(init=False)
+    pass_rate_delta: float = field(init=False)
+    baseline_status_counts: Mapping[TrialStatus, int] = field(init=False)
+    candidate_status_counts: Mapping[TrialStatus, int] = field(init=False)
+    baseline_status_rates: Mapping[TrialStatus, float] = field(init=False)
+    candidate_status_rates: Mapping[TrialStatus, float] = field(init=False)
+    paired_score_count: int = field(init=False)
+    mean_score_delta: float | None = field(init=False)
+    comparison_hash: str = field(init=False)
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TypeError("ExperimentComparison has no public constructor; use compare_experiment")
+
+    def __post_init__(self) -> None:
+        for field_name in ("experiment_id", "plan_hash", "baseline", "candidate"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"ExperimentComparison {field_name} cannot be empty")
+        if not _is_sha256_identifier(self.plan_hash):
+            raise ValueError("ExperimentComparison plan_hash must be a sha256 identifier")
+        if self.baseline == self.candidate:
+            raise ValueError("ExperimentComparison candidate must differ from baseline")
+        if not isinstance(self.task_distribution, TaskDistributionManifest):
+            raise TypeError(
+                "ExperimentComparison task_distribution must be a TaskDistributionManifest"
+            )
+        trials = tuple(self.trials)
+        if not trials or not all(isinstance(item, TrialComparison) for item in trials):
+            raise ValueError("ExperimentComparison trials cannot be empty")
+        if len(trials) != len(self.task_distribution.case_ids):
+            raise ValueError("ExperimentComparison trials must match the Task distribution")
+        for position, (case_id, trial) in enumerate(
+            zip(self.task_distribution.case_ids, trials, strict=True)
+        ):
+            if trial.position != position or trial.case_id != case_id:
+                raise ValueError("ExperimentComparison trials must follow Task distribution order")
+        trial_ids = tuple(
+            trial_id
+            for trial in trials
+            for trial_id in (trial.baseline_trial_id, trial.candidate_trial_id)
+        )
+        if len(set(trial_ids)) != len(trial_ids):
+            raise ValueError("ExperimentComparison Trial ids must be globally unique")
+
+        total_pairs = len(trials)
+        baseline_passes = sum(item.baseline_passed is True for item in trials)
+        candidate_passes = sum(item.candidate_passed is True for item in trials)
+        baseline_pass_rate = baseline_passes / total_pairs
+        candidate_pass_rate = candidate_passes / total_pairs
+        baseline_status_counts = MappingProxyType(
+            {
+                status: sum(item.baseline_status is status for item in trials)
+                for status in TrialStatus
+            }
+        )
+        candidate_status_counts = MappingProxyType(
+            {
+                status: sum(item.candidate_status is status for item in trials)
+                for status in TrialStatus
+            }
+        )
+        baseline_status_rates = MappingProxyType(
+            {status: count / total_pairs for status, count in baseline_status_counts.items()}
+        )
+        candidate_status_rates = MappingProxyType(
+            {status: count / total_pairs for status, count in candidate_status_counts.items()}
+        )
+        paired_deltas = tuple(item.score_delta for item in trials if item.score_delta is not None)
+        mean_score_delta = math.fsum(paired_deltas) / len(paired_deltas) if paired_deltas else None
+        payload = _frozen_object(
+            comparison_format_version=EXPERIMENT_COMPARISON_FORMAT_VERSION,
+            experiment_id=self.experiment_id,
+            plan_hash=self.plan_hash,
+            task_distribution_hash=self.task_distribution.manifest_hash,
+            baseline=self.baseline,
+            candidate=self.candidate,
+            trials=[_trial_comparison_payload(item) for item in trials],
+            total_pairs=total_pairs,
+            baseline_passes=baseline_passes,
+            candidate_passes=candidate_passes,
+            baseline_pass_rate=baseline_pass_rate,
+            candidate_pass_rate=candidate_pass_rate,
+            pass_rate_delta=candidate_pass_rate - baseline_pass_rate,
+            baseline_status_counts={
+                status.value: count for status, count in baseline_status_counts.items()
+            },
+            candidate_status_counts={
+                status.value: count for status, count in candidate_status_counts.items()
+            },
+            baseline_status_rates={
+                status.value: rate for status, rate in baseline_status_rates.items()
+            },
+            candidate_status_rates={
+                status.value: rate for status, rate in candidate_status_rates.items()
+            },
+            paired_score_count=len(paired_deltas),
+            mean_score_delta=mean_score_delta,
+        )
+        object.__setattr__(self, "trials", trials)
+        object.__setattr__(
+            self,
+            "comparison_format_version",
+            EXPERIMENT_COMPARISON_FORMAT_VERSION,
+        )
+        object.__setattr__(self, "total_pairs", total_pairs)
+        object.__setattr__(self, "baseline_passes", baseline_passes)
+        object.__setattr__(self, "candidate_passes", candidate_passes)
+        object.__setattr__(self, "baseline_pass_rate", baseline_pass_rate)
+        object.__setattr__(self, "candidate_pass_rate", candidate_pass_rate)
+        object.__setattr__(
+            self,
+            "pass_rate_delta",
+            candidate_pass_rate - baseline_pass_rate,
+        )
+        object.__setattr__(self, "baseline_status_counts", baseline_status_counts)
+        object.__setattr__(self, "candidate_status_counts", candidate_status_counts)
+        object.__setattr__(self, "baseline_status_rates", baseline_status_rates)
+        object.__setattr__(self, "candidate_status_rates", candidate_status_rates)
+        object.__setattr__(self, "paired_score_count", len(paired_deltas))
+        object.__setattr__(self, "mean_score_delta", mean_score_delta)
+        object.__setattr__(self, "comparison_hash", _configuration_hash(payload))
+
+
+def _experiment_comparison(
+    *,
+    experiment_id: str,
+    plan_hash: str,
+    task_distribution: TaskDistributionManifest,
+    baseline: str,
+    candidate: str,
+    trials: tuple[TrialComparison, ...],
+) -> ExperimentComparison:
+    comparison = object.__new__(ExperimentComparison)
+    values = {
+        "experiment_id": experiment_id,
+        "plan_hash": plan_hash,
+        "task_distribution": task_distribution,
+        "baseline": baseline,
+        "candidate": candidate,
+        "trials": trials,
+    }
+    for field_name, value in values.items():
+        object.__setattr__(comparison, field_name, value)
+    comparison.__post_init__()
+    return comparison
+
+
+def _evaluation_fields(
+    result: TrialResult,
+) -> tuple[bool | None, float | None]:
+    if result.evaluation is None:
+        return None, None
+    return result.evaluation.passed, result.evaluation.score
+
+
+def compare_experiment(
+    result: ExperimentResult,
+    *,
+    candidate: str,
+) -> ExperimentComparison:
+    """Project a complete, pre-registered candidate comparison without execution."""
+    if not isinstance(result, ExperimentResult):
+        raise TypeError("compare_experiment result must be an ExperimentResult")
+    if not _is_registered_experiment_result(result):
+        raise ValueError("compare_experiment requires a result verified by JsonlTrajectoryStore")
+    if not isinstance(candidate, str) or not candidate.strip():
+        raise ValueError("compare_experiment candidate cannot be empty")
+    baseline = result.baseline
+    if baseline is None:
+        raise ValueError("Experiment plan does not declare a baseline")
+    task_distribution = result.plan.task_distribution
+    if task_distribution is None:
+        raise ValueError("Experiment plan did not pre-register a Task distribution")
+    if candidate == baseline:
+        raise ValueError("compare_experiment candidate must differ from baseline")
+    if candidate not in result.results:
+        raise ValueError("compare_experiment candidate is not a planned variant")
+    planned_candidates = set(result.results).difference({baseline})
+    if planned_candidates != {candidate}:
+        raise ValueError("compare_experiment candidate must be the sole pre-registered candidate")
+
+    baseline_results = result.results[baseline]
+    candidate_results = result.results[candidate]
+    baseline_specs = result.plan.trial_specs[baseline]
+    candidate_specs = result.plan.trial_specs[candidate]
+    expected_pairs = len(task_distribution.case_ids)
+    if len(baseline_results) != expected_pairs or len(candidate_results) != expected_pairs:
+        raise ValueError("compare_experiment requires complete baseline and candidate variants")
+
+    trials: list[TrialComparison] = []
+    for position, case_id in enumerate(task_distribution.case_ids):
+        baseline_spec = baseline_specs[position]
+        candidate_spec = candidate_specs[position]
+        projection = _comparison_projection(baseline_spec, case_id=case_id)
+        projection_hash = _configuration_hash(projection)
+        if projection_hash != _configuration_hash(
+            _comparison_projection(candidate_spec, case_id=case_id)
+        ):
+            raise ValueError(
+                f"compare_experiment Trial pair is not comparable at position {position}"
+            )
+        baseline_result = baseline_results[position]
+        candidate_result = candidate_results[position]
+        baseline_passed, baseline_score = _evaluation_fields(baseline_result)
+        candidate_passed, candidate_score = _evaluation_fields(candidate_result)
+        trials.append(
+            _trial_comparison(
+                position=position,
+                case_id=case_id,
+                case_hash=projection_hash,
+                task_id=baseline_spec.task.id,
+                seed=baseline_spec.seed,
+                baseline_trial_id=baseline_result.trial_id,
+                candidate_trial_id=candidate_result.trial_id,
+                baseline_trajectory_hash=_trajectory_hash(baseline_result.trajectory),
+                candidate_trajectory_hash=_trajectory_hash(candidate_result.trajectory),
+                baseline_status=baseline_result.status,
+                candidate_status=candidate_result.status,
+                baseline_passed=baseline_passed,
+                candidate_passed=candidate_passed,
+                baseline_score=baseline_score,
+                candidate_score=candidate_score,
+            )
+        )
+    return _experiment_comparison(
+        experiment_id=result.experiment_id,
+        plan_hash=result.plan_hash,
+        task_distribution=task_distribution,
+        baseline=baseline,
+        candidate=candidate,
+        trials=tuple(trials),
+    )

--- a/python/iamai/harness/_experiment.py
+++ b/python/iamai/harness/_experiment.py
@@ -15,6 +15,7 @@ from ._model import (
     Trajectory,
     TrialResult,
     _configuration_hash,
+    _evaluation_payload,
     _freeze_json,
     _frozen_object,
 )
@@ -23,6 +24,75 @@ from ._trial import Trial, _configuration_snapshot
 
 if TYPE_CHECKING:
     from ._jsonl import JsonlTrajectoryStore
+
+
+TASK_DISTRIBUTION_MANIFEST_FORMAT_VERSION = "1"
+COMPARISON_PROJECTION_VERSION = "1"
+_JSONL_EVIDENCE_REGISTRATION = object()
+
+
+@dataclass(frozen=True, slots=True)
+class TaskDistributionManifest:
+    """Pre-registered identity and case order for one Task distribution."""
+
+    suite_id: str
+    version: str
+    split: str
+    case_ids: tuple[str, ...]
+    sampling_rule: str
+    manifest_hash: str = field(init=False)
+    _payload: Mapping[str, FrozenJsonValue] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        for field_name in ("suite_id", "version", "split", "sampling_rule"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"TaskDistributionManifest {field_name} cannot be empty"
+                )
+            _freeze_json(value, path=f"$.task_distribution.{field_name}")
+        raw_case_ids: object = self.case_ids
+        if isinstance(raw_case_ids, (str, bytes)) or not isinstance(
+            raw_case_ids, Sequence
+        ):
+            raise TypeError(
+                "TaskDistributionManifest case_ids must be a sequence of strings"
+            )
+        case_ids = tuple(raw_case_ids)
+        if not case_ids:
+            raise ValueError("TaskDistributionManifest case_ids cannot be empty")
+        for case_id in case_ids:
+            if not isinstance(case_id, str) or not case_id.strip():
+                raise ValueError(
+                    "TaskDistributionManifest case_ids must contain non-empty strings"
+                )
+            _freeze_json(case_id, path="$.task_distribution.case_ids[]")
+        if len(set(case_ids)) != len(case_ids):
+            raise ValueError("TaskDistributionManifest case_ids must be unique")
+        payload = _frozen_object(
+            manifest_format_version=TASK_DISTRIBUTION_MANIFEST_FORMAT_VERSION,
+            suite_id=self.suite_id,
+            version=self.version,
+            split=self.split,
+            case_ids=case_ids,
+            sampling_rule=self.sampling_rule,
+        )
+        object.__setattr__(self, "case_ids", case_ids)
+        object.__setattr__(self, "_payload", payload)
+        object.__setattr__(self, "manifest_hash", _configuration_hash(payload))
+
+
+def _task_distribution_payload(
+    manifest: TaskDistributionManifest,
+) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        **dict(manifest._payload),
+        manifest_hash=manifest.manifest_hash,
+    )
 
 
 def _trajectory_spec(trajectory: Trajectory) -> Mapping[str, FrozenJsonValue]:
@@ -36,6 +106,48 @@ def _trajectory_spec(trajectory: Trajectory) -> Mapping[str, FrozenJsonValue]:
     )
 
 
+def _comparison_projection(
+    trajectory: Trajectory,
+    *,
+    case_id: str,
+) -> Mapping[str, FrozenJsonValue]:
+    trial_configuration = dict(trajectory.configuration)
+    trial_configuration.pop("agent", None)
+    return _frozen_object(
+        comparison_projection_version=COMPARISON_PROJECTION_VERSION,
+        case_id=case_id,
+        format_version=trajectory.format_version,
+        task={"id": trajectory.task.id, "input": trajectory.task.input},
+        seed=trajectory.seed,
+        trial_configuration=trial_configuration,
+    )
+
+
+def _trial_result_projection(
+    result: TrialResult,
+) -> Mapping[str, FrozenJsonValue]:
+    evaluation = (
+        None if result.evaluation is None else _evaluation_payload(result.evaluation)
+    )
+    failure = (
+        None
+        if result.failure is None
+        else _frozen_object(
+            phase=result.failure.phase,
+            code=result.failure.code,
+            exception_type=result.failure.exception_type,
+            message=result.failure.message,
+        )
+    )
+    return _frozen_object(
+        trial_id=result.trial_id,
+        status=result.status.value,
+        final_output=result.final_output,
+        evaluation=evaluation,
+        failure=failure,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ExperimentPlan:
     """Immutable, serializable specification for one comparison Experiment."""
@@ -45,6 +157,10 @@ class ExperimentPlan:
     trial_specs: Mapping[str, tuple[Trajectory, ...]]
     baseline: str | None
     provenance: Mapping[str, JsonValue | FrozenJsonValue] = field(default_factory=dict)
+    task_distribution: TaskDistributionManifest | None = field(
+        default=None,
+        kw_only=True,
+    )
     plan_hash: str = field(init=False)
     _payload: Mapping[str, FrozenJsonValue] = field(
         init=False,
@@ -113,21 +229,70 @@ class ExperimentPlan:
 
         if self.baseline is not None and self.baseline not in frozen_variants:
             raise ValueError("ExperimentPlan baseline must name a planned variant")
+        task_distribution = self.task_distribution
+        if task_distribution is not None:
+            if not isinstance(task_distribution, TaskDistributionManifest):
+                raise TypeError(
+                    "ExperimentPlan task_distribution must be a "
+                    "TaskDistributionManifest or None"
+                )
+            if self.baseline is None:
+                raise ValueError(
+                    "ExperimentPlan with a Task distribution must declare a baseline"
+                )
+            if len(frozen_variants) != 2:
+                raise ValueError(
+                    "ExperimentPlan with a Task distribution must contain exactly "
+                    "one baseline and one candidate"
+                )
+            baseline_specs = frozen_variants[self.baseline]
+            if len(baseline_specs) != len(task_distribution.case_ids):
+                raise ValueError(
+                    "TaskDistributionManifest case_ids must match every variant slot"
+                )
+            for variant, specs in frozen_variants.items():
+                if len(specs) != len(task_distribution.case_ids):
+                    raise ValueError(
+                        "TaskDistributionManifest case_ids must match every variant slot"
+                    )
+                for position, (baseline_spec, candidate_spec) in enumerate(
+                    zip(baseline_specs, specs, strict=True)
+                ):
+                    case_id = task_distribution.case_ids[position]
+                    baseline_projection_hash = _configuration_hash(
+                        _comparison_projection(baseline_spec, case_id=case_id)
+                    )
+                    candidate_projection_hash = _configuration_hash(
+                        _comparison_projection(candidate_spec, case_id=case_id)
+                    )
+                    if baseline_projection_hash != candidate_projection_hash:
+                        raise ValueError(
+                            "ExperimentPlan Task distribution slots must differ only "
+                            f"by Agent declaration: {variant}[{position}]"
+                        )
         provenance = _freeze_json(
             self.provenance,
             path="$.experiment.provenance",
         )
         if not isinstance(provenance, Mapping):
             raise TypeError("ExperimentPlan provenance must be an object")
+        payload_values: dict[str, object] = {
+            "experiment_id": self.experiment_id,
+            "version": self.version,
+            "baseline": self.baseline,
+            "provenance": provenance,
+            "variants": variant_payloads,
+        }
+        if task_distribution is not None:
+            payload_values["task_distribution"] = _task_distribution_payload(
+                task_distribution
+            )
         payload = _frozen_object(
-            experiment_id=self.experiment_id,
-            version=self.version,
-            baseline=self.baseline,
-            provenance=provenance,
-            variants=variant_payloads,
+            **payload_values,
         )
         object.__setattr__(self, "trial_specs", MappingProxyType(frozen_variants))
         object.__setattr__(self, "provenance", provenance)
+        object.__setattr__(self, "task_distribution", task_distribution)
         object.__setattr__(self, "_payload", payload)
         object.__setattr__(self, "plan_hash", _configuration_hash(payload))
 
@@ -159,6 +324,11 @@ class ExperimentResult:
     plan: ExperimentPlan
     results: Mapping[str, tuple[TrialResult, ...]]
     started_trial_ids: Mapping[str, tuple[str, ...]]
+    _evidence_registration: object | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         if not isinstance(self.plan, ExperimentPlan):
@@ -195,7 +365,10 @@ class ExperimentResult:
                     raise ValueError(
                         "ExperimentResult Trial does not match its planned provenance"
                     )
-                if replay(result.trajectory) != result:
+                replayed = replay(result.trajectory)
+                if _configuration_hash(
+                    _trial_result_projection(replayed)
+                ) != _configuration_hash(_trial_result_projection(result)):
                     raise ValueError(
                         "ExperimentResult projection does not match its Trajectory"
                     )
@@ -226,6 +399,10 @@ class ExperimentResult:
         return self.plan.baseline
 
     @property
+    def task_distribution(self) -> TaskDistributionManifest | None:
+        return self.plan.task_distribution
+
+    @property
     def plan_hash(self) -> str:
         return self.plan.plan_hash
 
@@ -241,6 +418,34 @@ class ExperimentResult:
             for variant, trial_ids in self.planned_trial_ids.items()
         )
 
+    @property
+    def jsonl_verified(self) -> bool:
+        """Return whether the result came from the supported JSONL verification path."""
+        return self._evidence_registration is _JSONL_EVIDENCE_REGISTRATION
+
+
+def _registered_experiment_result(
+    *,
+    plan: ExperimentPlan,
+    results: Mapping[str, tuple[TrialResult, ...]],
+    started_trial_ids: Mapping[str, tuple[str, ...]],
+) -> ExperimentResult:
+    result = ExperimentResult(
+        plan=plan,
+        results=results,
+        started_trial_ids=started_trial_ids,
+    )
+    object.__setattr__(
+        result,
+        "_evidence_registration",
+        _JSONL_EVIDENCE_REGISTRATION,
+    )
+    return result
+
+
+def _is_registered_experiment_result(result: ExperimentResult) -> bool:
+    return result.jsonl_verified
+
 
 class Experiment:
     """Run and persist an explicit set of comparison Trial variants."""
@@ -252,6 +457,7 @@ class Experiment:
         version: str,
         trials: Mapping[str, Sequence[Trial]],
         baseline: str | None = None,
+        task_distribution: TaskDistributionManifest | None = None,
         provenance: Mapping[str, JsonValue] | None = None,
     ) -> None:
         if not isinstance(trials, Mapping) or not trials:
@@ -283,6 +489,7 @@ class Experiment:
             version=version,
             trial_specs=specs_by_variant,
             baseline=baseline,
+            task_distribution=task_distribution,
             provenance={} if provenance is None else provenance,
         )
 
@@ -301,6 +508,10 @@ class Experiment:
     @property
     def baseline(self) -> str | None:
         return self.plan.baseline
+
+    @property
+    def task_distribution(self) -> TaskDistributionManifest | None:
+        return self.plan.task_distribution
 
     @property
     def plan_hash(self) -> str:
@@ -329,7 +540,9 @@ class Experiment:
             evaluator=slot.trial.evaluator,
             max_actions=slot.trial.config.max_actions,
         )
-        if live_configuration != planned_spec.configuration:
+        if _configuration_hash(live_configuration) != _configuration_hash(
+            planned_spec.configuration
+        ):
             raise ValueError(
                 "planned Trial declarations drifted: "
                 f"{slot.trial.config.trial_id}"

--- a/python/iamai/harness/_jsonl.py
+++ b/python/iamai/harness/_jsonl.py
@@ -16,7 +16,9 @@ from typing import BinaryIO, Iterator, cast
 from ._experiment import (
     ExperimentPlan,
     ExperimentResult,
+    TaskDistributionManifest,
     _TrialSlot,
+    _registered_experiment_result,
     _trajectory_spec,
 )
 from ._model import (
@@ -26,7 +28,9 @@ from ._model import (
     TrajectoryRecord,
     TrialResult,
     _configuration_hash,
+    _freeze_json,
     _thaw_json,
+    _trajectory_hash,
 )
 from ._replay import replay
 
@@ -36,6 +40,37 @@ MAX_JSONL_RECORD_BYTES = 16 * 1024 * 1024
 _ACTIVE_WRITERS: set[Path] = set()
 _ACTIVE_READERS: dict[Path, int] = {}
 _ACTIVE_WRITERS_GUARD = threading.Lock()
+
+_ENTRY_CHAIN_FIELDS = {
+    "record_type",
+    "store_format_version",
+    "entry_sequence",
+    "previous_entry_digest",
+    "entry_digest",
+}
+_PLAN_ENTRY_FIELDS = _ENTRY_CHAIN_FIELDS | {"plan", "plan_hash"}
+_TRIAL_ENTRY_FIELDS = _ENTRY_CHAIN_FIELDS | {
+    "experiment_id",
+    "plan_hash",
+    "variant",
+    "position",
+    "trial_id",
+    "spec_hash",
+}
+_COMMITTED_ENTRY_FIELDS = _TRIAL_ENTRY_FIELDS | {
+    "trajectory",
+    "trajectory_digest",
+}
+_TRAJECTORY_FIELDS = {
+    "format_version",
+    "trial_id",
+    "task",
+    "seed",
+    "configuration",
+    "config_hash",
+    "records",
+}
+_TRAJECTORY_SPEC_FIELDS = _TRAJECTORY_FIELDS - {"records"}
 
 
 def _lock_stream(stream: BinaryIO) -> None:
@@ -218,6 +253,7 @@ def _validate_entry_chain(
             isinstance(entry_sequence, bool)
             or not isinstance(entry_sequence, int)
             or entry_sequence != expected_sequence
+            or "previous_entry_digest" not in entry
             or entry.get("previous_entry_digest") != previous_digest
             or not isinstance(entry_digest, str)
             or entry_digest != _digest(digest_payload)
@@ -256,15 +292,36 @@ def _object(value: object, *, field: str) -> Mapping[str, object]:
     return value
 
 
+def _require_exact_fields(
+    value: Mapping[str, object],
+    expected: set[str],
+    *,
+    field: str,
+) -> None:
+    if set(value) != expected:
+        raise ValueError(f"JSONL Store {field} fields are invalid")
+
+
 def _trajectory_from_payload(value: object) -> Trajectory:
     payload = _object(value, field="Trajectory")
+    _require_exact_fields(payload, _TRAJECTORY_FIELDS, field="Trajectory")
     task_payload = _object(payload.get("task"), field="Trajectory task")
+    _require_exact_fields(
+        task_payload,
+        {"id", "input"},
+        field="Trajectory task",
+    )
     records_payload = payload.get("records")
     if not isinstance(records_payload, list):
         raise ValueError("JSONL Trajectory records must be an array")
     records: list[TrajectoryRecord] = []
     for raw_record in records_payload:
         record = _object(raw_record, field="Trajectory record")
+        _require_exact_fields(
+            record,
+            {"sequence", "kind", "payload"},
+            field="Trajectory record",
+        )
         records.append(
             TrajectoryRecord(
                 sequence=record.get("sequence"),  # type: ignore[arg-type]
@@ -544,7 +601,7 @@ class JsonlTrajectoryStore:
                 "trial_id": trajectory.trial_id,
                 "spec_hash": spec_hash,
                 "trajectory": trajectory_payload,
-                "trajectory_digest": _digest(trajectory_payload),
+                "trajectory_digest": _trajectory_hash(trajectory),
             }
         )
 
@@ -615,12 +672,41 @@ class JsonlTrajectoryStore:
         manifest = entries[0]
         if manifest.get("record_type") != "experiment.plan":
             raise ValueError("JSONL Store must start with an Experiment plan")
+        _require_exact_fields(
+            manifest,
+            _PLAN_ENTRY_FIELDS,
+            field="Experiment plan entry",
+        )
         if manifest.get("store_format_version") != EXPERIMENT_STORE_FORMAT_VERSION:
             raise ValueError("unsupported JSONL Store format version")
         plan_payload = _object(manifest.get("plan"), field="Experiment plan")
         stored_plan_hash = manifest.get("plan_hash")
         if not isinstance(stored_plan_hash, str):
             raise ValueError("JSONL Store Experiment plan hash is invalid")
+        frozen_plan_payload = _freeze_json(
+            plan_payload,
+            path="$.experiment.plan",
+        )
+        if not isinstance(frozen_plan_payload, Mapping):
+            raise AssertionError("Experiment plan did not freeze as an object")
+        if _configuration_hash(frozen_plan_payload) != stored_plan_hash:
+            raise ValueError(
+                "JSONL Store Experiment plan payload hash does not match"
+            )
+        expected_plan_fields = {
+            "experiment_id",
+            "version",
+            "baseline",
+            "provenance",
+            "variants",
+        }
+        if "task_distribution" in plan_payload:
+            expected_plan_fields.add("task_distribution")
+        _require_exact_fields(
+            plan_payload,
+            expected_plan_fields,
+            field="Experiment plan",
+        )
         experiment_id = plan_payload.get("experiment_id")
         version = plan_payload.get("version")
         baseline = plan_payload.get("baseline")
@@ -635,10 +721,58 @@ class JsonlTrajectoryStore:
         if not isinstance(variants_payload, list) or not variants_payload:
             raise ValueError("JSONL Store Experiment variants are invalid")
 
+        task_distribution: TaskDistributionManifest | None = None
+        if "task_distribution" in plan_payload:
+            distribution_payload = _object(
+                plan_payload.get("task_distribution"),
+                field="Experiment Task distribution",
+            )
+            expected_distribution_fields = {
+                "manifest_format_version",
+                "suite_id",
+                "version",
+                "split",
+                "case_ids",
+                "sampling_rule",
+                "manifest_hash",
+            }
+            if set(distribution_payload) != expected_distribution_fields:
+                raise ValueError(
+                    "JSONL Store Experiment Task distribution fields are invalid"
+                )
+            case_ids = distribution_payload.get("case_ids")
+            if not isinstance(case_ids, list):
+                raise ValueError(
+                    "JSONL Store Experiment Task distribution case_ids are invalid"
+                )
+            task_distribution = TaskDistributionManifest(
+                suite_id=distribution_payload.get("suite_id"),  # type: ignore[arg-type]
+                version=distribution_payload.get("version"),  # type: ignore[arg-type]
+                split=distribution_payload.get("split"),  # type: ignore[arg-type]
+                case_ids=tuple(case_ids),
+                sampling_rule=distribution_payload.get(  # type: ignore[arg-type]
+                    "sampling_rule"
+                ),
+            )
+            if (
+                distribution_payload.get("manifest_format_version")
+                != task_distribution._payload.get("manifest_format_version")
+                or distribution_payload.get("manifest_hash")
+                != task_distribution.manifest_hash
+            ):
+                raise ValueError(
+                    "JSONL Store Experiment Task distribution hash is invalid"
+                )
+
         trial_specs: dict[str, tuple[Trajectory, ...]] = {}
         slots: dict[tuple[str, int], tuple[str, str]] = {}
         for raw_variant in variants_payload:
             variant_payload = _object(raw_variant, field="Experiment variant")
+            _require_exact_fields(
+                variant_payload,
+                {"name", "trials"},
+                field="Experiment variant",
+            )
             variant = variant_payload.get("name")
             raw_trials = variant_payload.get("trials")
             if not isinstance(variant, str) or not isinstance(raw_trials, list):
@@ -648,8 +782,18 @@ class JsonlTrajectoryStore:
             specs: list[Trajectory] = []
             for raw_slot in raw_trials:
                 slot_payload = _object(raw_slot, field="Experiment Trial slot")
+                _require_exact_fields(
+                    slot_payload,
+                    {"position", "spec", "spec_hash"},
+                    field="Experiment Trial slot",
+                )
                 position = slot_payload.get("position")
                 spec = _object(slot_payload.get("spec"), field="Experiment Trial spec")
+                _require_exact_fields(
+                    spec,
+                    _TRAJECTORY_SPEC_FIELDS,
+                    field="Experiment Trial spec",
+                )
                 spec_hash = slot_payload.get("spec_hash")
                 trial_id = spec.get("trial_id")
                 if (
@@ -674,6 +818,7 @@ class JsonlTrajectoryStore:
             version=version,
             trial_specs=trial_specs,
             baseline=baseline,
+            task_distribution=task_distribution,
             provenance=cast(Mapping[str, FrozenJsonValue], provenance),
         )
         if plan.plan_hash != stored_plan_hash:
@@ -689,6 +834,15 @@ class JsonlTrajectoryStore:
             record_type = entry.get("record_type")
             if record_type not in {"trial.started", "trajectory.committed"}:
                 raise ValueError(f"invalid JSONL Store record type at {self.path}:{line_number}")
+            _require_exact_fields(
+                entry,
+                (
+                    _TRIAL_ENTRY_FIELDS
+                    if record_type == "trial.started"
+                    else _COMMITTED_ENTRY_FIELDS
+                ),
+                field=f"{record_type} entry",
+            )
             if entry.get("store_format_version") != EXPERIMENT_STORE_FORMAT_VERSION:
                 raise ValueError("unsupported JSONL Store format version")
             if (
@@ -723,13 +877,17 @@ class JsonlTrajectoryStore:
             if entry.get("trajectory_digest") != _digest(trajectory_payload):
                 raise ValueError("JSONL Store Trajectory digest does not match")
             trajectory = _trajectory_from_payload(trajectory_payload)
+            if entry.get("trajectory_digest") != _trajectory_hash(trajectory):
+                raise ValueError(
+                    "JSONL Store Trajectory canonical digest does not match"
+                )
             if _configuration_hash(_trajectory_spec(trajectory)) != declared_slot[1]:
                 raise ValueError("JSONL Store Trajectory provenance does not match its plan")
             result = replay(trajectory)
             committed_trial_ids.add(trial_id)
             collected[variant].append((position, result))
 
-        return ExperimentResult(
+        return _registered_experiment_result(
             plan=plan,
             results={
                 variant: tuple(

--- a/python/iamai/harness/_model.py
+++ b/python/iamai/harness/_model.py
@@ -408,3 +408,23 @@ def _evaluation_payload(evaluation: Evaluation) -> Mapping[str, FrozenJsonValue]
         evaluator=evaluation.evaluator,
         evaluator_version=evaluation.evaluator_version,
     )
+
+
+def _trajectory_hash(trajectory: Trajectory) -> str:
+    payload = _frozen_object(
+        format_version=trajectory.format_version,
+        trial_id=trajectory.trial_id,
+        task={"id": trajectory.task.id, "input": trajectory.task.input},
+        seed=trajectory.seed,
+        configuration=trajectory.configuration,
+        config_hash=trajectory.config_hash,
+        records=[
+            {
+                "sequence": record.sequence,
+                "kind": record.kind,
+                "payload": record.payload,
+            }
+            for record in trajectory.records
+        ],
+    )
+    return _configuration_hash(payload)

--- a/python/iamai/harness/_replay.py
+++ b/python/iamai/harness/_replay.py
@@ -76,7 +76,7 @@ def _require_exact_fields(
     field_name: str,
 ) -> None:
     if set(declaration) != expected:
-        raise _causal_error(f"controlled {field_name} fields are invalid")
+        raise _causal_error(f"{field_name} fields are invalid")
 
 
 def _non_negative_record_int(value: FrozenJsonValue, *, field_name: str) -> int:
@@ -465,6 +465,17 @@ def _validate_configuration(
     trajectory: Trajectory,
 ) -> Mapping[str, FrozenJsonValue]:
     configuration = trajectory.configuration
+    _require_exact_fields(
+        configuration,
+        {
+            "harness_configuration_version",
+            "agent",
+            "environment",
+            "evaluator",
+            "max_actions",
+        },
+        field_name="configuration",
+    )
     if (
         configuration.get("harness_configuration_version")
         != HARNESS_CONFIGURATION_VERSION
@@ -475,6 +486,11 @@ def _validate_configuration(
         declared = configuration.get(role)
         if not isinstance(declared, Mapping):
             raise ValueError(f"Trajectory configuration is missing declared {role}")
+        _require_exact_fields(
+            declared,
+            {"name", "version", "config"},
+            field_name=f"{role} declaration",
+        )
         name = declared.get("name")
         version = declared.get("version")
         component_config = declared.get("config")
@@ -751,17 +767,39 @@ def _validate_causal_order(
         raise _causal_error(
             f"{status.value} must place {marker_kind} immediately before termination"
         )
+    marker_fields = {
+        TrialStatus.COMPLETED: {
+            "passed",
+            "score",
+            "evaluator",
+            "evaluator_version",
+        },
+        TrialStatus.BUDGET_EXHAUSTED: {
+            "passed",
+            "score",
+            "evaluator",
+            "evaluator_version",
+        },
+        TrialStatus.FAILED: {"phase", "code", "exception_type", "message"},
+        TrialStatus.CANCELLED: {"phase", "operation"},
+    }[status]
+    _require_exact_fields(
+        marker.payload,
+        marker_fields,
+        field_name=f"{marker_kind} payload",
+    )
     body = middle[:-1]
 
     reset_seen = bool(body and body[0].kind == "environment.reset")
     if reset_seen and "observation" not in body[0].payload:
         raise _causal_error("Environment reset observation is missing")
-    if reset_seen and controlled:
+    if reset_seen:
         _require_exact_fields(
             body[0].payload,
             {"observation"},
             field_name="reset evidence",
         )
+    if reset_seen and controlled:
         reset_hash = _configuration_hash(
             _frozen_object(value=body[0].payload.get("observation"))
         )
@@ -787,6 +825,11 @@ def _validate_causal_order(
         if record.kind == "agent.action":
             if not reset_seen or pending_action or terminated or budget_exhausted:
                 raise _causal_error("Agent Action is outside an active Environment state")
+            _require_exact_fields(
+                record.payload,
+                {"name", "payload", "is_final"},
+                field_name="Agent Action payload",
+            )
             name = record.payload.get("name")
             is_final = record.payload.get("is_final")
             if (
@@ -998,17 +1041,17 @@ def _validate_causal_order(
         if record.kind == "environment.transition":
             if not pending_action or terminated or budget_exhausted:
                 raise _causal_error("Environment Transition has no pending Agent Action")
+            _require_exact_fields(
+                record.payload,
+                {"observation", "terminated", "output"},
+                field_name="Environment Transition",
+            )
             transition_terminated = record.payload.get("terminated")
             if not isinstance(transition_terminated, bool):
                 raise _causal_error("Environment Transition termination flag is invalid")
             if "observation" not in record.payload or "output" not in record.payload:
                 raise _causal_error("Environment Transition payload is incomplete")
             if controlled:
-                _require_exact_fields(
-                    record.payload,
-                    {"observation", "terminated", "output"},
-                    field_name="Environment Transition",
-                )
                 if pending_action_final:
                     if pending_tool_outcome is not None or not transition_terminated:
                         raise _causal_error(
@@ -1261,6 +1304,11 @@ def replay(trajectory: Trajectory) -> TrialResult:
         raise ValueError("Trajectory record sequence must be contiguous from zero")
     if trajectory.records[0].kind != "trial.started":
         raise ValueError("Trajectory must start with trial.started")
+    _require_exact_fields(
+        trajectory.records[0].payload,
+        set(),
+        field_name="Trial start payload",
+    )
     terminal_records = [
         record for record in trajectory.records if record.kind == "trial.terminated"
     ]
@@ -1274,6 +1322,17 @@ def replay(trajectory: Trajectory) -> TrialResult:
         status = TrialStatus(status_value)
     except ValueError as exc:
         raise ValueError(f"unsupported terminal Trial status: {status_value}") from exc
+    terminal_fields = {
+        TrialStatus.COMPLETED: {"status"},
+        TrialStatus.BUDGET_EXHAUSTED: {"status"},
+        TrialStatus.FAILED: {"status", "phase"},
+        TrialStatus.CANCELLED: {"status", "phase", "operation"},
+    }[status]
+    _require_exact_fields(
+        terminal_records[0].payload,
+        terminal_fields,
+        field_name="Trial termination payload",
+    )
     final_output = _validate_causal_order(trajectory, status)
 
     evaluation_records = [

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -351,6 +351,45 @@ def test_controlled_execution_docs_define_scope_and_non_guarantees() -> None:
     assert "不提供 OS、进程或网络沙箱" in readme_zh
 
 
+def test_paired_experiment_evidence_docs_define_scope_and_non_guarantees() -> None:
+    content = _read("docs/guides/research-harness.rst")
+    roadmap = _read("docs/guides/roadmap.rst")
+    api_index = _read("docs/api/index.rst")
+    context = _read("CONTEXT.md")
+    adr = _read("docs/adr/0003-paired-experiment-evidence-protocol.md")
+    readme = _read("README.md")
+    readme_zh = _read("README.zh.md")
+
+    public_names = (
+        "TaskDistributionManifest",
+        "TrialComparison",
+        "ExperimentComparison",
+        "compare_experiment",
+    )
+    for name in public_names:
+        assert name in content
+        assert name in api_index
+
+    assert "Paired Experiment Evidence Protocol" in content
+    assert "exactly one baseline and one candidate" in content
+    assert "JsonlTrajectoryStore-verified" in content
+    assert "jsonl_verified" in content
+    assert "固定分母" in content
+    assert "baseline_trajectory_hash" in content
+    assert "comparison_format_version" in content
+    assert "不是签名、可信时间戳或真实性证明" in content
+    assert "逐 Action 的 write-ahead log" in content
+    assert "配对实验评证协议\n   |implemented|" in roadmap
+    assert "Policy-backed Agent" in roadmap
+    assert "Task Distribution Manifest" in context
+    assert "Experiment Comparison" in context
+    assert adr.startswith("---\nstatus: accepted\n---")
+    assert "descriptive evidence" in adr
+    assert "does not establish statistical significance" in adr
+    assert "paired experiment evidence" in readme
+    assert "配对实验评证" in readme_zh
+
+
 def test_community_page_contains_blog_and_store_sections() -> None:
     content = _read("docs/community/index.rst")
 

--- a/tests/test_experiment_comparison.py
+++ b/tests/test_experiment_comparison.py
@@ -1,0 +1,920 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from iamai.harness import (
+    Action,
+    ExactEvaluator,
+    Experiment,
+    ExperimentComparison,
+    ExperimentPlan,
+    ExperimentResult,
+    JsonlTrajectoryStore,
+    LookupEnvironment,
+    ScriptedAgent,
+    Task,
+    TaskDistributionManifest,
+    Trial,
+    TrialComparison,
+    TrialConfig,
+    TrialStatus,
+    compare_experiment,
+)
+
+
+def _capital_trial(*, trial_id: str, answer: str) -> Trial:
+    return Trial(
+        task=Task(
+            id="capital-of-france",
+            input={"question": "What is the capital of France?"},
+        ),
+        agent=ScriptedAgent(
+            [Action.finish(answer)],
+            name=f"{trial_id}-agent",
+            version="1",
+        ),
+        environment=LookupEnvironment(
+            {},
+            name="country-capitals",
+            version="1",
+        ),
+        evaluator=ExactEvaluator("Paris", version="1"),
+        config=TrialConfig(trial_id=trial_id, seed=7, max_actions=1),
+    )
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _rewrite_jsonl_chain(path, entries: list[dict[str, object]]) -> None:
+    previous_digest: str | None = None
+    encoded_entries: list[str] = []
+    for sequence, entry in enumerate(entries):
+        entry["entry_sequence"] = sequence
+        entry["previous_entry_digest"] = previous_digest
+        entry.pop("entry_digest", None)
+        entry["entry_digest"] = _digest(entry)
+        previous_digest = entry["entry_digest"]  # type: ignore[assignment]
+        encoded_entries.append(
+            json.dumps(
+                entry,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+    path.write_text("\n".join(encoded_entries) + "\n", encoding="utf-8")
+
+
+def test_compare_persisted_experiment_reports_paired_baseline_evidence(tmp_path) -> None:
+    async def scenario() -> None:
+        distribution = TaskDistributionManifest(
+            suite_id="capital-suite",
+            version="1",
+            split="test",
+            case_ids=("capital-of-france/seed-7",),
+            sampling_rule="ordered-full-set-v1",
+        )
+        path = tmp_path / "capital-evidence.jsonl"
+        result = await Experiment(
+            experiment_id="capital-evidence",
+            version="1",
+            baseline="baseline",
+            task_distribution=distribution,
+            trials={
+                "baseline": (_capital_trial(trial_id="baseline-capital", answer="Lyon"),),
+                "candidate": (_capital_trial(trial_id="candidate-capital", answer="Paris"),),
+            },
+        ).run(JsonlTrajectoryStore(path))
+        loaded = JsonlTrajectoryStore(path).load()
+
+        assert loaded is not None
+        assert result.jsonl_verified
+        assert loaded.jsonl_verified
+        comparison = compare_experiment(loaded, candidate="candidate")
+
+        assert comparison == compare_experiment(result, candidate="candidate")
+        assert result.task_distribution == distribution
+        assert loaded.task_distribution == distribution
+        assert comparison.experiment_id == "capital-evidence"
+        assert comparison.plan_hash == result.plan_hash
+        assert comparison.task_distribution == distribution
+        assert comparison.baseline == "baseline"
+        assert comparison.candidate == "candidate"
+        assert comparison.total_pairs == 1
+        assert comparison.baseline_pass_rate == 0.0
+        assert comparison.candidate_pass_rate == 1.0
+        assert comparison.pass_rate_delta == 1.0
+        assert comparison.paired_score_count == 1
+        assert comparison.mean_score_delta == 1.0
+        assert comparison.trials[0].task_id == "capital-of-france"
+        assert comparison.trials[0].score_delta == 1.0
+        assert comparison.comparison_format_version == "1"
+        assert comparison.comparison_hash.startswith("sha256:")
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+        candidate_commit = next(
+            entry
+            for entry in entries
+            if entry["record_type"] == "trajectory.committed" and entry["variant"] == "candidate"
+        )
+        assert (
+            comparison.trials[0].candidate_trajectory_hash == candidate_commit["trajectory_digest"]
+        )
+        with pytest.raises(TypeError, match="no public constructor"):
+            ExperimentComparison(
+                experiment_id=comparison.experiment_id,
+                plan_hash=comparison.plan_hash,
+                task_distribution=comparison.task_distribution,
+                baseline=comparison.baseline,
+                candidate=comparison.candidate,
+                trials=comparison.trials,
+            )
+
+    asyncio.run(scenario())
+
+
+def test_comparison_keeps_failed_and_budget_exhausted_pairs_in_the_denominator(
+    tmp_path,
+) -> None:
+    class FailingAgent:
+        name = "failing-agent"
+        version = "1"
+        configuration = {"failure": "fixture"}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise RuntimeError("fixture failure")
+
+    def trial(*, trial_id: str, agent: object) -> Trial:
+        return Trial(
+            task=Task(id="paired-case", input={"question": "answer"}),
+            agent=agent,  # type: ignore[arg-type]
+            environment=LookupEnvironment(
+                {"answer": "Paris"},
+                name="paired-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id=trial_id, seed=11, max_actions=1),
+        )
+
+    def scripted(trial_id: str, action: Action) -> Trial:
+        return trial(
+            trial_id=trial_id,
+            agent=ScriptedAgent((action,), name=f"{trial_id}-agent", version="1"),
+        )
+
+    async def scenario() -> None:
+        result = await Experiment(
+            experiment_id="status-evidence",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="status-suite",
+                version="1",
+                split="test",
+                case_ids=("failed-candidate", "budget-candidate"),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (
+                    scripted("baseline-failed-pair", Action.finish("Paris")),
+                    scripted("baseline-budget-pair", Action.finish("Paris")),
+                ),
+                "candidate": (
+                    trial(trial_id="candidate-failed", agent=FailingAgent()),
+                    scripted(
+                        "candidate-budget",
+                        Action.invoke("lookup", {"key": "answer"}),
+                    ),
+                ),
+            },
+        ).run(JsonlTrajectoryStore(tmp_path / "status-evidence.jsonl"))
+
+        comparison = compare_experiment(result, candidate="candidate")
+
+        assert comparison.total_pairs == 2
+        assert comparison.candidate_pass_rate == 0.0
+        assert comparison.candidate_status_counts == {
+            TrialStatus.COMPLETED: 0,
+            TrialStatus.BUDGET_EXHAUSTED: 1,
+            TrialStatus.FAILED: 1,
+            TrialStatus.CANCELLED: 0,
+        }
+        assert comparison.candidate_status_rates[TrialStatus.FAILED] == 0.5
+        assert comparison.candidate_status_rates[TrialStatus.BUDGET_EXHAUSTED] == 0.5
+        assert comparison.paired_score_count == 1
+        assert comparison.mean_score_delta == -1.0
+
+    asyncio.run(scenario())
+
+
+def test_comparison_hash_binds_the_exact_persisted_trajectories(tmp_path) -> None:
+    class MessageFailingAgent:
+        name = "message-failing-agent"
+        version = "1"
+        configuration = {"fixture": "same-declaration"}
+
+        def __init__(self, message: str) -> None:
+            self.message = message
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise RuntimeError(self.message)
+
+    def failing_candidate(message: str) -> Trial:
+        return Trial(
+            task=Task(
+                id="capital-of-france",
+                input={"question": "What is the capital of France?"},
+            ),
+            agent=MessageFailingAgent(message),
+            environment=LookupEnvironment(
+                {},
+                name="country-capitals",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(
+                trial_id="trajectory-hash-candidate",
+                seed=7,
+                max_actions=1,
+            ),
+        )
+
+    async def run(path, failure_message: str):
+        result = await Experiment(
+            experiment_id="trajectory-hash-evidence",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="trajectory-hash-suite",
+                version="1",
+                split="test",
+                case_ids=("capital/seed-7",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (
+                    _capital_trial(
+                        trial_id="trajectory-hash-baseline",
+                        answer="Paris",
+                    ),
+                ),
+                "candidate": (failing_candidate(failure_message),),
+            },
+        ).run(JsonlTrajectoryStore(path))
+        return compare_experiment(result, candidate="candidate")
+
+    async def scenario() -> None:
+        first = await run(tmp_path / "trajectory-first.jsonl", "first failure")
+        second = await run(tmp_path / "trajectory-second.jsonl", "second failure")
+
+        assert first.plan_hash == second.plan_hash
+        assert first.candidate_status_counts == second.candidate_status_counts
+        assert (
+            first.trials[0].candidate_trajectory_hash != second.trials[0].candidate_trajectory_hash
+        )
+        assert first.comparison_hash != second.comparison_hash
+
+    asyncio.run(scenario())
+
+
+def test_task_distribution_rejects_a_string_as_case_sequence() -> None:
+    with pytest.raises(TypeError, match="case_ids must be a sequence"):
+        TaskDistributionManifest(
+            suite_id="invalid-suite",
+            version="1",
+            split="test",
+            case_ids="not-a-case-sequence",  # type: ignore[arg-type]
+            sampling_rule="ordered-full-set-v1",
+        )
+
+
+def test_experiment_plan_preserves_positional_provenance_compatibility() -> None:
+    baseline = _capital_trial(trial_id="positional-baseline", answer="Lyon")
+    candidate = _capital_trial(trial_id="positional-candidate", answer="Paris")
+
+    plan = ExperimentPlan(
+        "positional-provenance",
+        "1",
+        {
+            "baseline": (baseline.trajectory,),
+            "candidate": (candidate.trajectory,),
+        },
+        "baseline",
+        {"source_revision": "legacy-positional-call"},
+    )
+
+    assert plan.provenance == {"source_revision": "legacy-positional-call"}
+    assert plan.task_distribution is None
+
+
+def test_trial_comparison_cannot_be_publicly_constructed() -> None:
+    with pytest.raises(TypeError, match="no public constructor"):
+        TrialComparison(
+            position=0,
+            case_id="public-forgery",
+            case_hash=f"sha256:{'0' * 64}",
+            task_id="public-forgery-task",
+            seed=0,
+            baseline_trial_id="public-baseline",
+            candidate_trial_id="public-candidate",
+            baseline_status=TrialStatus.COMPLETED,
+            candidate_status=TrialStatus.COMPLETED,
+            baseline_passed=True,
+            candidate_passed=True,
+            baseline_score=1.0,
+            candidate_score=1.0,
+        )
+    with pytest.raises(TypeError, match="no public constructor"):
+        TrialComparison()
+    with pytest.raises(TypeError, match="no public constructor"):
+        ExperimentComparison()
+
+
+def test_distribution_rejects_unpaired_task_input_before_trials_start() -> None:
+    baseline = _capital_trial(trial_id="baseline-preflight", answer="Paris")
+    candidate = Trial(
+        task=Task(
+            id="capital-of-france",
+            input={"question": "What is the capital of Italy?"},
+        ),
+        agent=ScriptedAgent(
+            (Action.finish("Rome"),),
+            name="candidate-preflight-agent",
+            version="1",
+        ),
+        environment=LookupEnvironment(
+            {},
+            name="country-capitals",
+            version="1",
+        ),
+        evaluator=ExactEvaluator("Paris", version="1"),
+        config=TrialConfig(
+            trial_id="candidate-preflight",
+            seed=7,
+            max_actions=1,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="differ only by Agent declaration"):
+        Experiment(
+            experiment_id="preflight-evidence",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="preflight-suite",
+                version="1",
+                split="test",
+                case_ids=("capital/seed-7",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={"baseline": (baseline,), "candidate": (candidate,)},
+        )
+
+    assert baseline.trajectory.records == ()
+    assert candidate.trajectory.records == ()
+
+
+def test_distribution_uses_json_type_identity_for_pairing() -> None:
+    def trial(*, trial_id: str, task_value: object) -> Trial:
+        return Trial(
+            task=Task(id="json-type-case", input={"value": task_value}),
+            agent=ScriptedAgent(
+                (Action.finish("done"),),
+                name=f"{trial_id}-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="json-type-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id=trial_id, seed=0, max_actions=1),
+        )
+
+    baseline = trial(trial_id="json-bool", task_value=True)
+    candidate = trial(trial_id="json-int", task_value=1)
+
+    with pytest.raises(ValueError, match="differ only by Agent declaration"):
+        Experiment(
+            experiment_id="json-type-evidence",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="json-type-suite",
+                version="1",
+                split="test",
+                case_ids=("json-type/seed-0",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={"baseline": (baseline,), "candidate": (candidate,)},
+        )
+
+
+def test_result_projection_uses_json_type_identity(tmp_path) -> None:
+    async def scenario() -> None:
+        trial = Trial(
+            task=Task(id="json-result-type", input=None),
+            agent=ScriptedAgent(
+                (Action.finish(True),),
+                name="json-result-agent",
+                version="1",
+            ),
+            environment=LookupEnvironment(
+                {},
+                name="json-result-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator(True, version="1"),
+            config=TrialConfig(trial_id="json-result", seed=0, max_actions=1),
+        )
+        result = await Experiment(
+            experiment_id="json-result-projection",
+            version="1",
+            trials={"only": (trial,)},
+        ).run(JsonlTrajectoryStore(tmp_path / "json-result-projection.jsonl"))
+        forged = replace(result.results["only"][0], final_output=1)
+
+        with pytest.raises(ValueError, match="does not match its Trajectory"):
+            ExperimentResult(
+                plan=result.plan,
+                results={"only": (forged,)},
+                started_trial_ids={"only": ()},
+            )
+
+    asyncio.run(scenario())
+
+
+def test_live_declaration_drift_uses_json_type_identity(tmp_path) -> None:
+    class MutableAgent:
+        name = "mutable-agent"
+        version = "1"
+
+        def __init__(self) -> None:
+            self.configuration = {"mode": True}
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("done")
+
+    async def scenario() -> None:
+        agent = MutableAgent()
+        experiment = Experiment(
+            experiment_id="json-live-declaration",
+            version="1",
+            trials={
+                "only": (
+                    Trial(
+                        task=Task(id="json-live-declaration", input=None),
+                        agent=agent,
+                        environment=LookupEnvironment(
+                            {},
+                            name="json-live-environment",
+                            version="1",
+                        ),
+                        evaluator=ExactEvaluator("done", version="1"),
+                        config=TrialConfig(
+                            trial_id="json-live-trial",
+                            seed=0,
+                            max_actions=1,
+                        ),
+                    ),
+                )
+            },
+        )
+        agent.configuration["mode"] = 1
+
+        with pytest.raises(ValueError, match="declarations drifted"):
+            await experiment.run(JsonlTrajectoryStore(tmp_path / "json-live-declaration.jsonl"))
+
+        assert agent.calls == 0
+
+    asyncio.run(scenario())
+
+
+def test_distribution_preregisters_exactly_one_candidate() -> None:
+    with pytest.raises(ValueError, match="exactly one baseline and one candidate"):
+        Experiment(
+            experiment_id="candidate-selection",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="candidate-selection-suite",
+                version="1",
+                split="test",
+                case_ids=("capital/seed-7",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (_capital_trial(trial_id="selection-baseline", answer="Lyon"),),
+                "candidate-a": (_capital_trial(trial_id="selection-a", answer="Paris"),),
+                "candidate-b": (_capital_trial(trial_id="selection-b", answer="Paris"),),
+            },
+        )
+
+
+def test_comparison_rejects_a_legacy_plan_without_preregistered_distribution(
+    tmp_path,
+) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "legacy-comparison.jsonl"
+        result = await Experiment(
+            experiment_id="legacy-comparison",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="legacy-baseline", answer="Lyon"),),
+                "candidate": (_capital_trial(trial_id="legacy-candidate", answer="Paris"),),
+            },
+        ).run(JsonlTrajectoryStore(path))
+
+        manifest = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        assert "task_distribution" not in manifest["plan"]
+
+        with pytest.raises(ValueError, match="did not pre-register"):
+            compare_experiment(result, candidate="candidate")
+
+    asyncio.run(scenario())
+
+
+def test_comparison_rejects_an_incomplete_candidate_without_changing_denominator(
+    tmp_path,
+) -> None:
+    class InterruptedHarness(BaseException):
+        pass
+
+    class InterruptingAgent:
+        name = "interrupting-agent"
+        version = "1"
+        configuration = {"fixture": "interrupt-after-start"}
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            raise InterruptedHarness
+
+    async def scenario() -> None:
+        path = tmp_path / "incomplete-comparison.jsonl"
+        candidate = Trial(
+            task=Task(
+                id="capital-of-france",
+                input={"question": "What is the capital of France?"},
+            ),
+            agent=InterruptingAgent(),
+            environment=LookupEnvironment(
+                {},
+                name="country-capitals",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(
+                trial_id="incomplete-candidate",
+                seed=7,
+                max_actions=1,
+            ),
+        )
+        experiment = Experiment(
+            experiment_id="incomplete-comparison",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="incomplete-suite",
+                version="1",
+                split="test",
+                case_ids=("capital/seed-7",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (_capital_trial(trial_id="incomplete-baseline", answer="Lyon"),),
+                "candidate": (candidate,),
+            },
+        )
+        store = JsonlTrajectoryStore(path)
+
+        with pytest.raises(InterruptedHarness):
+            await experiment.run(store)
+        incomplete = store.load()
+
+        assert incomplete is not None
+        assert incomplete.results["baseline"]
+        assert incomplete.results["candidate"] == ()
+        assert incomplete.started_trial_ids["candidate"] == ("incomplete-candidate",)
+        with pytest.raises(ValueError, match="requires complete"):
+            compare_experiment(incomplete, candidate="candidate")
+
+    asyncio.run(scenario())
+
+
+def test_comparison_rejects_a_publicly_reconstructed_post_hoc_subset(tmp_path) -> None:
+    async def scenario() -> None:
+        original = await Experiment(
+            experiment_id="post-hoc-subset",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="post-hoc-suite",
+                version="1",
+                split="test",
+                case_ids=("no-change", "successful-only"),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (
+                    _capital_trial(trial_id="subset-baseline-0", answer="Lyon"),
+                    _capital_trial(trial_id="subset-baseline-1", answer="Lyon"),
+                ),
+                "candidate": (
+                    _capital_trial(trial_id="subset-candidate-0", answer="Lyon"),
+                    _capital_trial(trial_id="subset-candidate-1", answer="Paris"),
+                ),
+            },
+        ).run(JsonlTrajectoryStore(tmp_path / "post-hoc-subset.jsonl"))
+        subset_plan = ExperimentPlan(
+            experiment_id="post-hoc-subset-forged",
+            version="1",
+            trial_specs={
+                "baseline": (original.plan.trial_specs["baseline"][1],),
+                "candidate": (original.plan.trial_specs["candidate"][1],),
+            },
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="post-hoc-suite",
+                version="1",
+                split="test",
+                case_ids=("successful-only",),
+                sampling_rule="post-hoc-subset",
+            ),
+        )
+        reconstructed = ExperimentResult(
+            plan=subset_plan,
+            results={
+                "baseline": (original.results["baseline"][1],),
+                "candidate": (original.results["candidate"][1],),
+            },
+            started_trial_ids={"baseline": (), "candidate": ()},
+        )
+        clone = replace(original)
+
+        assert not reconstructed.jsonl_verified
+        assert not clone.jsonl_verified
+        assert clone != original
+        with pytest.raises(ValueError, match="verified by JsonlTrajectoryStore"):
+            compare_experiment(reconstructed, candidate="candidate")
+        with pytest.raises(ValueError, match="verified by JsonlTrajectoryStore"):
+            compare_experiment(clone, candidate="candidate")
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_distribution_drift_before_replacement_trials_run(
+    tmp_path,
+) -> None:
+    class CountingAgent:
+        name = "counting-agent"
+        version = "1"
+        configuration = {"answer": "Paris"}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            self.calls += 1
+            return Action.finish("Paris")
+
+    def trial(*, trial_id: str, agent: CountingAgent) -> Trial:
+        return Trial(
+            task=Task(id="distribution-drift", input=None),
+            agent=agent,
+            environment=LookupEnvironment(
+                {},
+                name="distribution-drift-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig(trial_id=trial_id, seed=3, max_actions=1),
+        )
+
+    def manifest(split: str) -> TaskDistributionManifest:
+        return TaskDistributionManifest(
+            suite_id="distribution-drift-suite",
+            version="1",
+            split=split,
+            case_ids=("distribution-drift/seed-3",),
+            sampling_rule="ordered-full-set-v1",
+        )
+
+    async def scenario() -> None:
+        path = tmp_path / "distribution-drift.jsonl"
+        await Experiment(
+            experiment_id="distribution-drift",
+            version="1",
+            baseline="baseline",
+            task_distribution=manifest("dev"),
+            trials={
+                "baseline": (trial(trial_id="drift-baseline", agent=CountingAgent()),),
+                "candidate": (trial(trial_id="drift-candidate", agent=CountingAgent()),),
+            },
+        ).run(JsonlTrajectoryStore(path))
+
+        replacement_baseline = CountingAgent()
+        replacement_candidate = CountingAgent()
+        replacement_trials = {
+            "baseline": (trial(trial_id="drift-baseline", agent=replacement_baseline),),
+            "candidate": (trial(trial_id="drift-candidate", agent=replacement_candidate),),
+        }
+        changed = Experiment(
+            experiment_id="distribution-drift",
+            version="1",
+            baseline="baseline",
+            task_distribution=manifest("test"),
+            trials=replacement_trials,
+        )
+
+        with pytest.raises(ValueError, match="different Experiment plan"):
+            await changed.run(JsonlTrajectoryStore(path))
+
+        assert replacement_baseline.calls == 0
+        assert replacement_candidate.calls == 0
+        assert all(
+            planned_trial.trajectory.records == ()
+            for variant in replacement_trials.values()
+            for planned_trial in variant
+        )
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_a_tampered_task_distribution_manifest(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "tampered-distribution.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="tampered-distribution",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="tampered-suite",
+                version="1",
+                split="test",
+                case_ids=("capital/seed-7",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (_capital_trial(trial_id="tampered-baseline", answer="Lyon"),),
+                "candidate": (_capital_trial(trial_id="tampered-candidate", answer="Paris"),),
+            },
+        ).run(store)
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+        plan = entries[0]["plan"]
+        assert isinstance(plan, dict)
+        distribution = plan["task_distribution"]
+        assert isinstance(distribution, dict)
+        distribution["split"] = "dev"
+        entries[0]["plan_hash"] = _digest(plan)
+        _rewrite_jsonl_chain(path, entries)
+
+        with pytest.raises(ValueError, match="Task distribution hash is invalid"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_store_rejects_unhashed_post_hoc_plan_claims(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "post-hoc-plan-claim.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="post-hoc-plan-claim",
+            version="1",
+            baseline="baseline",
+            trials={
+                "baseline": (_capital_trial(trial_id="post-hoc-baseline", answer="Lyon"),),
+                "candidate": (_capital_trial(trial_id="post-hoc-candidate", answer="Paris"),),
+            },
+        ).run(store)
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+        plan = entries[0]["plan"]
+        assert isinstance(plan, dict)
+        plan["post_hoc_claim"] = {"split": "test"}
+        _rewrite_jsonl_chain(path, entries)
+
+        with pytest.raises(ValueError, match="plan payload hash does not match"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "location",
+    ("entry", "trajectory", "task", "record", "record_payload"),
+)
+def test_store_rejects_unknown_evidence_fields_with_recomputed_digests(
+    tmp_path,
+    location: str,
+) -> None:
+    async def scenario() -> None:
+        path = tmp_path / f"unknown-{location}.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id=f"unknown-{location}",
+            version="1",
+            trials={
+                "only": (
+                    _capital_trial(
+                        trial_id=f"unknown-{location}-trial",
+                        answer="Paris",
+                    ),
+                )
+            },
+        ).run(store)
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+        committed = entries[-1]
+        trajectory = committed["trajectory"]
+        assert isinstance(trajectory, dict)
+        records = trajectory["records"]
+        assert isinstance(records, list)
+        first_record = records[0]
+        assert isinstance(first_record, dict)
+
+        if location == "entry":
+            committed["post_hoc_claim"] = "forged"
+        elif location == "trajectory":
+            trajectory["claimed_final_output"] = "forged"
+        elif location == "task":
+            task = trajectory["task"]
+            assert isinstance(task, dict)
+            task["post_hoc_claim"] = "forged"
+        elif location == "record":
+            first_record["post_hoc_claim"] = "forged"
+        else:
+            payload = first_record["payload"]
+            assert isinstance(payload, dict)
+            payload["post_hoc_claim"] = "forged"
+
+        if location != "entry":
+            committed["trajectory_digest"] = _digest(trajectory)
+        _rewrite_jsonl_chain(path, entries)
+
+        with pytest.raises(ValueError, match="fields are invalid"):
+            store.load()
+
+    asyncio.run(scenario())
+
+
+def test_store_requires_the_initial_previous_digest_field(tmp_path) -> None:
+    async def scenario() -> None:
+        path = tmp_path / "missing-previous-digest.jsonl"
+        store = JsonlTrajectoryStore(path)
+        await Experiment(
+            experiment_id="missing-previous-digest",
+            version="1",
+            trials={
+                "only": (
+                    _capital_trial(
+                        trial_id="missing-previous-digest-trial",
+                        answer="Paris",
+                    ),
+                )
+            },
+        ).run(store)
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+        entries[0].pop("previous_entry_digest")
+        entries[0].pop("entry_digest")
+        entries[0]["entry_digest"] = _digest(entries[0])
+        previous_digest = entries[0]["entry_digest"]
+        for entry in entries[1:]:
+            entry["previous_entry_digest"] = previous_digest
+            entry.pop("entry_digest")
+            entry["entry_digest"] = _digest(entry)
+            previous_digest = entry["entry_digest"]
+        path.write_text(
+            "".join(
+                f"{json.dumps(entry, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(',', ':'))}\n"
+                for entry in entries
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="entry chain"):
+            store.load()
+
+    asyncio.run(scenario())

--- a/tests/test_installed_extensions.py
+++ b/tests/test_installed_extensions.py
@@ -154,11 +154,13 @@ from iamai.harness import (
     JsonlTrajectoryStore,
     ScriptedAgent,
     Task,
+    TaskDistributionManifest,
     Tool,
     ToolResult,
     ToolSpec,
     Trial,
     TrialConfig,
+    compare_experiment,
 )
 from iamai.testing import (
     assert_adapter_api_result,
@@ -278,66 +280,81 @@ async def run_harness():
             cost_microunits=2,
         )
 
+    def installed_trial(trial_id, agent_name):
+        return Trial(
+            task=Task(id="installed-task", input=None),
+            agent=ScriptedAgent(
+                [
+                    Action.invoke("installed-tool", {"value": "observed"}),
+                    Action.finish("done"),
+                ],
+                name=agent_name,
+                version="1",
+            ),
+            environment=ControlledToolEnvironment(
+                tools=(
+                    Tool(
+                        ToolSpec(
+                            name="installed-tool",
+                            version="1",
+                            input_schema={
+                                "type": "object",
+                                "properties": {"value": {"type": "string"}},
+                                "required": ["value"],
+                                "additionalProperties": False,
+                            },
+                            permission_name="installed.read",
+                            reserved_tokens=1,
+                            reserved_cost_microunits=2,
+                        ),
+                        installed_tool,
+                    ),
+                ),
+                policy=ExecutionPolicy(
+                    version="1",
+                    allowed_tools=("installed-tool",),
+                    allowed_permissions=("installed.read",),
+                ),
+                budget=ExecutionBudget(
+                    max_tool_calls=1,
+                    max_tokens=1,
+                    max_cost_microunits=2,
+                    tool_timeout_seconds=1,
+                    currency="USD",
+                    pricing_version="installed-fixture-1",
+                ),
+                name="installed-environment",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("done", version="1"),
+            config=TrialConfig(trial_id=trial_id, max_actions=2),
+        )
+
+    distribution = TaskDistributionManifest(
+        suite_id="installed-suite",
+        version="1",
+        split="test",
+        case_ids=("installed-task/seed-0",),
+        sampling_rule="ordered-full-set-v1",
+    )
     path = Path("installed-harness.jsonl")
     result = await Experiment(
         experiment_id="installed-harness",
         version="1",
         baseline="baseline",
-        provenance={"distribution": "installed"},
+        task_distribution=distribution,
+        provenance={"runner": "installed-wheel"},
         trials={
             "baseline": (
-                Trial(
-                    task=Task(id="installed-task", input=None),
-                    agent=ScriptedAgent(
-                        [
-                            Action.invoke("installed-tool", {"value": "observed"}),
-                            Action.finish("done"),
-                        ],
-                        name="installed-agent",
-                        version="1",
-                    ),
-                    environment=ControlledToolEnvironment(
-                        tools=(
-                            Tool(
-                                ToolSpec(
-                                    name="installed-tool",
-                                    version="1",
-                                    input_schema={
-                                        "type": "object",
-                                        "properties": {"value": {"type": "string"}},
-                                        "required": ["value"],
-                                        "additionalProperties": False,
-                                    },
-                                    permission_name="installed.read",
-                                    reserved_tokens=1,
-                                    reserved_cost_microunits=2,
-                                ),
-                                installed_tool,
-                            ),
-                        ),
-                        policy=ExecutionPolicy(
-                            version="1",
-                            allowed_tools=("installed-tool",),
-                            allowed_permissions=("installed.read",),
-                        ),
-                        budget=ExecutionBudget(
-                            max_tool_calls=1,
-                            max_tokens=1,
-                            max_cost_microunits=2,
-                            tool_timeout_seconds=1,
-                            currency="USD",
-                            pricing_version="installed-fixture-1",
-                        ),
-                        name="installed-environment",
-                        version="1",
-                    ),
-                    evaluator=ExactEvaluator("done", version="1"),
-                    config=TrialConfig(trial_id="installed-trial", max_actions=2),
-                ),
-            )
+                installed_trial("installed-baseline", "installed-baseline-agent"),
+            ),
+            "candidate": (
+                installed_trial("installed-candidate", "installed-candidate-agent"),
+            ),
         },
     ).run(JsonlTrajectoryStore(path))
     loaded = JsonlTrajectoryStore(path).load()
+    comparison = compare_experiment(loaded, candidate="candidate")
     trajectory = result.results["baseline"][0].trajectory
     tool_outcome = next(
         record for record in trajectory.records if record.kind == "tool.call.outcome"
@@ -347,6 +364,9 @@ async def run_harness():
         "round_trip": loaded == result,
         "status": result.results["baseline"][0].status.value,
         "tool_status": tool_outcome.payload["status"],
+        "distribution_round_trip": loaded.task_distribution == distribution,
+        "comparison_pairs": comparison.total_pairs,
+        "comparison_delta": comparison.pass_rate_delta,
     }
 
 
@@ -432,6 +452,9 @@ print(
         "round_trip": True,
         "status": "completed",
         "tool_status": "succeeded",
+        "distribution_round_trip": True,
+        "comparison_pairs": 1,
+        "comparison_delta": 0.0,
     }
     for run in payload["runs"]:
         assert run["plugins"] == ["reference_plugin"]


### PR DESCRIPTION
## Summary
- pre-register paired task distributions and enforce Agent-only comparable baseline/candidate plans
- derive Store-verified, fixed-denominator comparisons bound to full Trajectory hashes
- harden JSONL and Replay owned schemas, while documenting record-first guarantees and non-guarantees

## Validation
- `uv run pytest -q --disable-warnings` — 471 passed
- `uv run ruff check .`
- `uv run python -m mypy`
- `cargo test --no-default-features` — 6 passed
- `bash scripts/check_example_configs.sh`
- `uv run sphinx-build -q -W --keep-going -b html docs docs/_build/html`