### PR TITLE
feat(harness): add policy-backed agent checkpoints

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,5 +117,5 @@ A fresh Trial using the same declared specification. It produces the same result
 _Avoid_: Replay
 
 **Policy Checkpoint**:
-An immutable version of the Agent behavior selected for an Experiment, including the model, prompts, memory policy, and action policy that affect decisions.
-_Avoid_: Latest model, mutable agent state
+An immutable, hash-bound, caller-declared version of decision-relevant Agent behavior selected for an Experiment. It records provider/model identity when applicable, prompt and tool-use policy, memory policy, context shaping, and versioned configuration. It is not provider attestation or a secret container.
+_Avoid_: Latest model, mutable agent state, credential store, verified provider identity

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ failed and budget-exhausted Trials. The resulting hashes are stable identifiers 
 for descriptive evidence; they are not signatures, statistical significance tests, or proof of
 generalization beyond the declared distribution.
 
+Policy-backed Agents can now bind a provider-neutral, caller-declared `PolicyCheckpoint` into the
+same Trial, Experiment, and JSONL provenance path. The checkpoint records non-secret policy metadata
+and exposes a canonical integrity hash; it is not an attestation, provider/model identity proof,
+prompt or Tool enforcement mechanism, or secret store. Remote provider integration remains future work.
+
 For declared asynchronous Tools, `ControlledToolEnvironment` adds strict `ToolSpec` input
 validation, a static default-deny `ExecutionPolicy`, approvals bound to one exact request, and
 run-scoped reservation ledgers for Tool calls, tokens, and integer cost microunits. Each handled

--- a/README.zh.md
+++ b/README.zh.md
@@ -78,6 +78,11 @@ JSONL，并在恢复时跳过已经提交的 Trial，不重复其副作用。只
 `ExperimentComparison`；failed 和 budget-exhausted Trial 也保留在分母中。comparison hash 是
 描述性证据的稳定标识与完整性检查，不是签名、显著性检验，也不能证明声明分布之外的泛化。
 
+Policy-backed Agent 现在可以把 provider-neutral、调用方声明的 `PolicyCheckpoint` 绑定进同一条 Trial、
+Experiment 与 JSONL provenance 路径。checkpoint 只记录非秘密 policy metadata 并提供 canonical 完整性
+hash；它不是 attestation、provider/model 身份证明、prompt 或 Tool enforcement，也不是 secret store。
+远程 provider 集成仍属后续工作。
+
 对于声明后的异步 Tool，`ControlledToolEnvironment` 提供严格的 `ToolSpec` 输入校验、静态
 default-deny `ExecutionPolicy`、绑定单次精确请求的审批，以及按 run 计算的 Tool 调用、token 和
 整数费用微单位 reservation ledger。每个被处理的非 final Action 都会记录 `tool.call.outcome`；

--- a/docs/adr/0004-policy-backed-agent-checkpoint.md
+++ b/docs/adr/0004-policy-backed-agent-checkpoint.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+---
+
+# Bind Agent behavior to policy checkpoints
+
+## Decision
+
+The provisional Harness composes `PolicyCheckpoint`, `AgentPolicy`, and
+`PolicyAgent` with the existing Agent interface. `ScriptedPolicy` provides an
+offline deterministic fixture for tests and examples. Remote provider adapters
+are future integrations and do not belong in the Harness core.
+
+`PolicyCheckpoint` freezes caller-declared decision-relevant policy metadata:
+provider and model identity when applicable, prompt and tool-use policy, memory
+policy, context shaping, and versioned configuration. `PolicyAgent` places the
+checkpoint and the policy implementation declaration in its existing Agent
+`configuration`.
+
+## Provenance
+
+The existing Agent configuration hash binds the declaration into Trial and
+Experiment evidence. The same generic configuration path carries it into Trial
+`config_hash`, Experiment spec and plan hashes, JSONL persistence, Replay, and
+paired comparison. No policy-specific provenance record, Store, registry, or
+Replay path is introduced.
+
+The checkpoint hash is a canonical content integrity identifier. It is not an attestation.
+It is also not a signature, trusted timestamp, provider attestation, model binary
+fingerprint, or proof of model execution. The Harness does not independently
+attest that a remote provider, model, prompt, memory policy, or tool-use policy
+matched the declaration, or that a policy implementation faithfully applied it.
+
+## Compatibility
+
+This decision does not change the Harness top-level configuration, Trajectory
+format, Experiment Store format, comparison projection version, or Replay
+execution model. Replay remains effect-free and does not invoke a policy,
+provider, Agent, Environment, or Tool. The stable messaging Runtime remains
+separate; these APIs are exported only from provisional `iamai.harness`.
+
+The abstraction is provider-neutral and adds no provider SDK, network request,
+prompt engine, memory system, or Tool executor.
+
+## Security boundary
+
+Policy checkpoints are non-secret persisted provenance. They must not contain
+API keys, access tokens, credentials, or other private secrets because the
+declaration may be persisted in Experiment plans and JSONL evidence. A policy
+checkpoint is not a secret store.
+
+`AgentPolicy` controls Agent decisions. It is distinct from `ExecutionPolicy`,
+which authorizes Tool execution inside `ControlledToolEnvironment`.
+`PolicyCheckpoint.tool_policy` is behavior provenance metadata only; it does not
+allow, deny, approve, budget, sandbox, or otherwise authorize a Tool call.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -21,6 +21,13 @@ Provisional research Harness
 ``ControlledToolEnvironment``。Harness ``ExecutionPolicy`` 不复用稳定消息 Runtime 的
 ``Permission`` 或 ``ToolRegistry``，``ControlledToolEnvironment`` 也不是隔离沙箱。
 
+Policy-backed Agent 接口包括 ``PolicyCheckpoint``、``AgentPolicy``、``PolicyAgent`` 和
+``ScriptedPolicy``。provider-neutral 的 checkpoint 把调用方声明的 Agent policy metadata 通过现有
+Agent configuration 绑定进 Trial/Experiment configuration hash 和 JSONL evidence；
+``checkpoint_hash`` 是内容完整性标识，不是签名、可信时间戳、provider/model identity attestation 或
+实际模型执行证明。``AgentPolicy != ExecutionPolicy``：前者提供 Agent decision implementation，
+后者仍负责 ``ControlledToolEnvironment`` 中真正的 Tool allow/deny。
+
 配对实验评证接口包括 ``TaskDistributionManifest``、``TrialComparison``、
 ``ExperimentComparison`` 与 ``compare_experiment``。manifest 预登记 exactly one baseline and one
 candidate 的固定 case 分布；manifest 字段是调用方声明，Harness 不执行 sampling rule。

--- a/docs/guides/research-harness.rst
+++ b/docs/guides/research-harness.rst
@@ -64,6 +64,93 @@ Event、SessionManager 或任何 LLM provider，也不会从顶层 ``iamai`` 重
 
    asyncio.run(main())
 
+Policy-backed Agent
+-------------------
+
+``PolicyCheckpoint`` 为 Experiment reproducibility evidence 冻结决策相关的调用方声明：适用时的
+provider/model、prompt/tool-use policy、memory policy、context shaping 与版本化配置。
+``PolicyAgent`` 把 checkpoint 和可替换的 ``AgentPolicy`` implementation declaration 放入现有 Agent
+configuration；``checkpoint_hash`` 与 Trial ``config_hash`` 使用相同的 canonical JSON 语义，因此声明会
+自然进入 Experiment spec/plan hash 和 ``JsonlTrajectoryStore``，无需新增格式或 provenance 系统。
+
+``ScriptedPolicy`` 是 provider-neutral、offline、deterministic fixture。它按 Trial 传入的
+``action_index`` 选择 Action，没有隐藏 cursor，同一个实例可以用于多个 Trial：
+
+.. code-block:: python
+
+   import asyncio
+
+   from iamai.harness import (
+       Action,
+       ExactEvaluator,
+       LookupEnvironment,
+       PolicyAgent,
+       PolicyCheckpoint,
+       ScriptedPolicy,
+       Task,
+       Trial,
+       TrialConfig,
+   )
+
+
+   checkpoint = PolicyCheckpoint(
+       checkpoint_id="capital-policy",
+       version="1",
+       provider=None,
+       model=None,
+       prompt_policy={"template_version": "fixture-1"},
+       tool_policy={"allowed_actions": ["lookup", "final"]},
+       memory_policy={"kind": "none"},
+       context_policy={"kind": "full-observation"},
+       configuration={"fixture": True},
+   )
+   agent = PolicyAgent(
+       ScriptedPolicy(
+           [
+               Action.invoke("lookup", {"key": "france"}),
+               Action.finish("Paris"),
+           ],
+           name="scripted-policy",
+           version="1",
+       ),
+       checkpoint,
+       name="capital-policy-agent",
+       version="1",
+   )
+
+
+   async def policy_main() -> None:
+       result = await Trial(
+           task=Task(id="capital-of-france", input={"question": "Capital?"}),
+           agent=agent,
+           environment=LookupEnvironment(
+               {"france": "Paris"},
+               name="country-capitals",
+               version="1",
+           ),
+           evaluator=ExactEvaluator("Paris", version="1"),
+           config=TrialConfig(trial_id="policy-trial", seed=7, max_actions=2),
+       ).run()
+       assert result.evaluation is not None and result.evaluation.passed
+
+
+   asyncio.run(policy_main())
+
+两个 paired Experiment slot 可以保持 Task、seed、Environment、Evaluator 和预算相同，仅使用不同的
+``PolicyCheckpoint`` 作为 baseline/candidate Agent declaration。现有 Agent-only pairing 会接受这种
+差异；plan 与 JSONL round trip 保存完整 checkpoint，``compare_experiment`` 仍从持久证据投影结果。
+``replay`` 只读取 Trajectory，不会重新调用 AgentPolicy 或 provider。
+
+checkpoint 是 caller-declared metadata，不是 provider attestation。``checkpoint_hash`` is not an
+attestation, signature, trusted timestamp, model fingerprint, or proof of actual provider/model,
+prompt, memory, or tool-policy execution. checkpoint is not a secret store；不得写入 API key、access token、
+credential 或 private secret，因为 Experiment 和 JSONL evidence 可能持久化整个声明。
+
+``AgentPolicy != ExecutionPolicy``。``AgentPolicy`` 只实现 Agent decision；``tool_policy`` 也只是行为
+provenance metadata。Tool 的 allow/deny、Approval 与预算仍由 ``ControlledToolEnvironment`` 和
+``ExecutionPolicy`` 执行。remote provider integration、prompt engine、memory system 和 provider
+attestation 不在当前垂直切片中。
+
 受控 Tool 执行
 --------------------
 

--- a/docs/guides/roadmap.rst
+++ b/docs/guides/roadmap.rst
@@ -82,10 +82,11 @@ Headless Trial
    这是描述性证据，不是签名、显著性检验或跨分布泛化证明。
 
 Policy-backed Agent
-   从 Headless Trial 的 Agent interface 冻结 policy checkpoint：模型与 provider 声明、prompt/tool-use
-   policy、memory policy、context shaping 和版本化配置必须进入 Trial provenance。该层先建立可替换的
-   policy interface 与确定性 fixture，再接远程模型；它不依赖某一种 Environment，也不会把某个 provider
-   SDK 固化为 Harness 核心。
+   |implemented| 第一条 provider-neutral policy checkpoint 垂直切片已提供冻结、hash-bound 的
+   ``PolicyCheckpoint``、可替换 ``AgentPolicy``、``PolicyAgent`` 和确定性 ``ScriptedPolicy``；声明通过
+   现有 Agent configuration 进入 Trial、Experiment 和 JSONL evidence。checkpoint 是调用方声明，
+   不提供 provider/model attestation，也不保存凭据。remote provider adapter、model fingerprinting、
+   更强的外部真实性证明、泛化评测、离线学习和消息桥接仍属后续工作。
 
 泛化评测套件
    在 paired evidence 之上定义多个独立 Task/Environment distribution、污染与迁移检查、重复 seed、

--- a/python/iamai/harness/__init__.py
+++ b/python/iamai/harness/__init__.py
@@ -34,11 +34,13 @@ from ._model import (
     TrajectoryRecord,
     Transition,
 )
+from ._policy import AgentPolicy, PolicyAgent, PolicyCheckpoint, ScriptedPolicy
 from ._replay import replay
 from ._trial import Trial
 
 __all__ = [
     "Action",
+    "AgentPolicy",
     "ApprovalDecision",
     "ApprovalRequest",
     "Approver",
@@ -54,7 +56,10 @@ __all__ = [
     "JsonlTrajectoryStore",
     "LookupEnvironment",
     "Observation",
+    "PolicyAgent",
+    "PolicyCheckpoint",
     "ScriptedAgent",
+    "ScriptedPolicy",
     "Task",
     "TaskDistributionManifest",
     "Tool",

--- a/python/iamai/harness/_policy.py
+++ b/python/iamai/harness/_policy.py
@@ -1,0 +1,269 @@
+"""Provider-neutral policy declarations for provisional Harness Agents."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from ._model import (
+    Action,
+    FrozenJsonValue,
+    JsonValue,
+    Observation,
+    Task,
+    Trajectory,
+    _action_payload,
+    _configuration_hash,
+    _freeze_json,
+    _frozen_object,
+    _thaw_json,
+)
+
+
+POLICY_CHECKPOINT_FORMAT_VERSION = "1"
+
+
+def _required_text(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+    frozen = _freeze_json(value, path=f"$.{field_name.replace(' ', '_')}")
+    if not isinstance(frozen, str):
+        raise AssertionError("JSON string did not remain a string")
+    return frozen
+
+
+def _frozen_mapping(value: object, *, path: str, field_name: str) -> Mapping[str, FrozenJsonValue]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be an object")
+    frozen = _freeze_json(value, path=path)
+    if not isinstance(frozen, Mapping):
+        raise AssertionError("JSON object did not remain an object")
+    return frozen
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyCheckpoint:
+    """Immutable caller declaration of decision-relevant Agent policy metadata."""
+
+    checkpoint_id: str
+    version: str
+    provider: str | None = None
+    model: str | None = None
+    prompt_policy: Mapping[str, JsonValue] = field(default_factory=dict)
+    tool_policy: Mapping[str, JsonValue] = field(default_factory=dict)
+    memory_policy: Mapping[str, JsonValue] = field(default_factory=dict)
+    context_policy: Mapping[str, JsonValue] = field(default_factory=dict)
+    configuration: Mapping[str, JsonValue] = field(default_factory=dict)
+    checkpoint_hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        checkpoint_id = _required_text(
+            self.checkpoint_id,
+            field_name="PolicyCheckpoint checkpoint_id",
+        )
+        version = _required_text(
+            self.version,
+            field_name="PolicyCheckpoint version",
+        )
+        provider = self.provider
+        model = self.model
+        if (provider is None) != (model is None):
+            raise ValueError(
+                "PolicyCheckpoint provider and model must be declared together"
+            )
+        if provider is not None:
+            provider = _required_text(
+                provider,
+                field_name="PolicyCheckpoint provider",
+            )
+            model = _required_text(
+                model,
+                field_name="PolicyCheckpoint model",
+            )
+
+        frozen_policies = {
+            field_name: _frozen_mapping(
+                getattr(self, field_name),
+                path=f"$.policy_checkpoint.{field_name}",
+                field_name=f"PolicyCheckpoint {field_name}",
+            )
+            for field_name in (
+                "prompt_policy",
+                "tool_policy",
+                "memory_policy",
+                "context_policy",
+                "configuration",
+            )
+        }
+        payload = _frozen_object(
+            policy_checkpoint_format_version=POLICY_CHECKPOINT_FORMAT_VERSION,
+            checkpoint_id=checkpoint_id,
+            version=version,
+            provider=provider,
+            model=model,
+            **frozen_policies,
+        )
+        object.__setattr__(self, "checkpoint_id", checkpoint_id)
+        object.__setattr__(self, "version", version)
+        object.__setattr__(self, "provider", provider)
+        object.__setattr__(self, "model", model)
+        for field_name, value in frozen_policies.items():
+            object.__setattr__(self, field_name, value)
+        object.__setattr__(self, "checkpoint_hash", _configuration_hash(payload))
+
+
+def _checkpoint_declaration(
+    checkpoint: PolicyCheckpoint,
+) -> Mapping[str, FrozenJsonValue]:
+    return _frozen_object(
+        policy_checkpoint_format_version=POLICY_CHECKPOINT_FORMAT_VERSION,
+        checkpoint_id=checkpoint.checkpoint_id,
+        version=checkpoint.version,
+        provider=checkpoint.provider,
+        model=checkpoint.model,
+        prompt_policy=checkpoint.prompt_policy,
+        tool_policy=checkpoint.tool_policy,
+        memory_policy=checkpoint.memory_policy,
+        context_policy=checkpoint.context_policy,
+        configuration=checkpoint.configuration,
+        checkpoint_hash=checkpoint.checkpoint_hash,
+    )
+
+
+class AgentPolicy(Protocol):
+    """Replaceable decision implementation used by a :class:`PolicyAgent`."""
+
+    name: str
+    version: str
+    configuration: Mapping[str, FrozenJsonValue]
+
+    async def decide(
+        self,
+        task: Task,
+        observation: Observation,
+        trajectory: Trajectory,
+        *,
+        seed: int,
+        action_index: int,
+    ) -> Action: ...
+
+
+class PolicyAgent:
+    """Bind a decision policy and checkpoint to the existing Agent interface."""
+
+    def __init__(
+        self,
+        policy: AgentPolicy,
+        checkpoint: PolicyCheckpoint,
+        *,
+        name: str = "policy-agent",
+        version: str = "1",
+    ) -> None:
+        if not isinstance(checkpoint, PolicyCheckpoint):
+            raise TypeError("PolicyAgent checkpoint must be a PolicyCheckpoint")
+        policy_name = _required_text(
+            getattr(policy, "name", None),
+            field_name="AgentPolicy name",
+        )
+        policy_version = _required_text(
+            getattr(policy, "version", None),
+            field_name="AgentPolicy version",
+        )
+        policy_configuration = _frozen_mapping(
+            getattr(policy, "configuration", None),
+            path="$.agent_policy.configuration",
+            field_name="AgentPolicy configuration",
+        )
+        self._policy = policy
+        self._checkpoint = checkpoint
+        self._name = _required_text(name, field_name="PolicyAgent name")
+        self._version = _required_text(version, field_name="PolicyAgent version")
+        self._configuration = _frozen_object(
+            kind="policy_backed",
+            policy_checkpoint=_checkpoint_declaration(checkpoint),
+            policy_implementation={
+                "name": policy_name,
+                "version": policy_version,
+                "config": policy_configuration,
+            },
+        )
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    async def decide(
+        self,
+        task: Task,
+        observation: Observation,
+        trajectory: Trajectory,
+        *,
+        seed: int,
+        action_index: int,
+    ) -> Action:
+        """Delegate one decision to the bound policy implementation."""
+        return await self._policy.decide(
+            task,
+            observation,
+            trajectory,
+            seed=seed,
+            action_index=action_index,
+        )
+
+
+class ScriptedPolicy:
+    """Deterministic reusable AgentPolicy fixture backed by predefined Actions."""
+
+    def __init__(
+        self,
+        actions: Sequence[Action],
+        *,
+        name: str = "scripted-policy",
+        version: str = "1",
+    ) -> None:
+        self._name = _required_text(name, field_name="AgentPolicy name")
+        self._version = _required_text(version, field_name="AgentPolicy version")
+        self._actions = tuple(actions)
+        if any(not isinstance(action, Action) for action in self._actions):
+            raise TypeError("ScriptedPolicy actions must contain Action values")
+        self._configuration = _frozen_object(
+            actions=[_thaw_json(_action_payload(action)) for action in self._actions]
+        )
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def configuration(self) -> Mapping[str, FrozenJsonValue]:
+        return self._configuration
+
+    async def decide(
+        self,
+        task: Task,
+        observation: Observation,
+        trajectory: Trajectory,
+        *,
+        seed: int,
+        action_index: int,
+    ) -> Action:
+        """Return the Action declared at the supplied Trial action index."""
+        del task, observation, trajectory, seed
+        if action_index < 0 or action_index >= len(self._actions):
+            raise RuntimeError("scripted policy ran out of actions")
+        return self._actions[action_index]

--- a/tests/test_controlled_execution.py
+++ b/tests/test_controlled_execution.py
@@ -1038,7 +1038,12 @@ def test_timeout_and_callback_failure_are_recoverable_environment_outcomes() -> 
         invalid_usage_effects += 1
         return ToolResult(output=None, tokens=10**5000)
 
-    def environment(name: str, handler: object) -> ControlledToolEnvironment:
+    def environment(
+        name: str,
+        handler: object,
+        *,
+        timeout: float = 1,
+    ) -> ControlledToolEnvironment:
         return ControlledToolEnvironment(
             tools=(
                 Tool(
@@ -1064,7 +1069,7 @@ def test_timeout_and_callback_failure_are_recoverable_environment_outcomes() -> 
                 max_tool_calls=1,
                 max_tokens=0,
                 max_cost_microunits=0,
-                tool_timeout_seconds=0.01,
+                tool_timeout_seconds=timeout,
                 currency="USD",
                 pricing_version="fixture-1",
             ),
@@ -1072,7 +1077,13 @@ def test_timeout_and_callback_failure_are_recoverable_environment_outcomes() -> 
             version="1",
         )
 
-    async def run(name: str, handler: object, trial_id: str) -> object:
+    async def run(
+        name: str,
+        handler: object,
+        trial_id: str,
+        *,
+        timeout: float = 1,
+    ) -> object:
         return await Trial(
             task=Task(id=trial_id, input=None),
             agent=ScriptedAgent(
@@ -1080,13 +1091,13 @@ def test_timeout_and_callback_failure_are_recoverable_environment_outcomes() -> 
                 name=f"{name}-agent",
                 version="1",
             ),
-            environment=environment(name, handler),
+            environment=environment(name, handler, timeout=timeout),
             evaluator=ExactEvaluator("recovered", version="1"),
             config=TrialConfig(trial_id=trial_id, max_actions=2),
         ).run()
 
     async def scenario() -> None:
-        timed_out = await run("slow", slow, "timeout-1")
+        timed_out = await run("slow", slow, "timeout-1", timeout=0.01)
         failed = await run("broken", broken, "failure-1")
         base_failed = await run("broken-base", broken_base, "base-failure-1")
         provider_failed = await run(

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -390,6 +390,40 @@ def test_paired_experiment_evidence_docs_define_scope_and_non_guarantees() -> No
     assert "配对实验评证" in readme_zh
 
 
+def test_policy_backed_agent_docs_define_provenance_and_non_guarantees() -> None:
+    content = _read("docs/guides/research-harness.rst")
+    roadmap = _read("docs/guides/roadmap.rst")
+    api_index = _read("docs/api/index.rst")
+    context = _read("CONTEXT.md")
+    adr = _read("docs/adr/0004-policy-backed-agent-checkpoint.md")
+    readme = _read("README.md")
+    readme_zh = _read("README.zh.md")
+
+    public_names = (
+        "PolicyCheckpoint",
+        "AgentPolicy",
+        "PolicyAgent",
+        "ScriptedPolicy",
+    )
+    for name in public_names:
+        assert name in content
+        assert name in api_index
+
+    assert "checkpoint_hash" in content
+    assert "checkpoint_hash" in api_index
+    assert "provider-neutral" in content
+    assert "Policy-backed Agent\n   |implemented|" in roadmap
+    assert "caller-declared" in context
+    assert "not provider attestation" in context
+    assert adr.startswith("---\nstatus: accepted\n---")
+    assert "not an attestation" in adr
+    assert "not a secret store" in adr
+    assert "AgentPolicy" in adr and "ExecutionPolicy" in adr
+    assert "AgentPolicy != ExecutionPolicy" in content
+    assert "Remote provider integration remains future work" in readme
+    assert "远程 provider 集成仍属后续工作" in readme_zh
+
+
 def test_community_page_contains_blog_and_store_sections() -> None:
     content = _read("docs/community/index.rst")
 

--- a/tests/test_installed_extensions.py
+++ b/tests/test_installed_extensions.py
@@ -152,7 +152,9 @@ from iamai.harness import (
     ExecutionBudget,
     ExecutionPolicy,
     JsonlTrajectoryStore,
-    ScriptedAgent,
+    PolicyAgent,
+    PolicyCheckpoint,
+    ScriptedPolicy,
     Task,
     TaskDistributionManifest,
     Tool,
@@ -281,13 +283,27 @@ async def run_harness():
         )
 
     def installed_trial(trial_id, agent_name):
+        checkpoint = PolicyCheckpoint(
+            checkpoint_id=f"{agent_name}-checkpoint",
+            version="1",
+            prompt_policy={"template_version": "installed-fixture-1"},
+            tool_policy={"allowed_actions": ["installed-tool", "final"]},
+            memory_policy={"kind": "none"},
+            context_policy={"kind": "full-observation"},
+            configuration={"fixture": True},
+        )
         return Trial(
             task=Task(id="installed-task", input=None),
-            agent=ScriptedAgent(
-                [
-                    Action.invoke("installed-tool", {"value": "observed"}),
-                    Action.finish("done"),
-                ],
+            agent=PolicyAgent(
+                ScriptedPolicy(
+                    [
+                        Action.invoke("installed-tool", {"value": "observed"}),
+                        Action.finish("done"),
+                    ],
+                    name=f"{agent_name}-policy",
+                    version="1",
+                ),
+                checkpoint,
                 name=agent_name,
                 version="1",
             ),
@@ -359,6 +375,8 @@ async def run_harness():
     tool_outcome = next(
         record for record in trajectory.records if record.kind == "tool.call.outcome"
     )
+    loaded_agent = loaded.plan.trial_specs["baseline"][0].configuration["agent"]
+    loaded_checkpoint = loaded_agent["config"]["policy_checkpoint"]
     return {
         "complete": result.complete,
         "round_trip": loaded == result,
@@ -367,6 +385,10 @@ async def run_harness():
         "distribution_round_trip": loaded.task_distribution == distribution,
         "comparison_pairs": comparison.total_pairs,
         "comparison_delta": comparison.pass_rate_delta,
+        "checkpoint_round_trip": (
+            loaded_checkpoint["checkpoint_id"] == "installed-baseline-agent-checkpoint"
+            and loaded_checkpoint["checkpoint_hash"].startswith("sha256:")
+        ),
     }
 
 
@@ -455,6 +477,7 @@ print(
         "distribution_round_trip": True,
         "comparison_pairs": 1,
         "comparison_delta": 0.0,
+        "checkpoint_round_trip": True,
     }
     for run in payload["runs"]:
         assert run["plugins"] == ["reference_plugin"]

--- a/tests/test_policy_agent.py
+++ b/tests/test_policy_agent.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+
+import iamai
+import iamai.harness as harness
+from iamai.harness import (
+    Action,
+    ExactEvaluator,
+    Experiment,
+    JsonlTrajectoryStore,
+    LookupEnvironment,
+    Observation,
+    PolicyAgent,
+    PolicyCheckpoint,
+    ScriptedPolicy,
+    Task,
+    TaskDistributionManifest,
+    Trial,
+    TrialConfig,
+    TrialStatus,
+    Trajectory,
+    compare_experiment,
+    replay,
+)
+
+
+def _checkpoint(**overrides: object) -> PolicyCheckpoint:
+    values: dict[str, object] = {
+        "checkpoint_id": "capital-policy",
+        "version": "1",
+        "provider": None,
+        "model": None,
+        "prompt_policy": {"template_version": "fixture-1"},
+        "tool_policy": {"allowed_actions": ["lookup", "final"]},
+        "memory_policy": {"kind": "none"},
+        "context_policy": {"kind": "full-observation"},
+        "configuration": {"fixture": True},
+    }
+    values.update(overrides)
+    return PolicyCheckpoint(**values)  # type: ignore[arg-type]
+
+
+def _policy_agent(
+    checkpoint: PolicyCheckpoint,
+    *,
+    actions: tuple[Action, ...] = (Action.finish("Paris"),),
+) -> PolicyAgent:
+    return PolicyAgent(
+        ScriptedPolicy(actions, name="capital-script", version="1"),
+        checkpoint,
+        name="capital-policy-agent",
+        version="1",
+    )
+
+
+def _trial(
+    *,
+    trial_id: str,
+    agent: PolicyAgent,
+    task_id: str = "capital-of-france",
+    seed: int = 7,
+) -> Trial:
+    return Trial(
+        task=Task(task_id, {"question": "What is the capital of France?"}),
+        agent=agent,
+        environment=LookupEnvironment({}, name="country-capitals", version="1"),
+        evaluator=ExactEvaluator("Paris", version="1"),
+        config=TrialConfig(trial_id=trial_id, seed=seed, max_actions=1),
+    )
+
+
+def test_policy_api_is_provisional_harness_only() -> None:
+    names = {"PolicyCheckpoint", "AgentPolicy", "PolicyAgent", "ScriptedPolicy"}
+
+    assert names.issubset(harness.__all__)
+    assert "POLICY_CHECKPOINT_FORMAT_VERSION" not in harness.__all__
+    for name in names:
+        assert not hasattr(iamai, name)
+
+
+def test_checkpoint_freezes_nested_source_values() -> None:
+    source = {"template": {"parts": ["system", "task"]}}
+    checkpoint = _checkpoint(prompt_policy=source)
+
+    source["template"]["parts"].append("mutated")
+
+    assert checkpoint.prompt_policy["template"]["parts"] == ("system", "task")
+    with pytest.raises(TypeError):
+        checkpoint.prompt_policy["new"] = "value"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        checkpoint.prompt_policy["template"]["parts"] = ()  # type: ignore[index]
+
+
+def test_checkpoint_hash_is_stable_across_mapping_insertion_order() -> None:
+    first = _checkpoint(
+        prompt_policy={"alpha": 1, "nested": {"left": True, "right": None}},
+    )
+    second = _checkpoint(
+        prompt_policy={"nested": {"right": None, "left": True}, "alpha": 1},
+    )
+
+    assert first.checkpoint_hash == second.checkpoint_hash
+    assert first.checkpoint_hash.startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        {"checkpoint_id": "other-policy"},
+        {"version": "2"},
+        {"provider": "openai-compatible", "model": "example-model"},
+        {"prompt_policy": {"template_version": "fixture-2"}},
+        {"tool_policy": {"allowed_actions": ["final"]}},
+        {"memory_policy": {"kind": "window", "size": 4}},
+        {"context_policy": {"kind": "last-observation"}},
+        {"configuration": {"fixture": False}},
+    ),
+)
+def test_checkpoint_hash_binds_every_semantic_field(changed: dict[str, object]) -> None:
+    assert _checkpoint(**changed).checkpoint_hash != _checkpoint().checkpoint_hash
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    ((None, None), ("openai-compatible", "example-model")),
+)
+def test_checkpoint_accepts_paired_provider_and_model(
+    provider: str | None,
+    model: str | None,
+) -> None:
+    checkpoint = _checkpoint(provider=provider, model=model)
+
+    assert checkpoint.provider == provider
+    assert checkpoint.model == model
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    (("provider", None), (None, "model")),
+)
+def test_checkpoint_rejects_partial_provider_declaration(
+    provider: str | None,
+    model: str | None,
+) -> None:
+    with pytest.raises(ValueError, match="must be declared together"):
+        _checkpoint(provider=provider, model=model)
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    (("", "model"), ("provider", ""), ("   ", "model"), ("provider", "   ")),
+)
+def test_checkpoint_rejects_empty_provider_declaration(
+    provider: str,
+    model: str,
+) -> None:
+    with pytest.raises(ValueError, match="cannot be empty"):
+        _checkpoint(provider=provider, model=model)
+
+
+@pytest.mark.parametrize(
+    "prompt_policy",
+    (
+        {"value": float("nan")},
+        {1: "non-string-key"},
+        {"value": object()},
+    ),
+)
+def test_checkpoint_reuses_harness_json_validation(prompt_policy: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        _checkpoint(prompt_policy=prompt_policy)
+
+
+def test_checkpoint_rejects_excessive_json_nesting() -> None:
+    nested: object = "leaf"
+    for _ in range(129):
+        nested = [nested]
+
+    with pytest.raises(ValueError, match="maximum JSON nesting depth"):
+        _checkpoint(context_policy={"nested": nested})
+
+
+def test_policy_agent_freezes_the_required_configuration_shape() -> None:
+    source = {"temperature": 0, "stops": ["done"]}
+
+    class MutablePolicy:
+        name = "mutable-policy"
+        version = "1"
+        configuration = source
+
+        async def decide(
+            self,
+            task: Task,
+            observation: Observation,
+            trajectory: Trajectory,
+            *,
+            seed: int,
+            action_index: int,
+        ) -> Action:
+            del task, observation, trajectory, seed, action_index
+            return Action.finish("Paris")
+
+    checkpoint = _checkpoint()
+    agent = PolicyAgent(MutablePolicy(), checkpoint)
+    source["stops"].append("mutated")
+
+    assert agent.configuration["kind"] == "policy_backed"
+    declaration = agent.configuration["policy_checkpoint"]
+    implementation = agent.configuration["policy_implementation"]
+    assert isinstance(declaration, Mapping)
+    assert isinstance(implementation, Mapping)
+    assert declaration["checkpoint_hash"] == checkpoint.checkpoint_hash
+    assert implementation == {
+        "name": "mutable-policy",
+        "version": "1",
+        "config": {"temperature": 0, "stops": ("done",)},
+    }
+    with pytest.raises(TypeError):
+        implementation["name"] = "changed"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("name", "version", "configuration", "error", "match"),
+    (
+        ("", "1", {}, ValueError, "AgentPolicy name cannot be empty"),
+        ("policy", "", {}, ValueError, "AgentPolicy version cannot be empty"),
+        ("policy", "1", [], TypeError, "configuration must be an object"),
+    ),
+)
+def test_policy_agent_validates_policy_declaration(
+    name: str,
+    version: str,
+    configuration: object,
+    error: type[Exception],
+    match: str,
+) -> None:
+    class InvalidPolicy:
+        async def decide(self, *args: object, **kwargs: object) -> Action:
+            del args, kwargs
+            return Action.finish("unused")
+
+    policy = InvalidPolicy()
+    policy.name = name
+    policy.version = version
+    policy.configuration = configuration
+
+    with pytest.raises(error, match=match):
+        PolicyAgent(policy, _checkpoint())  # type: ignore[arg-type]
+
+
+def test_policy_agent_completes_a_deterministic_trial() -> None:
+    async def scenario() -> None:
+        agent = _policy_agent(
+            _checkpoint(),
+            actions=(
+                Action.invoke("lookup", {"key": "france"}),
+                Action.finish("Paris"),
+            ),
+        )
+        result = await Trial(
+            task=Task("capital-of-france", {"question": "Capital?"}),
+            agent=agent,
+            environment=LookupEnvironment(
+                {"france": "Paris"},
+                name="country-capitals",
+                version="1",
+            ),
+            evaluator=ExactEvaluator("Paris", version="1"),
+            config=TrialConfig("policy-trial", seed=7, max_actions=2),
+        ).run()
+
+        assert result.status is TrialStatus.COMPLETED
+        assert result.final_output == "Paris"
+        assert result.evaluation is not None
+        assert result.evaluation.passed
+
+    asyncio.run(scenario())
+
+
+def test_scripted_policy_has_no_hidden_cross_trial_cursor() -> None:
+    async def scenario() -> None:
+        policy = ScriptedPolicy((Action.finish("Paris"),))
+        agent = PolicyAgent(policy, _checkpoint())
+
+        first = await _trial(trial_id="policy-reuse-1", agent=agent).run()
+        second = await _trial(trial_id="policy-reuse-2", agent=agent).run()
+
+        assert first.status is TrialStatus.COMPLETED
+        assert second.status is TrialStatus.COMPLETED
+        assert first.trajectory.config_hash == second.trajectory.config_hash
+
+    asyncio.run(scenario())
+
+
+def test_checkpoint_changes_bind_the_trial_configuration_hash() -> None:
+    first = _trial(
+        trial_id="checkpoint-a",
+        agent=_policy_agent(_checkpoint(prompt_policy={"template": "a"})),
+    )
+    second = _trial(
+        trial_id="checkpoint-b",
+        agent=_policy_agent(_checkpoint(prompt_policy={"template": "b"})),
+    )
+
+    assert first.trajectory.configuration["agent"] != second.trajectory.configuration["agent"]
+    assert first.trajectory.config_hash != second.trajectory.config_hash
+
+
+def test_task_trial_id_and_seed_do_not_pollute_configuration_hash() -> None:
+    agent = _policy_agent(_checkpoint())
+    first = _trial(trial_id="declaration-a", task_id="task-a", seed=1, agent=agent)
+    second = _trial(trial_id="declaration-b", task_id="task-b", seed=2, agent=agent)
+
+    assert first.trajectory.config_hash == second.trajectory.config_hash
+
+
+def test_replay_does_not_reinvoke_the_policy() -> None:
+    class CountingPolicy:
+        name = "counting-policy"
+        version = "1"
+        configuration: dict[str, object] = {}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(
+            self,
+            task: Task,
+            observation: Observation,
+            trajectory: Trajectory,
+            *,
+            seed: int,
+            action_index: int,
+        ) -> Action:
+            del task, observation, trajectory, seed, action_index
+            self.calls += 1
+            return Action.finish("Paris")
+
+    async def scenario() -> None:
+        policy = CountingPolicy()
+        result = await _trial(
+            trial_id="policy-replay",
+            agent=PolicyAgent(policy, _checkpoint()),
+        ).run()
+        trajectory = result.trajectory
+
+        replayed = replay(trajectory)
+
+        assert policy.calls == 1
+        assert replayed.status is result.status
+        assert replayed.final_output == result.final_output
+        assert replayed.evaluation == result.evaluation
+
+    asyncio.run(scenario())
+
+
+def test_checkpoint_round_trips_through_paired_experiment_evidence(tmp_path) -> None:
+    async def scenario() -> None:
+        baseline_checkpoint = _checkpoint(prompt_policy={"template": "baseline"})
+        candidate_checkpoint = _checkpoint(prompt_policy={"template": "candidate"})
+        store = JsonlTrajectoryStore(tmp_path / "policy-evidence.jsonl")
+        result = await Experiment(
+            experiment_id="policy-evidence",
+            version="1",
+            baseline="baseline",
+            task_distribution=TaskDistributionManifest(
+                suite_id="policy-suite",
+                version="1",
+                split="test",
+                case_ids=("capital-of-france/seed-7",),
+                sampling_rule="ordered-full-set-v1",
+            ),
+            trials={
+                "baseline": (
+                    _trial(
+                        trial_id="policy-baseline",
+                        agent=_policy_agent(baseline_checkpoint),
+                    ),
+                ),
+                "candidate": (
+                    _trial(
+                        trial_id="policy-candidate",
+                        agent=_policy_agent(candidate_checkpoint),
+                    ),
+                ),
+            },
+        ).run(store)
+        loaded = store.load()
+
+        assert loaded is not None
+        assert loaded == result
+        assert loaded.plan_hash == result.plan_hash
+        assert loaded.jsonl_verified is True
+        candidate_spec = loaded.plan.trial_specs["candidate"][0]
+        agent_declaration = candidate_spec.configuration["agent"]
+        assert isinstance(agent_declaration, Mapping)
+        agent_configuration = agent_declaration["config"]
+        assert isinstance(agent_configuration, Mapping)
+        checkpoint_declaration = agent_configuration["policy_checkpoint"]
+        assert isinstance(checkpoint_declaration, Mapping)
+        assert checkpoint_declaration["checkpoint_hash"] == (
+            candidate_checkpoint.checkpoint_hash
+        )
+        comparison = compare_experiment(loaded, candidate="candidate")
+        assert comparison.total_pairs == 1
+        assert comparison.pass_rate_delta == 0.0
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- add a provider-neutral `PolicyCheckpoint` for caller-declared Agent behavior provenance
- add the replaceable `AgentPolicy` interface, delegating `PolicyAgent`, and deterministic `ScriptedPolicy` fixture
- bind policy declarations through the existing Agent configuration into Trial/Experiment hashes and JSONL evidence
- document the provisional contract, non-attestation and secret-handling boundaries, and the implemented roadmap slice

## Design

This change composes with the existing Harness Agent configuration path. `PolicyAgent.configuration` freezes the checkpoint and policy implementation declarations before Trial construction; the existing configuration snapshot then carries them into `config_hash`, Experiment spec and plan hashes, JSONL persistence, Replay, and paired comparison. No parallel provenance record or execution path is introduced.

`PolicyCheckpoint` records non-secret, caller-declared provider/model identity when applicable, prompt/tool/memory/context policy metadata, and versioned configuration. Its `checkpoint_hash` uses the Harness canonical JSON hashing contract and is an integrity identifier, not a signature, trusted timestamp, provider/model attestation, or proof of actual execution.

`AgentPolicy` remains distinct from `ExecutionPolicy`: the former supplies Agent decisions, while Tool authorization remains the responsibility of `ControlledToolEnvironment`. No remote provider SDK, network call, prompt engine, memory system, or Tool executor is added.

## Evidence

- 33 focused tests cover public API isolation, immutability, JSON validation, provider/model invariants, hash stability and sensitivity, declaration freezing, deterministic Trial execution, cross-Trial reuse, config hash semantics, Replay independence, paired Experiment compatibility, JSONL round trip, and comparison
- the isolated installed-wheel probe now constructs and executes Policy-backed Agents while preserving Controlled Tool, JSONL, extension conformance, and paired comparison coverage
- ADR 0004 records the accepted composition, compatibility, provenance, and security boundaries

## Validation

- `uv sync --locked --all-packages --group dev --group docs`
- `uv run pytest -q tests/test_policy_agent.py` (33 passed)
- focused existing Harness, comparison, installed-wheel, and docs tests (77 passed)
- `uv run ruff check .`
- `uv run python -m mypy` (105 source files)
- `uv run pytest` (505 passed)
- `cargo test --no-default-features` (6 passed)
- `bash scripts/check_example_configs.sh`
- `LC_ALL=C LANG=C uv run sphinx-build -W --keep-going -b html docs docs/_build/html`
- `git diff --check upstream/dev...HEAD`

Local validation used Python 3.11.15, Rust 1.97.1, and macOS 14.8.9. GitHub CI provides the repository Python matrix evidence.

## Scope

- provisional `iamai.harness` only; no stable top-level `iamai` exports or Runtime changes
- no Harness configuration, Trajectory, Experiment Store, or comparison format bump
- no changes to Trial, Experiment, JSONL, Replay, evidence, or controlled-execution implementation
- no dependency, lockfile, release version, or workflow changes
- no provider integration, network use, credential persistence, or authenticity claim